### PR TITLE
Prefer renamed thread titles over preview text

### DIFF
--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -170,7 +170,8 @@ function normalizeCommandStatus(value: unknown): CommandExecutionData['status'] 
 }
 
 function pickThreadName(summary: Thread): string {
-  const direct = [summary.preview]
+  const rawSummary = summary as Record<string, unknown>
+  const direct = [rawSummary.name, rawSummary.title, summary.preview]
   for (const candidate of direct) {
     if (typeof candidate === 'string' && candidate.trim().length > 0) {
       return candidate.trim()


### PR DESCRIPTION
## Problem
When a thread is renamed outside CodexUI, the sidebar can keep showing the old first-message preview instead of the renamed thread title.

This is easy to notice after renaming a thread in the Codex desktop app on Windows and then opening the same account in CodexUI:
- the desktop app shows the new thread title
- `thread/list` already returns that renamed title in `name` or `title`
- CodexUI can still render the stale `preview` text as the thread label

Even though this is easy to reproduce from the Windows desktop app, the bug is not Windows-specific. It affects any environment where the backend returns a renamed thread title separately from the preview text.

## Root Cause
`src/api/normalizers/v2.ts` preferred `summary.preview` when deriving the UI thread title.

That meant CodexUI could ignore server-provided renamed titles from `thread/list` and fall back to the old first-message preview, so renamed threads looked unchanged after refresh.

## Fix
Update thread title normalization to prefer explicit renamed title fields first:
- `summary.name`
- `summary.title`
- `summary.preview`

This keeps the existing preview fallback for older payloads, while allowing CodexUI to reflect renamed thread titles whenever the backend provides them.

## Why This Is Safe
- it only changes how the UI chooses a display label from an already returned thread summary
- it does not change storage, RPC shape, or rename behavior itself
- if `name`/`title` are absent, behavior still falls back to `preview` exactly as before

## Testing
- `npm run build`
- headless Playwright against `http://localhost:4179/`
- live verification using `/codex-api/rpc` that `thread/list` returned a thread with a renamed `name` different from its `preview`
- headless UI assertion confirmed CodexUI rendered the renamed title `Verify fork sync status` instead of the old preview text
- Playwright console only showed the existing `favicon.ico` 404
