### PR TITLE
Fix Windows Codex integration and thread grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 dist-cli/
 output/
+.playwright-cli/
 *.tsbuildinfo
 
 package-lock.json

--- a/src/App.vue
+++ b/src/App.vue
@@ -319,6 +319,7 @@ import {
 import type { ReasoningEffort, SpeedMode, ThreadScrollState } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
 import type { GithubTipsScope, GithubTrendingProject, TelegramStatus } from './api/codexGateway'
+import { getPathLeafName, getPathParent } from './pathUtils.js'
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'codex-web-local.sidebar-collapsed.v1'
 const worktreeName = import.meta.env.VITE_WORKTREE_NAME ?? 'unknown'
@@ -1049,23 +1050,6 @@ async function loadTrendingProjects(): Promise<void> {
     isTrendingProjectsLoading.value = false
   }
 }
-
-function getPathParent(path: string): string {
-  const trimmed = path.trim().replace(/\/+$/, '')
-  if (!trimmed) return ''
-  const slashIndex = trimmed.lastIndexOf('/')
-  if (slashIndex <= 0) return ''
-  return trimmed.slice(0, slashIndex)
-}
-
-function getPathLeafName(path: string): string {
-  const trimmed = path.trim().replace(/\/+$/, '')
-  if (!trimmed) return ''
-  const slashIndex = trimmed.lastIndexOf('/')
-  if (slashIndex < 0) return trimmed
-  return trimmed.slice(slashIndex + 1)
-}
-
 function joinPath(parent: string, child: string): string {
   const normalizedParent = parent.trim().replace(/\/+$/, '')
   const normalizedChild = child.trim().replace(/^\/+/, '')

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -22,6 +22,7 @@ import {
   readThreadInProgressFromResponse,
 } from './normalizers/v2'
 import type { SpeedMode, UiMessage, UiProjectGroup } from '../types/codex'
+import { normalizePathForUi } from '../pathUtils.js'
 
 type CurrentModelConfig = {
   model: string
@@ -398,16 +399,17 @@ function normalizeWorkspaceRootsState(payload: unknown): WorkspaceRootsState {
   const labels: Record<string, string> = {}
   if (labelsRaw && typeof labelsRaw === 'object' && !Array.isArray(labelsRaw)) {
     for (const [key, value] of Object.entries(labelsRaw as Record<string, unknown>)) {
-      if (typeof key === 'string' && key.length > 0 && typeof value === 'string') {
-        labels[key] = value
+      const normalizedKey = typeof key === 'string' ? normalizePathForUi(key) : ''
+      if (normalizedKey.length > 0 && typeof value === 'string') {
+        labels[normalizedKey] = value
       }
     }
   }
 
   return {
-    order: normalizeArray(record.order),
+    order: normalizeArray(record.order).map((value) => normalizePathForUi(value)),
     labels,
-    active: normalizeArray(record.active),
+    active: normalizeArray(record.active).map((value) => normalizePathForUi(value)),
   }
 }
 
@@ -434,7 +436,11 @@ export async function createWorktree(sourceCwd: string): Promise<WorktreeCreateR
   if (!response.ok || !payload.data) {
     throw new Error(payload.error || 'Failed to create worktree')
   }
-  return payload.data
+  return {
+    ...payload.data,
+    cwd: normalizePathForUi(payload.data.cwd),
+    gitRoot: normalizePathForUi(payload.data.gitRoot),
+  }
 }
 
 export async function autoCommitWorktreeChanges(cwd: string, message: string): Promise<WorktreeAutoCommitResult> {
@@ -514,7 +520,7 @@ export async function openProjectRoot(path: string, options?: { createIfMissing?
     record.data && typeof record.data === 'object' && !Array.isArray(record.data)
       ? (record.data as Record<string, unknown>)
       : {}
-  const normalizedPath = typeof data.path === 'string' ? data.path.trim() : ''
+  const normalizedPath = typeof data.path === 'string' ? normalizePathForUi(data.path) : ''
   return normalizedPath
 }
 
@@ -536,7 +542,7 @@ export async function getProjectRootSuggestion(basePath: string): Promise<{ name
       : {}
   return {
     name: typeof data.name === 'string' ? data.name.trim() : '',
-    path: typeof data.path === 'string' ? data.path.trim() : '',
+    path: typeof data.path === 'string' ? normalizePathForUi(data.path) : '',
   }
 }
 

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -7,14 +7,10 @@ import type {
   UserInput,
 } from '../appServerDtos'
 import type { CommandExecutionData, UiFileAttachment, UiMessage, UiProjectGroup, UiThread } from '../../types/codex'
+import { normalizePathForComparison, normalizePathForUi, toProjectName } from '../../pathUtils.js'
 
 function toIso(seconds: number): string {
   return new Date(seconds * 1000).toISOString()
-}
-
-function toProjectName(cwd: string): string {
-  const parts = cwd.split('/').filter(Boolean)
-  return parts.at(-1) || cwd || 'unknown-project'
 }
 
 function toRawPayload(value: unknown): string {
@@ -200,20 +196,21 @@ function readThreadInProgress(summary: Thread): boolean {
 
 function toUiThread(summary: Thread): UiThread {
   const rawSummary = summary as Record<string, unknown>
-  const cwd = typeof rawSummary.cwd === 'string' ? rawSummary.cwd : summary.cwd
+  const cwd = normalizePathForUi(typeof rawSummary.cwd === 'string' ? rawSummary.cwd : summary.cwd)
+  const comparableCwd = normalizePathForComparison(cwd)
   const hasWorktree =
     rawSummary.isWorktree === true ||
     rawSummary.worktree === true ||
     rawSummary.worktreeId !== undefined ||
     rawSummary.worktreePath !== undefined ||
-    cwd.includes('/.codex/worktrees/') ||
-    cwd.includes('/.git/worktrees/')
+    comparableCwd.includes('/.codex/worktrees/') ||
+    comparableCwd.includes('/.git/worktrees/')
 
   return {
     id: summary.id,
     title: toThreadTitle(summary),
-    projectName: toProjectName(summary.cwd),
-    cwd: summary.cwd,
+    projectName: toProjectName(cwd),
+    cwd,
     hasWorktree,
     createdAtIso: toIso(summary.createdAt),
     updatedAtIso: toIso(summary.updatedAt),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,9 +10,16 @@ import { dirname } from 'node:path'
 import { get as httpsGet } from 'node:https'
 import { Command } from 'commander'
 import qrcode from 'qrcode-terminal'
+import {
+  canRunCommand,
+  getNpmGlobalBinDir,
+  getUserNpmPrefix,
+  prependPathEntry,
+  resolveCodexCommand,
+} from '../commandResolution.js'
 import { createServer as createApp } from '../server/httpServer.js'
 import { generatePassword } from '../server/password.js'
-import { canRunCommand, getUserNpmPrefix, resolveCodexCommand, spawnSyncCommand } from '../utils/commandInvocation.js'
+import { spawnSyncCommand } from '../utils/commandInvocation.js'
 
 const program = new Command().name('codexui').description('Web interface for Codex app-server')
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -51,11 +58,6 @@ function isTermuxRuntime(): boolean {
   return Boolean(process.env.TERMUX_VERSION || process.env.PREFIX?.includes('/com.termux/'))
 }
 
-function canRun(command: string, args: string[] = []): boolean {
-  const result = canRunCommand(command, args)
-  return result
-}
-
 function runOrFail(command: string, args: string[], label: string): void {
   const result = spawnSyncCommand(command, args, { stdio: 'inherit' })
   if (result.status !== 0) {
@@ -69,11 +71,11 @@ function runWithStatus(command: string, args: string[]): number {
 }
 
 function resolveCloudflaredCommand(): string | null {
-  if (canRun('cloudflared', ['--version'])) {
+  if (canRunCommand('cloudflared', ['--version'])) {
     return 'cloudflared'
   }
   const localCandidate = join(homedir(), '.local', 'bin', 'cloudflared')
-  if (existsSync(localCandidate) && canRun(localCandidate, ['--version'])) {
+  if (existsSync(localCandidate) && canRunCommand(localCandidate, ['--version'])) {
     return localCandidate
   }
   return null
@@ -140,7 +142,7 @@ async function ensureCloudflaredInstalledLinux(): Promise<string | null> {
   console.log('\ncloudflared not found. Installing to ~/.local/bin...\n')
   await downloadFile(downloadUrl, destination)
   chmodSync(destination, 0o755)
-  process.env.PATH = `${userBinDir}:${process.env.PATH ?? ''}`
+  process.env.PATH = prependPathEntry(process.env.PATH ?? '', userBinDir)
 
   const installed = resolveCloudflaredCommand()
   if (!installed) {
@@ -213,7 +215,7 @@ function ensureCodexInstalled(): string | null {
       const userPrefix = getUserNpmPrefix()
       console.log(`\nGlobal npm install requires elevated permissions. Retrying with --prefix ${userPrefix}...\n`)
       runOrFail('npm', ['install', '-g', '--prefix', userPrefix, pkg], `${label} (user prefix)`)
-      process.env.PATH = `${join(userPrefix, 'bin')}:${process.env.PATH ?? ''}`
+      process.env.PATH = prependPathEntry(process.env.PATH ?? '', getNpmGlobalBinDir(userPrefix))
     }
 
     if (isTermuxRuntime()) {
@@ -448,6 +450,9 @@ async function startServer(options: { port: string; password: string | boolean; 
     }
   }
   const codexCommand = ensureCodexInstalled() ?? resolveCodexCommand()
+  if (codexCommand) {
+    process.env.CODEXUI_CODEX_COMMAND = codexCommand
+  }
   if (!hasCodexAuth() && codexCommand) {
     console.log('\nCodex is not logged in. Starting `codex login`...\n')
     runOrFail(codexCommand, ['login'], 'Codex login')
@@ -535,6 +540,7 @@ async function startServer(options: { port: string; password: string | boolean; 
 
 async function runLogin() {
   const codexCommand = ensureCodexInstalled() ?? 'codex'
+  process.env.CODEXUI_CODEX_COMMAND = codexCommand
   console.log('\nStarting `codex login`...\n')
   runOrFail(codexCommand, ['login'], 'Codex login')
 }

--- a/src/commandResolution.ts
+++ b/src/commandResolution.ts
@@ -1,0 +1,193 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+export type CommandInvocation = {
+  command: string
+  args: string[]
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const unique: string[] = []
+  for (const value of values) {
+    const normalized = value?.trim()
+    if (!normalized || unique.includes(normalized)) continue
+    unique.push(normalized)
+  }
+  return unique
+}
+
+function isPathLike(command: string): boolean {
+  return command.includes('/') || command.includes('\\') || /^[a-zA-Z]:/.test(command)
+}
+
+function isRunnableCommand(command: string, args: string[] = []): boolean {
+  if (isPathLike(command) && !existsSync(command)) {
+    return false
+  }
+  return canRunCommand(command, args)
+}
+
+function getWindowsAppDataNpmPrefix(): string | null {
+  const appData = process.env.APPDATA?.trim()
+  return appData ? join(appData, 'npm') : null
+}
+
+function getPotentialNpmPrefixes(): string[] {
+  return uniqueStrings([
+    process.env.npm_config_prefix,
+    process.env.PREFIX,
+    getUserNpmPrefix(),
+    process.platform === 'win32' ? getWindowsAppDataNpmPrefix() : null,
+  ])
+}
+
+function getPotentialCodexPackageDirs(prefix: string): string[] {
+  const dirs = [join(prefix, 'node_modules', '@openai', 'codex')]
+  if (process.platform !== 'win32') {
+    dirs.push(join(prefix, 'lib', 'node_modules', '@openai', 'codex'))
+  }
+  return dirs
+}
+
+function getPotentialCodexExecutables(prefix: string): string[] {
+  return getPotentialCodexPackageDirs(prefix).map((packageDir) => (
+    process.platform === 'win32'
+      ? join(
+          packageDir,
+          'node_modules',
+          '@openai',
+          'codex-win32-x64',
+          'vendor',
+          'x86_64-pc-windows-msvc',
+          'codex',
+          'codex.exe',
+        )
+      : join(packageDir, 'bin', 'codex')
+  ))
+}
+
+function getPotentialRipgrepExecutables(prefix: string): string[] {
+  return getPotentialCodexPackageDirs(prefix).map((packageDir) => (
+    process.platform === 'win32'
+      ? join(
+          packageDir,
+          'node_modules',
+          '@openai',
+          'codex-win32-x64',
+          'vendor',
+          'x86_64-pc-windows-msvc',
+          'path',
+          'rg.exe',
+        )
+      : join(packageDir, 'bin', 'rg')
+  ))
+}
+
+export function canRunCommand(command: string, args: string[] = []): boolean {
+  const result = spawnSync(command, args, {
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  return !result.error && result.status === 0
+}
+
+export function getUserNpmPrefix(): string {
+  return join(homedir(), '.npm-global')
+}
+
+export function getNpmGlobalBinDir(prefix: string): string {
+  return process.platform === 'win32' ? prefix : join(prefix, 'bin')
+}
+
+export function prependPathEntry(existingPath: string, entry: string): string {
+  const normalizedEntry = entry.trim()
+  if (!normalizedEntry) return existingPath
+
+  const parts = existingPath
+    .split(delimiter)
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  if (parts.includes(normalizedEntry)) {
+    return existingPath
+  }
+
+  return existingPath ? `${normalizedEntry}${delimiter}${existingPath}` : normalizedEntry
+}
+
+export function resolveCodexCommand(): string | null {
+  const explicit = process.env.CODEXUI_CODEX_COMMAND?.trim()
+  const packageCandidates = getPotentialNpmPrefixes().flatMap(getPotentialCodexExecutables)
+  const fallbackCandidates = process.platform === 'win32'
+    ? [...packageCandidates, 'codex']
+    : ['codex', ...packageCandidates]
+
+  for (const candidate of uniqueStrings([explicit, ...fallbackCandidates])) {
+    if (isRunnableCommand(candidate, ['--version'])) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export function resolveRipgrepCommand(): string | null {
+  const explicit = process.env.CODEXUI_RG_COMMAND?.trim()
+  const packageCandidates = getPotentialNpmPrefixes().flatMap(getPotentialRipgrepExecutables)
+  const fallbackCandidates = process.platform === 'win32'
+    ? [...packageCandidates, 'rg']
+    : ['rg', ...packageCandidates]
+
+  for (const candidate of uniqueStrings([explicit, ...fallbackCandidates])) {
+    if (isRunnableCommand(candidate, ['--version'])) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export function resolvePythonCommand(): CommandInvocation | null {
+  const candidates: CommandInvocation[] = process.platform === 'win32'
+    ? [
+        { command: 'python', args: [] },
+        { command: 'py', args: ['-3'] },
+        { command: 'python3', args: [] },
+      ]
+    : [
+        { command: 'python3', args: [] },
+        { command: 'python', args: [] },
+      ]
+
+  for (const candidate of candidates) {
+    if (isRunnableCommand(candidate.command, [...candidate.args, '--version'])) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export function resolveSkillInstallerScriptPath(codexHome?: string): string | null {
+  const normalizedCodexHome = codexHome?.trim()
+  const candidates = uniqueStrings([
+    normalizedCodexHome
+      ? join(normalizedCodexHome, 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py')
+      : null,
+    process.env.CODEX_HOME?.trim()
+      ? join(process.env.CODEX_HOME.trim(), 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py')
+      : null,
+    join(homedir(), '.codex', 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py'),
+    join(homedir(), '.cursor', 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py'),
+  ])
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -41,6 +41,7 @@ import type {
   UiServerRequestReply,
   UiThread,
 } from '../types/codex'
+import { normalizePathForUi, toProjectName } from '../pathUtils.js'
 
 function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
   return groups.flatMap((group) => group.threads)
@@ -172,8 +173,10 @@ function loadProjectOrder(): string[] {
     if (!Array.isArray(parsed)) return []
     const order: string[] = []
     for (const item of parsed) {
-      if (typeof item === 'string' && item.length > 0 && !order.includes(item)) {
-        order.push(item)
+      if (typeof item !== 'string' || item.length === 0) continue
+      const normalizedItem = toProjectName(item)
+      if (normalizedItem.length > 0 && !order.includes(normalizedItem)) {
+        order.push(normalizedItem)
       }
     }
     return order
@@ -199,8 +202,9 @@ function loadProjectDisplayNames(): Record<string, string> {
 
     const displayNames: Record<string, string> = {}
     for (const [projectName, displayName] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof projectName === 'string' && projectName.length > 0 && typeof displayName === 'string') {
-        displayNames[projectName] = displayName
+      const normalizedProjectName = typeof projectName === 'string' ? toProjectName(projectName) : ''
+      if (normalizedProjectName.length > 0 && typeof displayName === 'string') {
+        displayNames[normalizedProjectName] = displayName
       }
     }
     return displayNames
@@ -616,15 +620,8 @@ function mergeIncomingWithLocalInProgressThreads(
   return merged
 }
 
-function toProjectName(cwd: string): string {
-  const parts = cwd.split('/').filter(Boolean)
-  return parts.at(-1) || cwd || 'unknown-project'
-}
-
 function toProjectNameFromWorkspaceRoot(value: string): string {
-  const normalized = value.replace(/\\/gu, '/')
-  const parts = normalized.split('/').filter(Boolean)
-  return parts.at(-1) || normalized
+  return toProjectName(value)
 }
 
 function toOptimisticThreadTitle(message: string): string {
@@ -1036,7 +1033,7 @@ export function useDesktopState() {
 
   function insertOptimisticThread(threadId: string, cwd: string, firstMessageText: string): void {
     const nowIso = new Date().toISOString()
-    const normalizedCwd = cwd.trim()
+    const normalizedCwd = normalizePathForUi(cwd)
     const projectName = toProjectName(normalizedCwd)
     const nextThread: UiThread = {
       id: threadId,

--- a/src/pathUtils.ts
+++ b/src/pathUtils.ts
@@ -1,0 +1,50 @@
+function stripWindowsDevicePathPrefix(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+
+  if (trimmed.startsWith('\\\\?\\UNC\\')) {
+    return `\\\\${trimmed.slice('\\\\?\\UNC\\'.length)}`
+  }
+
+  if (trimmed.startsWith('\\\\?\\')) {
+    return trimmed.slice('\\\\?\\'.length)
+  }
+
+  return trimmed
+}
+
+export function normalizePathForUi(value: string): string {
+  return stripWindowsDevicePathPrefix(value)
+}
+
+function isWindowsLikePath(value: string): boolean {
+  return /^[a-z]:[\\/]/iu.test(value) || value.startsWith('\\\\')
+}
+
+export function normalizePathForComparison(value: string): string {
+  const normalized = normalizePathForUi(value).replace(/[\\/]+/gu, '/')
+  return isWindowsLikePath(normalized) ? normalized.toLowerCase() : normalized
+}
+
+export function getPathLeafName(value: string): string {
+  const normalized = normalizePathForUi(value).replace(/[\\/]+$/u, '')
+  if (!normalized) return ''
+
+  const separatorIndex = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  if (separatorIndex < 0) return normalized
+  return normalized.slice(separatorIndex + 1)
+}
+
+export function getPathParent(value: string): string {
+  const normalized = normalizePathForUi(value).replace(/[\\/]+$/u, '')
+  if (!normalized) return ''
+
+  const separatorIndex = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  if (separatorIndex <= 0) return ''
+  return normalized.slice(0, separatorIndex)
+}
+
+export function toProjectName(value: string): string {
+  const leaf = getPathLeafName(value)
+  return leaf || normalizePathForUi(value) || 'unknown-project'
+}

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -12,7 +12,11 @@ import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
 import { TelegramThreadBridge } from './telegramThreadBridge.js'
-import { getSpawnInvocation, resolveCodexCommand } from '../utils/commandInvocation.js'
+import { getSpawnInvocation } from '../utils/commandInvocation.js'
+import {
+  resolveCodexCommand,
+  resolveRipgrepCommand,
+} from '../commandResolution.js'
 
 type JsonRpcCall = {
   jsonrpc: '2.0'
@@ -234,7 +238,13 @@ async function fetchGithubTrending(since: 'daily' | 'weekly' | 'monthly', limit:
 
 async function listFilesWithRipgrep(cwd: string): Promise<string[]> {
   return await new Promise<string[]>((resolve, reject) => {
-    const proc = spawn('rg', ['--files', '--hidden', '-g', '!.git', '-g', '!node_modules'], {
+    const ripgrepCommand = resolveRipgrepCommand()
+    if (!ripgrepCommand) {
+      reject(new Error('ripgrep (rg) is not available'))
+      return
+    }
+
+    const proc = spawn(ripgrepCommand, ['--files', '--hidden', '-g', '!.git', '-g', '!node_modules'], {
       cwd,
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -919,11 +929,19 @@ class AppServerProcess {
     'sandbox_mode="danger-full-access"',
   ]
 
+  private getCodexCommand(): string {
+    const codexCommand = resolveCodexCommand()
+    if (!codexCommand) {
+      throw new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
+    }
+    return codexCommand
+  }
+
   private start(): void {
     if (this.process) return
 
     this.stopping = false
-    const invocation = getSpawnInvocation(resolveCodexCommand() ?? 'codex', this.appServerArgs)
+    const invocation = getSpawnInvocation(this.getCodexCommand(), this.appServerArgs)
     const proc = spawn(invocation.command, invocation.args, { stdio: ['pipe', 'pipe', 'pipe'] })
     this.process = proc
 
@@ -1204,7 +1222,13 @@ class MethodCatalog {
 
   private async runGenerateSchemaCommand(outDir: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      const invocation = getSpawnInvocation(resolveCodexCommand() ?? 'codex', ['app-server', 'generate-json-schema', '--out', outDir])
+      const codexCommand = resolveCodexCommand()
+      if (!codexCommand) {
+        reject(new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.'))
+        return
+      }
+
+      const invocation = getSpawnInvocation(codexCommand, ['app-server', 'generate-json-schema', '--out', outDir])
       const process = spawn(invocation.command, invocation.args, {
         stdio: ['ignore', 'ignore', 'pipe'],
       })

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { writeFile } from 'node:fs/promises'
+import { resolvePythonCommand, resolveSkillInstallerScriptPath } from '../commandResolution.js'
 
 type AppServerLike = {
   rpc(method: string, params: unknown): Promise<unknown>
@@ -51,18 +52,6 @@ function getCodexHomeDir(): string {
 
 function getSkillsInstallDir(): string {
   return join(getCodexHomeDir(), 'skills')
-}
-
-function resolveSkillInstallerScriptPath(): string {
-  const candidates = [
-    join(getCodexHomeDir(), 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py'),
-    join(homedir(), '.codex', 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py'),
-    join(homedir(), '.cursor', 'skills', '.system', 'skill-installer', 'scripts', 'install-skill-from-github.py'),
-  ]
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate
-  }
-  throw new Error(`Skill installer script not found. Checked: ${candidates.join(', ')}`)
 }
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000
@@ -1157,13 +1146,21 @@ export async function handleSkillsRoutes(
       }
       const localDir = await detectUserSkillsDir(appServer)
       await pullInstalledSkillsFolderFromRepo(state.githubToken, state.repoOwner, state.repoName)
-      const installerScript = resolveSkillInstallerScriptPath()
+      const installerScript = resolveSkillInstallerScriptPath(getCodexHomeDir())
+      if (!installerScript) {
+        throw new Error('Skill installer script not found')
+      }
+      const pythonCommand = resolvePythonCommand()
+      if (!pythonCommand) {
+        throw new Error('Python 3 is required to install skills')
+      }
       const localSkills = await scanInstalledSkillsFromDisk()
       for (const skill of remote) {
         const owner = skill.owner || uniqueOwnerByName.get(skill.name) || ''
         if (!owner) continue
         if (!localSkills.has(skill.name)) {
-          await runCommand('python3', [
+          await runCommand(pythonCommand.command, [
+            ...pythonCommand.args,
             installerScript,
             '--repo', `${HUB_SKILLS_OWNER}/${HUB_SKILLS_REPO}`,
             '--path', `skills/${owner}/${skill.name}`,
@@ -1237,7 +1234,14 @@ export async function handleSkillsRoutes(
         setJson(res, 400, { error: 'Missing owner or name' })
         return true
       }
-      const installerScript = resolveSkillInstallerScriptPath()
+      const installerScript = resolveSkillInstallerScriptPath(getCodexHomeDir())
+      if (!installerScript) {
+        throw new Error('Skill installer script not found')
+      }
+      const pythonCommand = resolvePythonCommand()
+      if (!pythonCommand) {
+        throw new Error('Python 3 is required to install skills')
+      }
       const installDest = await withTimeout(
         detectUserSkillsDir(appServer),
         10_000,
@@ -1247,7 +1251,8 @@ export async function handleSkillsRoutes(
       if (existsSync(skillDir)) {
         await rm(skillDir, { recursive: true, force: true })
       }
-      await runCommand('python3', [
+      await runCommand(pythonCommand.command, [
+        ...pythonCommand.args,
         installerScript,
         '--repo', `${HUB_SKILLS_OWNER}/${HUB_SKILLS_REPO}`,
         '--path', `skills/${owner}/${name}`,


### PR DESCRIPTION
## Summary
- normalize Windows device-prefixed paths before using them in thread grouping and workspace-root state
- derive project names from normalized paths so Windows threads stop showing `\\?\D:\...` buckets in the sidebar
- improve Windows command resolution for Codex, ripgrep, and skill installer helpers without regressing fork-specific routes

## Testing
- npm run build
- headless Playwright against http://localhost:4178/
- manual verification on Windows that thread/project names render correctly in the sidebar
