### PR TITLE
feat(ui): allow editing queued messages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -196,10 +196,11 @@
               <div class="composer-with-queue">
                 <QueuedMessages
                   :messages="selectedThreadQueuedMessages"
+                  @edit="onEditQueuedMessage"
                   @steer="steerQueuedMessage"
                   @delete="removeQueuedMessage"
                 />
-                <ThreadComposer :active-thread-id="composerThreadContextId"
+                <ThreadComposer ref="threadComposerRef" :active-thread-id="composerThreadContextId"
                   :cwd="composerCwd"
                   :models="availableModelIds"
                   :selected-model="selectedModelId" :selected-reasoning-effort="selectedReasoningEffort"
@@ -252,6 +253,7 @@ import {
   searchThreads,
 } from './api/codexGateway'
 import type { ReasoningEffort, ThreadScrollState } from './types/codex'
+import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'codex-web-local.sidebar-collapsed.v1'
 const worktreeName = import.meta.env.VITE_WORKTREE_NAME ?? 'unknown'
@@ -405,6 +407,7 @@ const {
 const route = useRoute()
 const router = useRouter()
 const { isMobile } = useMobile()
+const threadComposerRef = ref<ThreadComposerExposed | null>(null)
 const isRouteSyncInProgress = ref(false)
 const hasInitialized = ref(false)
 const newThreadCwd = ref('')
@@ -691,6 +694,26 @@ function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fil
     return
   }
   void sendMessageToSelectedThread(text, payload.imageUrls, payload.skills, payload.mode, payload.fileAttachments)
+}
+
+function onEditQueuedMessage(messageId: string): void {
+  const message = selectedThreadQueuedMessages.value.find((item) => item.id === messageId)
+  const composer = threadComposerRef.value
+  if (!message || !composer) return
+
+  if (composer.hasUnsavedDraft()) {
+    const shouldReplace = window.confirm('Replace the current draft with this queued message for editing?')
+    if (!shouldReplace) return
+  }
+
+  const payload: ComposerDraftPayload = {
+    text: message.text,
+    imageUrls: [...message.imageUrls],
+    fileAttachments: message.fileAttachments.map((attachment) => ({ ...attachment })),
+    skills: message.skills.map((skill) => ({ ...skill })),
+  }
+  composer.hydrateDraft(payload)
+  removeQueuedMessage(messageId)
 }
 
 async function rollbackAndResendDictation(payload: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -408,6 +408,7 @@ const route = useRoute()
 const router = useRouter()
 const { isMobile } = useMobile()
 const threadComposerRef = ref<ThreadComposerExposed | null>(null)
+const editingQueuedMessageState = ref<{ threadId: string; queueIndex: number } | null>(null)
 const isRouteSyncInProgress = ref(false)
 const hasInitialized = ref(false)
 const newThreadCwd = ref('')
@@ -685,6 +686,14 @@ function onWindowKeyDown(event: KeyboardEvent): void {
 
 function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fileAttachments: Array<{ label: string; path: string; fsPath: string }>; skills: Array<{ name: string; path: string }>; mode: 'steer' | 'queue'; rollbackLatestUserTurn?: boolean }): void {
   const text = payload.text
+  const editingState = editingQueuedMessageState.value
+  const queueInsertIndex =
+    payload.mode === 'queue'
+    && editingState
+    && editingState.threadId === selectedThreadId.value
+      ? editingState.queueIndex
+      : undefined
+  editingQueuedMessageState.value = null
   if (isHomeRoute.value) {
     void submitFirstMessageForNewThread(text, payload.imageUrls, payload.skills, payload.fileAttachments)
     return
@@ -693,11 +702,12 @@ function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fil
     void rollbackAndResendDictation(payload)
     return
   }
-  void sendMessageToSelectedThread(text, payload.imageUrls, payload.skills, payload.mode, payload.fileAttachments)
+  void sendMessageToSelectedThread(text, payload.imageUrls, payload.skills, payload.mode, payload.fileAttachments, queueInsertIndex)
 }
 
 function onEditQueuedMessage(messageId: string): void {
-  const message = selectedThreadQueuedMessages.value.find((item) => item.id === messageId)
+  const queueIndex = selectedThreadQueuedMessages.value.findIndex((item) => item.id === messageId)
+  const message = queueIndex >= 0 ? selectedThreadQueuedMessages.value[queueIndex] : undefined
   const composer = threadComposerRef.value
   if (!message || !composer) return
 
@@ -706,6 +716,9 @@ function onEditQueuedMessage(messageId: string): void {
     if (!shouldReplace) return
   }
 
+  editingQueuedMessageState.value = selectedThreadId.value
+    ? { threadId: selectedThreadId.value, queueIndex }
+    : null
   const payload: ComposerDraftPayload = {
     text: message.text,
     imageUrls: [...message.imageUrls],

--- a/src/components/content/QueuedMessages.vue
+++ b/src/components/content/QueuedMessages.vue
@@ -6,8 +6,9 @@
         <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
           d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
       </svg>
-      <span class="queued-row-text">{{ msg.text }}</span>
+      <span class="queued-row-text">{{ getMessagePreview(msg) }}</span>
       <div class="queued-row-actions">
+        <button class="queued-row-edit" type="button" title="Edit queued message" @click="$emit('edit', msg.id)">Edit</button>
         <button class="queued-row-steer" type="button" title="Send now without interrupting work" @click="$emit('steer', msg.id)">Steer</button>
         <button class="queued-row-delete" type="button" aria-label="Delete queued message" title="Delete queued message" @click="$emit('delete', msg.id)">
           <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
@@ -22,14 +23,39 @@
 </template>
 
 <script setup lang="ts">
+type QueuedMessageRow = {
+  id: string
+  text: string
+  imageUrls?: string[]
+  skills?: Array<{ name: string; path: string }>
+  fileAttachments?: Array<{ label: string; path: string; fsPath: string }>
+}
+
 defineProps<{
-  messages: Array<{ id: string; text: string }>
+  messages: QueuedMessageRow[]
 }>()
 
 defineEmits<{
+  edit: [messageId: string]
   steer: [messageId: string]
   delete: [messageId: string]
 }>()
+
+function getMessagePreview(message: QueuedMessageRow): string {
+  const text = message.text.trim()
+  if (text) return text
+
+  const parts: string[] = []
+  const imageCount = message.imageUrls?.length ?? 0
+  const fileCount = message.fileAttachments?.length ?? 0
+  const skillCount = message.skills?.length ?? 0
+
+  if (imageCount > 0) parts.push(`${imageCount} image${imageCount === 1 ? '' : 's'}`)
+  if (fileCount > 0) parts.push(`${fileCount} file${fileCount === 1 ? '' : 's'}`)
+  if (skillCount > 0) parts.push(`${skillCount} skill${skillCount === 1 ? '' : 's'}`)
+
+  return parts.join(', ') || '(empty queued message)'
+}
 </script>
 
 <style scoped>
@@ -60,6 +86,10 @@ defineEmits<{
 }
 
 .queued-row-steer {
+  @apply rounded-md border border-zinc-300 bg-white px-2 py-0.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-100;
+}
+
+.queued-row-edit {
   @apply rounded-md border border-zinc-300 bg-white px-2 py-0.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-100;
 }
 

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -318,6 +318,13 @@ const props = defineProps<{
 
 export type FileAttachment = { label: string; path: string; fsPath: string }
 
+export type ComposerDraftPayload = {
+  text: string
+  imageUrls: string[]
+  fileAttachments: FileAttachment[]
+  skills: Array<{ name: string; path: string }>
+}
+
 export type SubmitPayload = {
   text: string
   imageUrls: string[]
@@ -325,6 +332,11 @@ export type SubmitPayload = {
   skills: Array<{ name: string; path: string }>
   mode: 'steer' | 'queue'
   rollbackLatestUserTurn?: boolean
+}
+
+export type ThreadComposerExposed = {
+  hydrateDraft: (payload: ComposerDraftPayload) => void
+  hasUnsavedDraft: () => boolean
 }
 
 const emit = defineEmits<{
@@ -437,6 +449,13 @@ const canSubmit = computed(() => {
   if (!props.activeThreadId) return false
   return draft.value.trim().length > 0 || selectedImages.value.length > 0 || fileAttachments.value.length > 0
 })
+const hasUnsavedDraft = computed(() =>
+  draft.value.trim().length > 0
+  || selectedImages.value.length > 0
+  || selectedSkills.value.length > 0
+  || fileAttachments.value.length > 0
+  || folderUploadGroups.value.length > 0,
+)
 const standaloneFileAttachments = computed(() => {
   const grouped = new Set<string>()
   for (const group of folderUploadGroups.value) {
@@ -840,6 +859,26 @@ function applyFileMention(suggestion: ComposerFileSuggestion): void {
   nextTick(() => input?.focus())
 }
 
+function hydrateDraft(payload: ComposerDraftPayload): void {
+  draft.value = payload.text
+  selectedImages.value = payload.imageUrls.map((url, index) => ({
+    id: `queued-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+    name: `Image ${index + 1}`,
+    url,
+  }))
+  selectedSkills.value = payload.skills.map((skill) => (
+    (props.skills ?? []).find((item) => item.path === skill.path)
+    ?? { name: skill.name, description: '', path: skill.path }
+  ))
+  fileAttachments.value = payload.fileAttachments.map((attachment) => ({ ...attachment }))
+  folderUploadGroups.value = []
+  dictationFeedback.value = ''
+  isAttachMenuOpen.value = false
+  isSlashMenuOpen.value = false
+  closeFileMention()
+  nextTick(() => inputRef.value?.focus())
+}
+
 function getMentionFileName(path: string): string {
   const idx = path.lastIndexOf('/')
   if (idx < 0) return path
@@ -913,6 +952,11 @@ function onDocumentClick(event: MouseEvent): void {
 
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
+})
+
+defineExpose<ThreadComposerExposed>({
+  hydrateDraft,
+  hasUnsavedDraft: () => hasUnsavedDraft.value,
 })
 
 onBeforeUnmount(() => {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -376,6 +376,7 @@ const {
   startRecording,
   stopRecording,
   toggleRecording,
+  cancel: cancelDictation,
 } = useDictation({
   getLanguage: () => props.dictationLanguage ?? 'auto',
   onTranscript: (text) => {
@@ -889,6 +890,7 @@ function applyFileMention(suggestion: ComposerFileSuggestion): void {
 }
 
 function hydrateDraft(payload: ComposerDraftPayload): void {
+  cancelDictation()
   replaceDraftState(payload)
   nextTick(() => inputRef.value?.focus())
 }
@@ -986,6 +988,7 @@ onBeforeUnmount(() => {
 watch(
   () => props.activeThreadId,
   () => {
+    cancelDictation()
     clearDraftState()
   },
 )

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -416,6 +416,7 @@ const mentionQuery = ref('')
 const fileMentionSuggestions = ref<ComposerFileSuggestion[]>([])
 const isFileMentionOpen = ref(false)
 const fileMentionHighlightedIndex = ref(0)
+const draftGeneration = ref(0)
 let fileMentionSearchToken = 0
 let fileMentionDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let isHoldPressActive = false
@@ -497,19 +498,41 @@ function onSubmit(mode: 'steer' | 'queue' = 'steer', options?: { rollbackLatestU
     mode,
     rollbackLatestUserTurn: options?.rollbackLatestUserTurn === true,
   })
-  draft.value = ''
-  selectedImages.value = []
-  selectedSkills.value = []
-  fileAttachments.value = []
-  folderUploadGroups.value = []
-  isAttachMenuOpen.value = false
-  isSlashMenuOpen.value = false
-  closeFileMention()
+  clearDraftState()
   if (isAndroid) {
     inputRef.value?.blur()
     return
   }
   nextTick(() => inputRef.value?.focus())
+}
+
+function replaceDraftState(payload: ComposerDraftPayload): void {
+  draftGeneration.value += 1
+  draft.value = payload.text
+  selectedImages.value = payload.imageUrls.map((url, index) => ({
+    id: `queued-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+    name: `Image ${index + 1}`,
+    url,
+  }))
+  selectedSkills.value = payload.skills.map((skill) => (
+    (props.skills ?? []).find((item) => item.path === skill.path)
+    ?? { name: skill.name, description: '', path: skill.path }
+  ))
+  fileAttachments.value = payload.fileAttachments.map((attachment) => ({ ...attachment }))
+  folderUploadGroups.value = []
+  dictationFeedback.value = ''
+  isAttachMenuOpen.value = false
+  isSlashMenuOpen.value = false
+  closeFileMention()
+}
+
+function clearDraftState(): void {
+  replaceDraftState({
+    text: '',
+    imageUrls: [],
+    fileAttachments: [],
+    skills: [],
+  })
 }
 
 function onInterrupt(): void {
@@ -627,10 +650,12 @@ function isImageFile(file: File): boolean {
 
 function addFiles(files: FileList | null): void {
   if (!files || files.length === 0) return
+  const generation = draftGeneration.value
   for (const file of Array.from(files)) {
     if (isImageFile(file)) {
       const reader = new FileReader()
       reader.onload = () => {
+        if (generation !== draftGeneration.value) return
         if (typeof reader.result !== 'string') return
         selectedImages.value.push({
           id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -641,6 +666,7 @@ function addFiles(files: FileList | null): void {
       reader.readAsDataURL(file)
     } else {
       void uploadFile(file).then((serverPath) => {
+        if (generation !== draftGeneration.value) return
         if (serverPath) addFileAttachment(serverPath)
       }).catch(() => {})
     }
@@ -649,6 +675,7 @@ function addFiles(files: FileList | null): void {
 
 async function addFolderFiles(files: FileList | null): Promise<void> {
   if (!files || files.length === 0) return
+  const generation = draftGeneration.value
   const rows = Array.from(files)
   const firstRelativePath = (rows[0] as File & { webkitRelativePath?: string }).webkitRelativePath || rows[0].name
   const folderName = firstRelativePath.split('/').filter(Boolean)[0] || 'Folder'
@@ -666,6 +693,7 @@ async function addFolderFiles(files: FileList | null): Promise<void> {
   ]
 
   const updateGroup = (updater: (group: FolderUploadGroup) => FolderUploadGroup): void => {
+    if (generation !== draftGeneration.value) return
     folderUploadGroups.value = folderUploadGroups.value.map((group) => (
       group.id === groupId ? updater(group) : group
     ))
@@ -674,6 +702,7 @@ async function addFolderFiles(files: FileList | null): Promise<void> {
   for (const file of rows) {
     try {
       const serverPath = await uploadFile(file)
+      if (generation !== draftGeneration.value) return
       if (serverPath) {
         const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name
         addFileAttachment(serverPath, relativePath)
@@ -860,22 +889,7 @@ function applyFileMention(suggestion: ComposerFileSuggestion): void {
 }
 
 function hydrateDraft(payload: ComposerDraftPayload): void {
-  draft.value = payload.text
-  selectedImages.value = payload.imageUrls.map((url, index) => ({
-    id: `queued-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
-    name: `Image ${index + 1}`,
-    url,
-  }))
-  selectedSkills.value = payload.skills.map((skill) => (
-    (props.skills ?? []).find((item) => item.path === skill.path)
-    ?? { name: skill.name, description: '', path: skill.path }
-  ))
-  fileAttachments.value = payload.fileAttachments.map((attachment) => ({ ...attachment }))
-  folderUploadGroups.value = []
-  dictationFeedback.value = ''
-  isAttachMenuOpen.value = false
-  isSlashMenuOpen.value = false
-  closeFileMention()
+  replaceDraftState(payload)
   nextTick(() => inputRef.value?.focus())
 }
 
@@ -972,15 +986,7 @@ onBeforeUnmount(() => {
 watch(
   () => props.activeThreadId,
   () => {
-    draft.value = ''
-    selectedImages.value = []
-    selectedSkills.value = []
-    fileAttachments.value = []
-    folderUploadGroups.value = []
-    dictationFeedback.value = ''
-    isAttachMenuOpen.value = false
-    isSlashMenuOpen.value = false
-    closeFileMention()
+    clearDraftState()
   },
 )
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -652,6 +652,7 @@ export function useDesktopState() {
     fallbackRetried: boolean
   }
   const queuedMessagesByThreadId = ref<Record<string, QueuedMessage[]>>({})
+  const queueProcessingByThreadId = ref<Record<string, boolean>>({})
   const eventUnreadByThreadId = ref<Record<string, boolean>>({})
   const availableModelIds = ref<string[]>([])
   const selectedModelId = ref(loadSelectedModelId())
@@ -2240,6 +2241,7 @@ export function useDesktopState() {
     skills: Array<{ name: string; path: string }> = [],
     mode: 'steer' | 'queue' = 'steer',
     fileAttachments: FileAttachment[] = [],
+    queueInsertIndex?: number,
   ): Promise<void> {
     const threadId = selectedThreadId.value
     const nextText = text.trim()
@@ -2250,9 +2252,14 @@ export function useDesktopState() {
     if (isInProgress && mode === 'queue') {
       const queue = queuedMessagesByThreadId.value[threadId] ?? []
       const id = `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const nextQueue = [...queue]
+      const insertIndex = typeof queueInsertIndex === 'number'
+        ? Math.max(0, Math.min(queueInsertIndex, nextQueue.length))
+        : nextQueue.length
+      nextQueue.splice(insertIndex, 0, { id, text: nextText, imageUrls, skills, fileAttachments })
       queuedMessagesByThreadId.value = {
         ...queuedMessagesByThreadId.value,
-        [threadId]: [...queue, { id, text: nextText, imageUrls, skills, fileAttachments }],
+        [threadId]: nextQueue,
       }
       return
     }
@@ -2442,8 +2449,13 @@ export function useDesktopState() {
   }
 
   async function processQueuedMessages(threadId: string): Promise<void> {
+    if (queueProcessingByThreadId.value[threadId] === true) return
     const queue = queuedMessagesByThreadId.value[threadId]
     if (!queue || queue.length === 0) return
+    queueProcessingByThreadId.value = {
+      ...queueProcessingByThreadId.value,
+      [threadId]: true,
+    }
     const [next, ...rest] = queue
     queuedMessagesByThreadId.value = rest.length > 0
       ? { ...queuedMessagesByThreadId.value, [threadId]: rest }
@@ -2461,6 +2473,7 @@ export function useDesktopState() {
       setThreadInProgress(threadId, false)
       setTurnActivityForThread(threadId, null)
     } finally {
+      queueProcessingByThreadId.value = omitKey(queueProcessingByThreadId.value, threadId)
       isSendingMessage.value = false
     }
   }
@@ -2793,6 +2806,7 @@ export function useDesktopState() {
     turnErrorByThreadId.value = {}
     activeTurnIdByThreadId.value = {}
     queuedMessagesByThreadId.value = {}
+    queueProcessingByThreadId.value = {}
   }
 
   const selectedThreadQueuedMessages = computed<QueuedMessage[]>(() => {

--- a/src/composables/useDictation.ts
+++ b/src/composables/useDictation.ts
@@ -195,6 +195,13 @@ export function useDictation(options: {
     }
   }
 
+  function cancel() {
+    stopRequestedBeforeStart = false
+    cancelTranscription()
+    cleanup()
+    state.value = 'idle'
+  }
+
   async function transcribe(recordedChunks: Blob[], mimeType: string) {
     if (recordedChunks.length === 0) {
       options.onEmpty?.()
@@ -274,8 +281,7 @@ export function useDictation(options: {
   }
 
   onBeforeUnmount(() => {
-    cancelTranscription()
-    cleanup()
+    cancel()
   })
 
   function toggleRecording() {
@@ -296,5 +302,6 @@ export function useDictation(options: {
     startRecording,
     stopRecording,
     toggleRecording,
+    cancel,
   }
 }


### PR DESCRIPTION
feat(ui): allow editing queued messages
- add an Edit action to queued messages
- restore queued message text/images/files/skills back into the composer
- confirm before replacing an existing unsaved draft

<img width="1324" height="1218" alt="image" src="https://github.com/user-attachments/assets/16611176-daf9-40c6-962f-5df9f9f28f65" />
