### PR TITLE
Add thread context usage indicator to the web UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -216,6 +216,18 @@
               @start-new-thread="onStartNewThreadFromToolbar"
             />
           </template>
+          <template #actions>
+            <div
+              v-if="showThreadContextBadge"
+              class="content-thread-context"
+              :data-state="threadContextBadgeState"
+              :title="threadContextTooltip"
+            >
+              <span class="content-thread-context-label">Context</span>
+              <span class="content-thread-context-value">{{ threadContextPrimaryText }}</span>
+              <span class="content-thread-context-meta">{{ threadContextSecondaryText }}</span>
+            </div>
+          </template>
         </ContentHeader>
 
         <section class="content-body">
@@ -400,7 +412,7 @@ import {
   searchThreads,
   switchAccount,
 } from './api/codexGateway'
-import type { ReasoningEffort, SpeedMode, ThreadScrollState, UiAccountEntry, UiRateLimitWindow } from './types/codex'
+import type { ReasoningEffort, SpeedMode, ThreadScrollState, UiAccountEntry, UiRateLimitWindow, UiThreadTokenUsage } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
 import type { GithubTipsScope, GithubTrendingProject, TelegramStatus } from './api/codexGateway'
 import { getPathLeafName, getPathParent } from './pathUtils.js'
@@ -526,6 +538,7 @@ const {
   projectGroups,
   projectDisplayNameById,
   selectedThread,
+  selectedThreadTokenUsage,
   selectedThreadScrollState,
   selectedThreadServerRequests,
   selectedLiveOverlay,
@@ -699,12 +712,69 @@ const composerCwd = computed(() => {
   return selectedThread.value?.cwd?.trim() ?? ''
 })
 const isSelectedThreadInProgress = computed(() => !isHomeRoute.value && selectedThread.value?.inProgress === true)
+const showThreadContextBadge = computed(() => !isHomeRoute.value && !isSkillsRoute.value && selectedThreadId.value.trim().length > 0)
 const isAccountSwitchBlocked = computed(() =>
   isSendingMessage.value ||
   isInterruptingTurn.value ||
   isSelectedThreadInProgress.value ||
   selectedThreadServerRequests.value.length > 0,
 )
+
+function formatCompactTokenCount(value: number): string {
+  if (!Number.isFinite(value)) return '0'
+  return new Intl.NumberFormat('en-US', {
+    notation: value >= 1000 ? 'compact' : 'standard',
+    maximumFractionDigits: value >= 100000 ? 0 : 1,
+  }).format(Math.max(0, Math.trunc(value)))
+}
+
+function buildThreadContextTooltip(usage: UiThreadTokenUsage | null): string {
+  if (!usage) {
+    return 'Waiting for Codex thread/tokenUsage/updated events for this thread.'
+  }
+
+  const lines = [
+    `Current context usage: ${usage.currentContextTokens.toLocaleString()} tokens`,
+    `Cumulative thread usage: ${usage.total.totalTokens.toLocaleString()} tokens`,
+  ]
+
+  if (typeof usage.modelContextWindow === 'number') {
+    lines.unshift(`Model context window: ${usage.modelContextWindow.toLocaleString()} tokens`)
+    lines.push(`Remaining context: ${(usage.remainingContextTokens ?? 0).toLocaleString()} tokens`)
+  } else {
+    lines.push('Model context window is unavailable in the latest usage event.')
+  }
+
+  return lines.join('\n')
+}
+
+const threadContextBadgeState = computed(() => {
+  const remainingPercent = selectedThreadTokenUsage.value?.remainingContextPercent
+  if (remainingPercent === null || typeof remainingPercent !== 'number') return 'pending'
+  if (remainingPercent <= 10) return 'danger'
+  if (remainingPercent <= 25) return 'warning'
+  return 'ok'
+})
+
+const threadContextPrimaryText = computed(() => {
+  const usage = selectedThreadTokenUsage.value
+  if (!usage) return 'Awaiting data'
+  if (typeof usage.remainingContextTokens === 'number') {
+    return `${formatCompactTokenCount(usage.remainingContextTokens)} left`
+  }
+  return `${formatCompactTokenCount(usage.currentContextTokens)} used`
+})
+
+const threadContextSecondaryText = computed(() => {
+  const usage = selectedThreadTokenUsage.value
+  if (!usage) return 'Updates after the next token usage event'
+  if (typeof usage.modelContextWindow === 'number') {
+    return `${formatCompactTokenCount(usage.currentContextTokens)} used / ${formatCompactTokenCount(usage.modelContextWindow)}`
+  }
+  return 'Window size unavailable'
+})
+
+const threadContextTooltip = computed(() => buildThreadContextTooltip(selectedThreadTokenUsage.value))
 const newThreadFolderOptions = computed(() => {
   const options: Array<{ value: string; label: string }> = []
   const seenCwds = new Set<string>()
@@ -2199,6 +2269,38 @@ async function submitFirstMessageForNewThread(
 
 .content-body {
   @apply flex-1 min-h-0 min-w-0 w-full flex flex-col gap-2 sm:gap-3 pt-1 pb-2 sm:pb-4 overflow-y-hidden overflow-x-hidden;
+}
+
+.content-thread-context {
+  @apply hidden min-w-0 rounded-xl border px-2.5 py-1 text-left sm:flex sm:flex-col sm:items-end sm:gap-0.5;
+}
+
+.content-thread-context[data-state='ok'] {
+  @apply border-emerald-200 bg-emerald-50;
+}
+
+.content-thread-context[data-state='warning'] {
+  @apply border-amber-200 bg-amber-50;
+}
+
+.content-thread-context[data-state='danger'] {
+  @apply border-rose-200 bg-rose-50;
+}
+
+.content-thread-context[data-state='pending'] {
+  @apply border-zinc-200 bg-zinc-50;
+}
+
+.content-thread-context-label {
+  @apply text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-500;
+}
+
+.content-thread-context-value {
+  @apply text-xs font-semibold text-zinc-900;
+}
+
+.content-thread-context-meta {
+  @apply text-[11px] text-zinc-500;
 }
 
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -48,6 +48,7 @@ import type {
   UiRateLimitSnapshot,
   UiServerRequest,
   UiServerRequestReply,
+  UiThreadTokenUsage,
   UiThread,
 } from '../types/codex'
 import { normalizePathForUi, toProjectName } from '../pathUtils.js'
@@ -58,6 +59,7 @@ function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
 
 const READ_STATE_STORAGE_KEY = 'codex-web-local.thread-read-state.v1'
 const SCROLL_STATE_STORAGE_KEY = 'codex-web-local.thread-scroll-state.v1'
+const THREAD_TOKEN_USAGE_STORAGE_KEY = 'codex-web-local.thread-token-usage.v1'
 const SELECTED_THREAD_STORAGE_KEY = 'codex-web-local.selected-thread-id.v1'
 const SELECTED_MODEL_STORAGE_KEY = 'codex-web-local.selected-model-id.v1'
 const PROJECT_ORDER_STORAGE_KEY = 'codex-web-local.project-order.v1'
@@ -198,6 +200,90 @@ function loadThreadScrollStateMap(): Record<string, ThreadScrollState> {
 function saveThreadScrollStateMap(state: Record<string, ThreadScrollState>): void {
   if (typeof window === 'undefined') return
   window.localStorage.setItem(SCROLL_STATE_STORAGE_KEY, JSON.stringify(state))
+}
+
+function normalizeStoredTokenCount(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value))
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed))
+    }
+  }
+
+  return null
+}
+
+function normalizeTokenUsageBreakdown(value: unknown): UiThreadTokenUsage['last'] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  return {
+    totalTokens: normalizeStoredTokenCount(record.totalTokens) ?? 0,
+    inputTokens: normalizeStoredTokenCount(record.inputTokens) ?? 0,
+    cachedInputTokens: normalizeStoredTokenCount(record.cachedInputTokens) ?? 0,
+    outputTokens: normalizeStoredTokenCount(record.outputTokens) ?? 0,
+    reasoningOutputTokens: normalizeStoredTokenCount(record.reasoningOutputTokens) ?? 0,
+  }
+}
+
+function normalizeThreadTokenUsage(value: unknown): UiThreadTokenUsage | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const total = normalizeTokenUsageBreakdown(record.total)
+  const last = normalizeTokenUsageBreakdown(record.last)
+  if (!total || !last) return null
+
+  const modelContextWindow = normalizeStoredTokenCount(record.modelContextWindow)
+  const currentContextTokens = last.totalTokens
+  const remainingContextTokens = typeof modelContextWindow === 'number'
+    ? Math.max(modelContextWindow - currentContextTokens, 0)
+    : null
+  const remainingContextPercent = typeof modelContextWindow === 'number' && modelContextWindow > 0
+    ? clamp(Math.round((remainingContextTokens ?? 0) / modelContextWindow * 100), 0, 100)
+    : null
+
+  return {
+    total,
+    last,
+    modelContextWindow,
+    currentContextTokens,
+    remainingContextTokens,
+    remainingContextPercent,
+  }
+}
+
+function loadThreadTokenUsageMap(): Record<string, UiThreadTokenUsage> {
+  if (typeof window === 'undefined') return {}
+
+  try {
+    const raw = window.localStorage.getItem(THREAD_TOKEN_USAGE_STORAGE_KEY)
+    if (!raw) return {}
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
+    const normalizedMap: Record<string, UiThreadTokenUsage> = {}
+    for (const [threadId, usage] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!threadId) continue
+      const normalizedUsage = normalizeThreadTokenUsage(usage)
+      if (normalizedUsage) {
+        normalizedMap[threadId] = normalizedUsage
+      }
+    }
+    return normalizedMap
+  } catch {
+    return {}
+  }
+}
+
+function saveThreadTokenUsageMap(state: Record<string, UiThreadTokenUsage>): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(THREAD_TOKEN_USAGE_STORAGE_KEY, JSON.stringify(state))
 }
 
 function loadSelectedThreadId(): string {
@@ -829,6 +915,7 @@ export function useDesktopState() {
   const pendingServerRequestsByThreadId = ref<Record<string, UiServerRequest[]>>({})
   const pendingTurnRequestByThreadId = ref<Record<string, PendingTurnRequest>>({})
   const codexRateLimit = ref<UiRateLimitSnapshot | null>(null)
+  const threadTokenUsageByThreadId = ref<Record<string, UiThreadTokenUsage>>(loadThreadTokenUsageMap())
 
   const threadTitleById = ref<Record<string, string>>({})
 
@@ -892,6 +979,11 @@ export function useDesktopState() {
     }
   })
   const codexQuota = computed<UiRateLimitSnapshot | null>(() => codexRateLimit.value)
+  const selectedThreadTokenUsage = computed<UiThreadTokenUsage | null>(() => {
+    const threadId = selectedThreadId.value
+    if (!threadId) return null
+    return threadTokenUsageByThreadId.value[threadId] ?? null
+  })
   const messages = computed<UiMessage[]>(() => {
     const threadId = selectedThreadId.value
     if (!threadId) return []
@@ -923,6 +1015,27 @@ export function useDesktopState() {
   function setSelectedModelId(modelId: string): void {
     selectedModelId.value = modelId.trim()
     saveSelectedModelId(selectedModelId.value)
+  }
+
+  function setThreadTokenUsage(threadId: string, usage: UiThreadTokenUsage | null): void {
+    const normalizedThreadId = threadId.trim()
+    if (!normalizedThreadId) return
+
+    if (!usage) {
+      if (!(normalizedThreadId in threadTokenUsageByThreadId.value)) return
+      threadTokenUsageByThreadId.value = omitKey(threadTokenUsageByThreadId.value, normalizedThreadId)
+      saveThreadTokenUsageMap(threadTokenUsageByThreadId.value)
+      return
+    }
+
+    const current = threadTokenUsageByThreadId.value[normalizedThreadId]
+    if (current && JSON.stringify(current) === JSON.stringify(usage)) return
+
+    threadTokenUsageByThreadId.value = {
+      ...threadTokenUsageByThreadId.value,
+      [normalizedThreadId]: usage,
+    }
+    saveThreadTokenUsageMap(threadTokenUsageByThreadId.value)
   }
 
   function setWorktreeGitAutomationEnabled(enabled: boolean): void {
@@ -1756,6 +1869,20 @@ export function useDesktopState() {
     return ''
   }
 
+  function readThreadTokenUsageUpdate(
+    notification: RpcNotification,
+  ): { threadId: string; tokenUsage: UiThreadTokenUsage } | null {
+    if (notification.method !== 'thread/tokenUsage/updated') return null
+    const params = asRecord(notification.params)
+    const threadId = extractThreadIdFromNotification(notification)
+    if (!threadId) return null
+
+    const tokenUsage = normalizeThreadTokenUsage(params?.tokenUsage)
+    if (!tokenUsage) return null
+
+    return { threadId, tokenUsage }
+  }
+
   function readTurnErrorMessage(notification: RpcNotification): string {
     if (notification.method !== 'turn/completed') return ''
     const params = asRecord(notification.params)
@@ -2403,6 +2530,11 @@ export function useDesktopState() {
     if (notification.method === 'account/rateLimits/updated') {
       setCodexRateLimit(pickCodexRateLimitSnapshot(notification.params))
       return
+    }
+
+    const tokenUsageUpdate = readThreadTokenUsageUpdate(notification)
+    if (tokenUsageUpdate) {
+      setThreadTokenUsage(tokenUsageUpdate.threadId, tokenUsageUpdate.tokenUsage)
     }
 
     const turnActivity = readTurnActivity(notification)
@@ -3805,6 +3937,7 @@ export function useDesktopState() {
     projectGroups,
     projectDisplayNameById,
     selectedThread,
+    selectedThreadTokenUsage,
     selectedThreadScrollState,
     selectedThreadServerRequests,
     selectedLiveOverlay,

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -171,6 +171,23 @@ export type UiRateLimitSnapshot = {
   planType: string | null
 }
 
+export type UiTokenUsageBreakdown = {
+  totalTokens: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningOutputTokens: number
+}
+
+export type UiThreadTokenUsage = {
+  total: UiTokenUsageBreakdown
+  last: UiTokenUsageBreakdown
+  modelContextWindow: number | null
+  currentContextTokens: number
+  remainingContextTokens: number | null
+  remainingContextPercent: number | null
+}
+
 export type UiProjectGroup = {
   projectName: string
   threads: UiThread[]

--- a/tests.md
+++ b/tests.md
@@ -39,6 +39,30 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Remove `~/.codex/telegram-bridge.json` to clear saved Telegram token.
 
+### Feature: Current thread context remaining indicator
+
+#### Prerequisites
+- App is running from this repository.
+- At least one thread can send prompts to Codex successfully.
+- The selected model/app-server emits `thread/tokenUsage/updated` notifications.
+
+#### Steps
+1. Open an existing thread in the web UI.
+2. Note the header area on the right side of the thread title and confirm a `Context` badge is present.
+3. If the badge shows `Awaiting data`, send a prompt and wait for Codex to finish at least one turn.
+4. After the turn completes, inspect the `Context` badge again.
+5. Hover the badge and read the tooltip details.
+6. Refresh the page and reopen the same thread.
+
+#### Expected Results
+- The current thread header shows a `Context` badge for thread-specific usage state.
+- Once a token usage event arrives, the badge shows remaining context (for example `152K left`) and secondary text with used/window counts.
+- The tooltip includes current context usage, cumulative thread usage, and remaining context details.
+- After refresh, the last known context badge state for that thread is restored from local storage.
+
+#### Rollback/Cleanup
+- None.
+
 ### Feature: Telegram chatIds persisted for bot DM sending
 
 #### Prerequisites


### PR DESCRIPTION
## Summary
- listen for Codex `thread/tokenUsage/updated` notifications in the web UI
- store per-thread token usage state and restore the last known value after refresh
- show a context badge in the thread header with remaining context, used/window counts, and tooltip details

## Details
Codex app-server already emits thread-level token usage updates, including `total`, `last`, and `modelContextWindow`. This change wires that data into the web UI and surfaces the current thread's remaining context in a lightweight header indicator.

The indicator follows the same semantic choice used by Codex TUI:
- use `last.totalTokens` as the current context occupancy
- keep `total.totalTokens` as cumulative thread usage for secondary detail/tooltip display

## Testing
- `npx pnpm run build`
- manually verify the new `Context` badge updates after a thread receives `thread/tokenUsage/updated`
