### PR TITLE
fix(windows): resolve codex command invocations

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@ import { chmodSync, createWriteStream, existsSync, mkdirSync } from 'node:fs'
 import { readFile, stat, writeFile } from 'node:fs/promises'
 import { homedir, networkInterfaces } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { spawn, spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { createInterface } from 'node:readline/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname } from 'node:path'
@@ -12,6 +12,7 @@ import { Command } from 'commander'
 import qrcode from 'qrcode-terminal'
 import { createServer as createApp } from '../server/httpServer.js'
 import { generatePassword } from '../server/password.js'
+import { canRunCommand, getUserNpmPrefix, resolveCodexCommand, spawnSyncCommand } from '../utils/commandInvocation.js'
 
 const program = new Command().name('codexui').description('Web interface for Codex app-server')
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -32,45 +33,20 @@ function isTermuxRuntime(): boolean {
 }
 
 function canRun(command: string, args: string[] = []): boolean {
-  const result = spawnSync(command, args, { stdio: 'ignore' })
-  return result.status === 0
+  const result = canRunCommand(command, args)
+  return result
 }
 
 function runOrFail(command: string, args: string[], label: string): void {
-  const result = spawnSync(command, args, { stdio: 'inherit' })
+  const result = spawnSyncCommand(command, args, { stdio: 'inherit' })
   if (result.status !== 0) {
     throw new Error(`${label} failed with exit code ${String(result.status ?? -1)}`)
   }
 }
 
 function runWithStatus(command: string, args: string[]): number {
-  const result = spawnSync(command, args, { stdio: 'inherit' })
+  const result = spawnSyncCommand(command, args, { stdio: 'inherit' })
   return result.status ?? -1
-}
-
-function getUserNpmPrefix(): string {
-  return join(homedir(), '.npm-global')
-}
-
-function resolveCodexCommand(): string | null {
-  if (canRun('codex', ['--version'])) {
-    return 'codex'
-  }
-
-  const userCandidate = join(getUserNpmPrefix(), 'bin', 'codex')
-  if (existsSync(userCandidate) && canRun(userCandidate, ['--version'])) {
-    return userCandidate
-  }
-
-  const prefix = process.env.PREFIX?.trim()
-  if (!prefix) {
-    return null
-  }
-  const candidate = join(prefix, 'bin', 'codex')
-  if (existsSync(candidate) && canRun(candidate, ['--version'])) {
-    return candidate
-  }
-  return null
 }
 
 function resolveCloudflaredCommand(): string | null {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -11,6 +11,7 @@ import { basename, isAbsolute, join, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
+import { getSpawnInvocation, resolveCodexCommand } from '../utils/commandInvocation.js'
 
 type JsonRpcCall = {
   jsonrpc: '2.0'
@@ -780,7 +781,8 @@ class AppServerProcess {
     if (this.process) return
 
     this.stopping = false
-    const proc = spawn('codex', this.appServerArgs, { stdio: ['pipe', 'pipe', 'pipe'] })
+    const invocation = getSpawnInvocation(resolveCodexCommand() ?? 'codex', this.appServerArgs)
+    const proc = spawn(invocation.command, invocation.args, { stdio: ['pipe', 'pipe', 'pipe'] })
     this.process = proc
 
     proc.stdout.setEncoding('utf8')
@@ -1060,7 +1062,8 @@ class MethodCatalog {
 
   private async runGenerateSchemaCommand(outDir: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      const process = spawn('codex', ['app-server', 'generate-json-schema', '--out', outDir], {
+      const invocation = getSpawnInvocation(resolveCodexCommand() ?? 'codex', ['app-server', 'generate-json-schema', '--out', outDir])
+      const process = spawn(invocation.command, invocation.args, {
         stdio: ['ignore', 'ignore', 'pipe'],
       })
 

--- a/src/utils/commandInvocation.ts
+++ b/src/utils/commandInvocation.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, extname, join } from 'node:path'
+
+const WINDOWS_CMD_NAMES = new Set(['codex', 'npm', 'npx'])
+
+function quoteCmdExeArg(value: string): string {
+  const normalized = value.replace(/"/g, '""')
+  if (!/[\s"]/u.test(normalized)) {
+    return normalized
+  }
+  return `"${normalized}"`
+}
+
+function needsCmdExeWrapper(command: string): boolean {
+  if (process.platform !== 'win32') {
+    return false
+  }
+
+  const lowerCommand = command.toLowerCase()
+  const baseName = basename(lowerCommand)
+  if (/\.(cmd|bat)$/i.test(baseName)) {
+    return true
+  }
+
+  if (extname(baseName)) {
+    return false
+  }
+
+  return WINDOWS_CMD_NAMES.has(baseName)
+}
+
+export function getSpawnInvocation(command: string, args: string[] = []): { command: string; args: string[] } {
+  if (needsCmdExeWrapper(command)) {
+    return {
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', [quoteCmdExeArg(command), ...args.map((arg) => quoteCmdExeArg(arg))].join(' ')],
+    }
+  }
+
+  return { command, args }
+}
+
+export function spawnSyncCommand(
+  command: string,
+  args: string[] = [],
+  options: Parameters<typeof spawnSync>[2] = {},
+) {
+  const invocation = getSpawnInvocation(command, args)
+  return spawnSync(invocation.command, invocation.args, options)
+}
+
+export function canRunCommand(command: string, args: string[] = []): boolean {
+  const result = spawnSyncCommand(command, args, { stdio: 'ignore' })
+  return result.status === 0
+}
+
+export function getUserNpmPrefix(): string {
+  return join(homedir(), '.npm-global')
+}
+
+export function resolveCodexCommand(): string | null {
+  if (canRunCommand('codex', ['--version'])) {
+    return 'codex'
+  }
+
+  if (process.platform === 'win32') {
+    const windowsCandidates = [
+      process.env.APPDATA ? join(process.env.APPDATA, 'npm', 'codex.cmd') : '',
+      join(homedir(), '.local', 'bin', 'codex.cmd'),
+      join(getUserNpmPrefix(), 'bin', 'codex.cmd'),
+    ].filter(Boolean)
+
+    for (const candidate of windowsCandidates) {
+      if (existsSync(candidate) && canRunCommand(candidate, ['--version'])) {
+        return candidate
+      }
+    }
+  }
+
+  const userCandidate = join(getUserNpmPrefix(), 'bin', 'codex')
+  if (existsSync(userCandidate) && canRunCommand(userCandidate, ['--version'])) {
+    return userCandidate
+  }
+
+  const prefix = process.env.PREFIX?.trim()
+  if (!prefix) {
+    return null
+  }
+
+  const candidate = join(prefix, 'bin', 'codex')
+  if (existsSync(candidate) && canRunCommand(candidate, ['--version'])) {
+    return candidate
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add a shared Windows-safe command invocation helper for bare commands and .cmd/.bat wrappers
- reuse that helper when checking/installing Codex from the CLI entrypoint
- use the same resolution path when spawning \\codex app-server\\ and schema generation inside the server bridge

## Problem
On Windows, bare spawn() / spawnSync() calls against codex or codex.cmd can fail to resolve correctly, which causes codexUI to think Codex is missing or prevents the app-server from starting even after the UI launches.