### PR TITLE
Improve home-screen project selection and creation UX

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -229,17 +229,121 @@
                 <ComposerDropdown class="new-thread-folder-dropdown" :model-value="newThreadCwd"
                   :options="newThreadFolderOptions" placeholder="Choose folder"
                   :enable-search="true"
-                  search-placeholder="Quick search project"
-                  :show-add-action="true"
-                  add-action-label="+ Add new project"
-                  :default-add-value="defaultNewProjectName"
-                  add-placeholder="Project name or absolute path"
                   :disabled="false" @update:model-value="onSelectNewThreadFolder"
-                  @add="onAddNewProject" />
+                />
+                <p v-if="newThreadCwd" class="new-thread-folder-selected" :title="newThreadCwd">
+                  Selected folder: {{ newThreadCwd }}
+                </p>
+                <div class="new-thread-folder-actions">
+                  <button class="new-thread-folder-action new-thread-folder-action-primary" type="button" @click="onOpenExistingFolder">
+                    Select folder
+                  </button>
+                </div>
+                <div v-if="isExistingFolderPickerOpen" class="new-thread-open-folder">
+                  <div class="new-thread-open-folder-header">
+                    <p class="new-thread-open-folder-title">Select folder</p>
+                    <button class="new-thread-open-folder-close" type="button" @click="onCloseExistingFolderPanel">
+                      Cancel
+                    </button>
+                  </div>
+                  <p class="new-thread-open-folder-label">Current folder</p>
+                  <div class="new-thread-open-folder-current">
+                    <p class="new-thread-open-folder-path" :title="existingFolderBrowsePath || 'Unavailable'">
+                      {{ existingFolderBrowsePath || 'Unavailable' }}
+                    </p>
+                    <button
+                      class="new-thread-folder-action new-thread-folder-action-primary"
+                      type="button"
+                      :disabled="!existingFolderBrowsePath || !!existingFolderError || isExistingFolderLoading || isOpeningExistingFolder"
+                      @click="onConfirmExistingFolder()"
+                    >
+                      {{ isOpeningExistingFolder ? 'Opening…' : 'Open' }}
+                    </button>
+                  </div>
+                  <div class="new-thread-open-folder-actions">
+                    <label class="new-thread-open-folder-toggle">
+                      <input
+                        v-model="showHiddenFolders"
+                        class="new-thread-open-folder-toggle-input"
+                        type="checkbox"
+                        @change="onToggleHiddenFolders"
+                      />
+                      <span>Show hidden folders</span>
+                    </label>
+                    <button
+                      class="new-thread-folder-action"
+                      :class="{ 'new-thread-folder-action-primary': isCreateFolderOpen }"
+                      type="button"
+                      :aria-pressed="isCreateFolderOpen"
+                      :disabled="!existingFolderBrowsePath || isExistingFolderLoading || isOpeningExistingFolder || isCreatingFolder"
+                      @click="onOpenCreateFolderPanel"
+                    >
+                      New folder
+                    </button>
+                  </div>
+                  <div v-if="isCreateFolderOpen" class="new-thread-open-folder-create">
+                    <div class="new-thread-open-folder-create-composer">
+                      <input
+                        ref="createFolderInputRef"
+                        v-model="createFolderDraft"
+                        class="new-thread-open-folder-create-input"
+                        type="text"
+                        placeholder="Folder name"
+                        @keydown.enter.prevent="onCreateFolder"
+                        @keydown.esc.prevent="onCloseCreateFolderPanel"
+                      />
+                      <button
+                        class="new-thread-folder-action new-thread-folder-action-primary new-thread-open-folder-create-submit"
+                        type="button"
+                        :disabled="!canCreateFolder || isCreatingFolder"
+                        @click="onCreateFolder"
+                      >
+                        {{ createFolderSubmitLabel }}
+                      </button>
+                    </div>
+                    <p v-if="createFolderError" class="new-thread-open-folder-error">{{ createFolderError }}</p>
+                  </div>
+                  <input
+                    v-model="existingFolderFilter"
+                    class="new-thread-open-folder-filter"
+                    type="text"
+                    placeholder="Filter folders..."
+                  />
+                  <p v-if="existingFolderError" class="new-thread-open-folder-error">{{ existingFolderError }}</p>
+                  <p v-else-if="isExistingFolderLoading" class="new-thread-open-folder-status">Loading folders…</p>
+                  <p v-else-if="existingFolderFilteredEntries.length === 0" class="new-thread-open-folder-status">
+                    {{ existingFolderFilter.trim() ? 'No folders match this filter.' : 'No subfolders found here.' }}
+                  </p>
+                  <ul v-else class="new-thread-open-folder-list">
+                    <li v-for="entry in existingFolderFilteredEntries" :key="entry.key" class="new-thread-open-folder-item">
+                      <button
+                        class="new-thread-open-folder-item-main"
+                        type="button"
+                        :title="entry.path"
+                        :disabled="isExistingFolderLoading || isOpeningExistingFolder"
+                        @click="onBrowseExistingFolder(entry.path)"
+                      >
+                        <span class="new-thread-open-folder-item-name">{{ entry.name }}</span>
+                      </button>
+                      <button
+                        v-if="entry.kind === 'directory'"
+                        class="new-thread-open-folder-item-open"
+                        type="button"
+                        :disabled="isExistingFolderLoading || isOpeningExistingFolder"
+                        @click="onConfirmExistingFolder(entry.path)"
+                      >
+                        Open
+                      </button>
+                    </li>
+                  </ul>
+                </div>
                 <ComposerRuntimeDropdown
                   class="new-thread-runtime-dropdown"
                   v-model="newThreadRuntime"
                 />
+                <p class="new-thread-runtime-help">
+                  <code>Local project</code> uses the selected folder directly. <code>New worktree</code> creates an isolated Git worktree before the first prompt.
+                </p>
                 <div
                   v-if="worktreeInitStatus.phase !== 'idle'"
                   class="worktree-init-status"
@@ -390,10 +494,12 @@ import {
   createWorktree,
   getGithubProjectsForScope,
   getAccounts,
+  createLocalDirectory,
   getHomeDirectory,
   getProjectRootSuggestion,
   getTelegramStatus,
   getWorkspaceRootsState,
+  listLocalDirectories,
   openProjectRoot,
   removeAccount,
   refreshAccountsFromAuth,
@@ -402,8 +508,8 @@ import {
 } from './api/codexGateway'
 import type { ReasoningEffort, SpeedMode, ThreadScrollState, UiAccountEntry, UiRateLimitWindow } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
-import type { GithubTipsScope, GithubTrendingProject, TelegramStatus } from './api/codexGateway'
-import { getPathLeafName, getPathParent } from './pathUtils.js'
+import type { GithubTipsScope, GithubTrendingProject, LocalDirectoryEntry, TelegramStatus } from './api/codexGateway'
+import { getPathLeafName, getPathParent, normalizePathForUi } from './pathUtils.js'
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'codex-web-local.sidebar-collapsed.v1'
 const LAST_ACTIVE_THREAD_ROUTE_STORAGE_KEY = 'codex-web-local.last-active-thread-route.v1'
@@ -605,6 +711,7 @@ let threadSearchTimer: ReturnType<typeof setTimeout> | null = null
 const defaultNewProjectName = ref('New Project (1)')
 const homeDirectory = ref('')
 const isSettingsOpen = ref(false)
+const createFolderInputRef = ref<HTMLInputElement | null>(null)
 const accounts = ref<UiAccountEntry[]>([])
 const isRefreshingAccounts = ref(false)
 const isSwitchingAccounts = ref(false)
@@ -632,6 +739,19 @@ const dictationLanguage = ref(loadDictationLanguagePref())
 const dictationLanguageOptions = computed(() => buildDictationLanguageOptions())
 const worktreeGitAutomationEnabled = ref(loadBoolPref(WORKTREE_GIT_AUTOMATION_KEY, true))
 const showGithubTrendingProjects = ref(loadBoolPref(GITHUB_TRENDING_PROJECTS_KEY, true))
+const isCreateFolderOpen = ref(false)
+const createFolderDraft = ref('')
+const createFolderError = ref('')
+const isCreatingFolder = ref(false)
+const isExistingFolderPickerOpen = ref(false)
+const existingFolderBrowsePath = ref('')
+const existingFolderParentPath = ref('')
+const existingFolderEntries = ref<LocalDirectoryEntry[]>([])
+const existingFolderError = ref('')
+const isExistingFolderLoading = ref(false)
+const isOpeningExistingFolder = ref(false)
+const showHiddenFolders = ref(false)
+const existingFolderFilter = ref('')
 const telegramStatus = ref<TelegramStatus>({
   configured: false,
   active: false,
@@ -644,6 +764,7 @@ const mobileResumeReloadTriggered = ref(false)
 const mobileResumeSyncInProgress = ref(false)
 let accountStatePollTimer: number | null = null
 let isAccountStatePollInFlight = false
+let existingFolderBrowseRequestId = 0
 
 const routeThreadId = computed(() => {
   const rawThreadId = route.params.threadId
@@ -739,6 +860,52 @@ const newThreadFolderOptions = computed(() => {
 
   return options
 })
+const createFolderParentPath = computed(() => existingFolderBrowsePath.value.trim())
+const isCreateFolderNameValid = computed(() => {
+  const draft = createFolderDraft.value.trim()
+  if (!draft) return false
+  if (draft === '.' || draft === '..') return false
+  return !/[\\/]/u.test(draft)
+})
+const canCreateFolder = computed(() => {
+  return isCreateFolderNameValid.value && createFolderParentPath.value.trim().length > 0
+})
+const createFolderSubmitLabel = computed(() => {
+  if (isCreatingFolder.value) return 'Creating…'
+  return 'Create'
+})
+const canBrowseExistingFolderParent = computed(() => {
+  const current = existingFolderBrowsePath.value.trim()
+  const parent = existingFolderParentPath.value.trim()
+  return Boolean(current && parent && current !== parent)
+})
+const existingFolderDisplayEntries = computed(() => {
+  const entries: Array<{ key: string; name: string; path: string; kind: 'parent' | 'directory' }> = []
+  if (canBrowseExistingFolderParent.value) {
+    entries.push({
+      key: `parent:${existingFolderParentPath.value}`,
+      name: '..',
+      path: existingFolderParentPath.value,
+      kind: 'parent',
+    })
+  }
+  for (const entry of existingFolderEntries.value) {
+    entries.push({
+      key: `directory:${entry.path}`,
+      name: entry.name,
+      path: entry.path,
+      kind: 'directory',
+    })
+  }
+  return entries
+})
+const existingFolderFilteredEntries = computed(() => {
+  const filter = existingFolderFilter.value.trim().toLowerCase()
+  if (!filter) return existingFolderDisplayEntries.value
+  return existingFolderDisplayEntries.value.filter((entry) =>
+    entry.kind === 'parent' || entry.name.toLowerCase().includes(filter),
+  )
+})
 const darkModeMediaQuery = typeof window !== 'undefined' ? window.matchMedia('(prefers-color-scheme: dark)') : null
 const githubTipsScopeOptions = computed<Array<{ value: GithubTipsScope; label: string }>>(() => [
   { value: 'search-daily', label: 'Search daily' },
@@ -764,7 +931,6 @@ onMounted(() => {
   applyDarkMode()
   darkModeMediaQuery?.addEventListener('change', applyDarkMode)
   void initialize()
-  void applyLaunchProjectPathFromUrl()
   void loadHomeDirectory()
   void loadWorkspaceRootOptionsState()
   void refreshDefaultProjectName()
@@ -1253,6 +1419,10 @@ function onWindowPageShow(event: PageTransitionEvent): void {
 }
 
 function onWindowFocus(): void {
+  if (route.name === 'home') {
+    void loadWorkspaceRootOptionsState()
+    void refreshDefaultProjectName()
+  }
   maybeSyncAfterMobileResume()
 }
 
@@ -1417,45 +1587,143 @@ function scheduleMobileConversationJumpToLatest(): void {
 
 function onSelectNewThreadFolder(cwd: string): void {
   newThreadCwd.value = cwd.trim()
+  createFolderError.value = ''
 }
 
-async function onAddNewProject(rawInput: string): Promise<void> {
-  const normalizedInput = rawInput.trim()
-  if (!normalizedInput) return
+async function onOpenExistingFolder(): Promise<void> {
+  const startPath = newThreadCwd.value.trim() || await resolveProjectBaseDirectory()
+  if (!startPath) return
+  isCreateFolderOpen.value = false
+  isExistingFolderPickerOpen.value = true
+  existingFolderFilter.value = ''
+  await loadExistingFolderListing(startPath)
+}
 
-  const isPath = looksLikePath(normalizedInput)
-  const baseDir = await resolveProjectBaseDirectory()
-  const targetPath = isPath
-    ? normalizedInput
-    : joinPath(baseDir, normalizedInput)
+function onCloseExistingFolderPanel(): void {
+  existingFolderBrowseRequestId += 1
+  isExistingFolderPickerOpen.value = false
+  isExistingFolderLoading.value = false
+  existingFolderError.value = ''
+  existingFolderFilter.value = ''
+  onCloseCreateFolderPanel()
+}
+
+async function onBrowseExistingFolder(path: string): Promise<void> {
+  if (!path || isExistingFolderLoading.value) return
+  existingFolderFilter.value = ''
+  await loadExistingFolderListing(path)
+}
+
+function onToggleHiddenFolders(): void {
+  const currentPath = existingFolderBrowsePath.value.trim()
+  if (!isExistingFolderPickerOpen.value || !currentPath) return
+  void loadExistingFolderListing(currentPath)
+}
+
+async function onConfirmExistingFolder(path = existingFolderBrowsePath.value): Promise<void> {
+  const targetPath = path.trim()
   if (!targetPath) return
 
+  existingFolderError.value = ''
+  isOpeningExistingFolder.value = true
   try {
     const normalizedPath = await openProjectRoot(targetPath, {
-      createIfMissing: !isPath,
-      label: isPath ? '' : normalizedInput,
+      createIfMissing: false,
+      label: '',
     })
-    if (normalizedPath) {
-      newThreadCwd.value = normalizedPath
-      pinProjectToTop(getPathLeafName(normalizedPath))
-      void loadWorkspaceRootOptionsState()
-      void refreshDefaultProjectName()
+    if (!normalizedPath) {
+      existingFolderError.value = 'Failed to open the selected folder.'
+      return
     }
-  } catch {
-    // Error is surfaced on next request if path is invalid.
+
+    newThreadCwd.value = normalizedPath
+    pinProjectToTop(getPathLeafName(normalizedPath))
+    await loadWorkspaceRootOptionsState()
+    await refreshDefaultProjectName()
+    onCloseExistingFolderPanel()
+  } catch (error) {
+    existingFolderError.value = error instanceof Error ? error.message : 'Failed to open the selected folder.'
+  } finally {
+    isOpeningExistingFolder.value = false
   }
 }
 
-async function applyLaunchProjectPathFromUrl(): Promise<void> {
-  if (typeof window === 'undefined') return
+async function onOpenCreateFolderPanel(): Promise<void> {
+  existingFolderError.value = ''
+  createFolderError.value = ''
+  if (!isExistingFolderPickerOpen.value) {
+    const startPath = newThreadCwd.value.trim() || await resolveProjectBaseDirectory()
+    if (!startPath) return
+    isExistingFolderPickerOpen.value = true
+    existingFolderFilter.value = ''
+    await loadExistingFolderListing(startPath)
+    if (existingFolderError.value) return
+  }
+  if (isCreateFolderOpen.value) {
+    onCloseCreateFolderPanel()
+    return
+  }
+  createFolderDraft.value = defaultNewProjectName.value
+  isCreateFolderOpen.value = true
+  void nextTick(() => createFolderInputRef.value?.focus())
+}
+
+function onCloseCreateFolderPanel(): void {
+  createFolderError.value = ''
+  createFolderDraft.value = ''
+  isCreateFolderOpen.value = false
+}
+
+async function onCreateFolder(): Promise<void> {
+  const normalizedInput = createFolderDraft.value.trim()
+  if (!normalizedInput) return
+
+  createFolderError.value = ''
+  isCreatingFolder.value = true
+
+  const baseDir = createFolderParentPath.value.trim()
+  const targetPath = normalizeAbsolutePath(joinPath(baseDir, normalizedInput))
+
+  if (!targetPath) {
+    createFolderError.value = 'Unable to determine where the new folder should be created.'
+    isCreatingFolder.value = false
+    return
+  }
+
+  if (!isCreateFolderNameValid.value) {
+    createFolderError.value = 'Enter a single folder name.'
+    isCreatingFolder.value = false
+    return
+  }
+
+  try {
+    const normalizedPath = await createLocalDirectory(targetPath)
+    if (!normalizedPath) {
+      createFolderError.value = 'Failed to create the folder.'
+      return
+    }
+
+    createFolderError.value = ''
+    existingFolderFilter.value = ''
+    await loadExistingFolderListing(normalizedPath)
+    onCloseCreateFolderPanel()
+  } catch (error) {
+    createFolderError.value = error instanceof Error ? error.message : 'Failed to create folder.'
+  } finally {
+    isCreatingFolder.value = false
+  }
+}
+
+async function applyLaunchProjectPathFromUrl(): Promise<boolean> {
+  if (typeof window === 'undefined') return false
   const launchProjectPath = new URLSearchParams(window.location.search).get('openProjectPath')?.trim() ?? ''
-  if (!launchProjectPath) return
+  if (!launchProjectPath) return false
   try {
     const normalizedPath = await openProjectRoot(launchProjectPath, {
       createIfMissing: false,
       label: '',
     })
-    if (!normalizedPath) return
+    if (!normalizedPath) return false
     newThreadCwd.value = normalizedPath
     pinProjectToTop(getPathLeafName(normalizedPath))
     await router.replace({ name: 'home' })
@@ -1463,8 +1731,10 @@ async function applyLaunchProjectPathFromUrl(): Promise<void> {
     const nextUrl = new URL(window.location.href)
     nextUrl.searchParams.delete('openProjectPath')
     window.history.replaceState({}, '', nextUrl.toString())
+    return true
   } catch {
     // If launch path is invalid, keep normal startup behavior.
+    return false
   }
 }
 
@@ -1481,13 +1751,6 @@ async function resolveProjectBaseDirectory(): Promise<string> {
     // Fallback handled by empty return.
   }
   return ''
-}
-
-function looksLikePath(value: string): boolean {
-  if (!value) return false
-  if (value.startsWith('~/')) return true
-  if (value.startsWith('/')) return true
-  return /^[a-zA-Z]:[\\/]/.test(value)
 }
 
 async function refreshDefaultProjectName(): Promise<void> {
@@ -1533,6 +1796,30 @@ async function loadWorkspaceRootOptionsState(): Promise<void> {
   }
 }
 
+async function loadExistingFolderListing(path: string): Promise<void> {
+  const requestId = ++existingFolderBrowseRequestId
+  existingFolderBrowsePath.value = normalizePathForUi(path).trim()
+  existingFolderError.value = ''
+  isExistingFolderLoading.value = true
+
+  try {
+    const listing = await listLocalDirectories(path, { showHidden: showHiddenFolders.value })
+    if (requestId !== existingFolderBrowseRequestId) return
+    existingFolderBrowsePath.value = listing.path
+    existingFolderParentPath.value = listing.parentPath
+    existingFolderEntries.value = listing.entries
+  } catch (error) {
+    if (requestId !== existingFolderBrowseRequestId) return
+    existingFolderError.value = error instanceof Error ? error.message : 'Failed to load local folders.'
+    existingFolderParentPath.value = ''
+    existingFolderEntries.value = []
+  } finally {
+    if (requestId === existingFolderBrowseRequestId) {
+      isExistingFolderLoading.value = false
+    }
+  }
+}
+
 async function loadTrendingProjects(): Promise<void> {
   isTrendingProjectsLoading.value = true
   try {
@@ -1544,10 +1831,56 @@ async function loadTrendingProjects(): Promise<void> {
   }
 }
 function joinPath(parent: string, child: string): string {
-  const normalizedParent = parent.trim().replace(/\/+$/, '')
-  const normalizedChild = child.trim().replace(/^\/+/, '')
+  const normalizedParent = normalizePathForUi(parent).trim().replace(/[\\/]+$/u, '')
+  const normalizedChild = normalizePathForUi(child).trim().replace(/^[\\/]+/u, '')
   if (!normalizedParent || !normalizedChild) return ''
-  return `${normalizedParent}/${normalizedChild}`
+  const separator = normalizedParent.includes('\\') && !normalizedParent.includes('/') ? '\\' : '/'
+  return `${normalizedParent}${separator}${normalizedChild}`
+}
+
+function normalizeAbsolutePath(value: string): string {
+  const normalizedValue = normalizePathForUi(value).trim()
+  if (!normalizedValue) return ''
+
+  const uncMatch = normalizedValue.match(/^\\\\([^\\/]+)[\\/]+([^\\/]+)([\\/].*)?$/u)
+  if (uncMatch) {
+    const [, server, share, suffix = ''] = uncMatch
+    const segments = collapsePathSegments(suffix.split(/[\\/]+/u))
+    return segments.length > 0
+      ? `\\\\${server}\\${share}\\${segments.join('\\')}`
+      : `\\\\${server}\\${share}`
+  }
+
+  const driveMatch = normalizedValue.match(/^([a-zA-Z]:)([\\/].*)?$/u)
+  if (driveMatch) {
+    const [, drive, suffix = ''] = driveMatch
+    const separator = normalizedValue.includes('\\') && !normalizedValue.includes('/') ? '\\' : '/'
+    const segments = collapsePathSegments(suffix.split(/[\\/]+/u))
+    return segments.length > 0 ? `${drive}${separator}${segments.join(separator)}` : `${drive}${separator}`
+  }
+
+  if (normalizedValue.startsWith('/')) {
+    const segments = collapsePathSegments(normalizedValue.split('/'))
+    return segments.length > 0 ? `/${segments.join('/')}` : '/'
+  }
+
+  return normalizedValue
+}
+
+function collapsePathSegments(rawSegments: readonly string[]): string[] {
+  const segments: string[] = []
+  for (const rawSegment of rawSegments) {
+    const segment = rawSegment.trim()
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      if (segments.length > 0) {
+        segments.pop()
+      }
+      continue
+    }
+    segments.push(segment)
+  }
+  return segments
 }
 
 function onSelectModel(modelId: string): void {
@@ -1829,7 +2162,10 @@ async function initialize(): Promise<void> {
     includeSelectedThreadMessages: true,
   })
   void loadAccountsState({ silent: true })
-  await restoreLastActiveThreadRoute()
+  const appliedLaunchProjectPath = await applyLaunchProjectPathFromUrl()
+  if (!appliedLaunchProjectPath) {
+    await restoreLastActiveThreadRoute()
+  }
   hasInitialized.value = true
   await syncThreadSelectionWithRoute()
 }
@@ -2198,7 +2534,7 @@ async function submitFirstMessageForNewThread(
 }
 
 .content-body {
-  @apply flex-1 min-h-0 min-w-0 w-full flex flex-col gap-2 sm:gap-3 pt-1 pb-2 sm:pb-4 overflow-y-hidden overflow-x-hidden;
+  @apply flex-1 min-h-0 min-w-0 w-full flex flex-col gap-2 sm:gap-3 pt-1 pb-2 sm:pb-4 overflow-y-auto overflow-x-hidden;
 }
 
 
@@ -2207,7 +2543,7 @@ async function submitFirstMessageForNewThread(
 }
 
 .content-grid {
-  @apply flex-1 min-h-0 flex flex-col gap-3;
+  @apply flex flex-col gap-3;
 }
 
 .content-thread {
@@ -2215,11 +2551,11 @@ async function submitFirstMessageForNewThread(
 }
 
 .composer-with-queue {
-  @apply w-full;
+  @apply w-full shrink-0 px-2 sm:px-6;
 }
 
 .new-thread-empty {
-  @apply flex-1 min-h-0 flex flex-col items-center justify-center gap-0.5 px-3 sm:px-6;
+  @apply flex flex-col items-center justify-start gap-0.5 px-3 py-4 sm:px-6 sm:py-6;
 }
 
 .new-thread-hero {
@@ -2242,8 +2578,173 @@ async function submitFirstMessageForNewThread(
   @apply h-4 w-4 sm:h-5 sm:w-5 mt-0;
 }
 
+.new-thread-folder-selected {
+  @apply mt-2 mb-0 max-w-3xl text-center text-xs text-zinc-500 break-all;
+}
+
+.new-thread-folder-actions {
+  @apply mt-3 flex w-full max-w-3xl flex-wrap items-center justify-center gap-2;
+}
+
+.new-thread-folder-action {
+  @apply inline-flex h-9 items-center justify-center rounded-full border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-default disabled:opacity-60;
+}
+
+.new-thread-folder-action-primary {
+  @apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;
+}
+
+.new-thread-open-folder {
+  @apply mt-3 flex w-full max-w-3xl flex-col gap-2 rounded-2xl border border-zinc-200 bg-white px-4 py-4 text-left shadow-sm;
+}
+
+.new-thread-open-folder-header {
+  @apply flex items-center justify-between gap-3;
+}
+
+.new-thread-open-folder-title {
+  @apply m-0 text-sm font-semibold text-zinc-900;
+}
+
+.new-thread-open-folder-close {
+  @apply border-0 bg-transparent p-0 text-sm text-zinc-500 transition hover:text-zinc-800;
+}
+
+.new-thread-open-folder-label {
+  @apply m-0 text-xs font-medium uppercase tracking-wide text-zinc-500;
+}
+
+.new-thread-open-folder-current {
+  @apply flex items-start gap-2;
+}
+
+.new-thread-open-folder-path {
+  @apply m-0 min-w-0 flex-1 rounded-xl bg-zinc-100 px-3 py-2 font-mono text-xs text-zinc-700 break-all;
+}
+
+.new-thread-open-folder-actions {
+  @apply flex flex-wrap items-center gap-2;
+}
+
+.new-thread-open-folder-toggle {
+  @apply inline-flex items-center gap-2 text-sm text-zinc-600;
+}
+
+.new-thread-open-folder-toggle-input {
+  @apply relative h-4 w-4 shrink-0 appearance-none rounded-[4px] border border-zinc-300 bg-white outline-none transition;
+}
+
+.new-thread-open-folder-toggle-input:focus-visible {
+  box-shadow: 0 0 0 3px rgb(228 228 231);
+}
+
+.new-thread-open-folder-toggle-input:checked {
+  border-color: rgb(24 24 27);
+  background-color: rgb(255 255 255);
+}
+
+.new-thread-open-folder-toggle-input::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 4px;
+  height: 8px;
+  border-right: 2px solid rgb(24 24 27);
+  border-bottom: 2px solid rgb(24 24 27);
+  transform: rotate(45deg);
+  opacity: 0;
+}
+
+.new-thread-open-folder-toggle-input:checked::after {
+  opacity: 1;
+}
+
+.new-thread-open-folder-filter {
+  @apply w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none transition focus:border-zinc-400;
+}
+
+.new-thread-open-folder-create {
+  @apply flex flex-col gap-2;
+}
+
+.new-thread-open-folder-create-composer {
+  @apply flex items-center gap-2;
+}
+
+.new-thread-open-folder-create-input {
+  @apply w-full min-w-0 flex-1 rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none transition focus:border-zinc-400;
+}
+
+.new-thread-open-folder-create-submit {
+  @apply shrink-0;
+}
+
+.new-thread-folder-action[aria-pressed='true'] {
+  @apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;
+}
+
+.new-thread-open-folder-status {
+  @apply m-0 rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-600;
+}
+
+.new-thread-open-folder-error {
+  @apply m-0 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700;
+}
+
+.new-thread-open-folder-list {
+  @apply m-0 flex max-h-72 list-none flex-col gap-1 overflow-y-auto p-0 pr-3;
+  scrollbar-gutter: stable;
+  scrollbar-color: rgb(161 161 170) rgb(244 244 245);
+  scrollbar-width: thin;
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar {
+  width: 10px;
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-track {
+  background: rgb(244 244 245);
+  border-radius: 9999px;
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb {
+  background: rgb(161 161 170);
+  border-radius: 9999px;
+  border: 2px solid rgb(244 244 245);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb:hover {
+  background: rgb(113 113 122);
+}
+
+.new-thread-open-folder-item {
+  @apply grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1;
+}
+
+.new-thread-open-folder-item-main {
+  @apply min-w-0 truncate rounded-xl border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-left text-sm font-medium leading-5 text-zinc-900 transition hover:border-zinc-300 hover:bg-zinc-100;
+}
+
+.new-thread-open-folder-item-main:disabled,
+.new-thread-open-folder-item-open:disabled {
+  @apply cursor-default opacity-60;
+}
+
+.new-thread-open-folder-item-name {
+  @apply block truncate;
+}
+
+.new-thread-open-folder-item-open {
+  @apply inline-flex h-7 items-center justify-center rounded-xl border border-zinc-200 bg-white px-2.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-50;
+}
+
 .new-thread-runtime-dropdown {
   @apply mt-3;
+}
+
+.new-thread-runtime-help {
+  @apply mt-2 mb-0 max-w-3xl text-center text-xs text-zinc-500;
 }
 
 .new-thread-trending {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -147,6 +147,17 @@ export type GithubTipsScope =
   | 'trending-weekly'
   | 'trending-monthly'
 
+export type LocalDirectoryEntry = {
+  name: string
+  path: string
+}
+
+export type LocalDirectoryListing = {
+  path: string
+  parentPath: string
+  entries: LocalDirectoryEntry[]
+}
+
 function normalizeGithubProjectDescription(fullName: string, rawDescription: string): string {
   const description = rawDescription.trim()
   if (!description) return ''
@@ -1133,6 +1144,51 @@ export async function getHomeDirectory(): Promise<string> {
   return typeof data.path === 'string' ? data.path.trim() : ''
 }
 
+export async function listLocalDirectories(path: string, options?: { showHidden?: boolean }): Promise<LocalDirectoryListing> {
+  const query = new URLSearchParams({ path })
+  if (options?.showHidden === true) {
+    query.set('showHidden', '1')
+  }
+  const response = await fetch(`/codex-local-directories?${query.toString()}`)
+  const payload = await readJsonResponse(response)
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to load local directories')
+    throw new Error(message)
+  }
+
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  const entriesRaw = Array.isArray(data.entries) ? data.entries : []
+
+  return {
+    path: typeof data.path === 'string' ? normalizePathForUi(data.path) : '',
+    parentPath: typeof data.parentPath === 'string' ? normalizePathForUi(data.parentPath) : '',
+    entries: entriesRaw.flatMap((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+      const record = item as Record<string, unknown>
+      const name = typeof record.name === 'string' ? record.name.trim() : ''
+      const entryPath = typeof record.path === 'string' ? normalizePathForUi(record.path) : ''
+      return name && entryPath ? [{ name, path: entryPath }] : []
+    }),
+  }
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    throw new Error(`Expected JSON response from ${response.url || 'request'}`)
+  }
+}
+
 export async function setWorkspaceRootsState(nextState: WorkspaceRootsState): Promise<void> {
   const response = await fetch('/codex-api/workspace-roots-state', {
     method: 'PUT',
@@ -1169,6 +1225,28 @@ export async function openProjectRoot(path: string, options?: { createIfMissing?
       : {}
   const normalizedPath = typeof data.path === 'string' ? normalizePathForUi(data.path) : ''
   return normalizedPath
+}
+
+export async function createLocalDirectory(path: string): Promise<string> {
+  const response = await fetch('/codex-api/local-directory', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  })
+  const payload = await readJsonResponse(response)
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to create local directory')
+    throw new Error(message)
+  }
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  return typeof data.path === 'string' ? normalizePathForUi(data.path) : ''
 }
 
 export async function getProjectRootSuggestion(basePath: string): Promise<{ name: string; path: string }> {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2419,6 +2419,29 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'POST' && url.pathname === '/codex-api/local-directory') {
+        const payload = asRecord(await readJsonBody(req))
+        const rawPath = typeof payload?.path === 'string' ? payload.path.trim() : ''
+        if (!rawPath) {
+          setJson(res, 400, { error: 'Missing path' })
+          return
+        }
+
+        const normalizedPath = isAbsolute(rawPath) ? rawPath : resolve(rawPath)
+        try {
+          const info = await stat(normalizedPath)
+          if (!info.isDirectory()) {
+            setJson(res, 400, { error: 'Path exists but is not a directory' })
+            return
+          }
+        } catch {
+          await mkdir(normalizedPath, { recursive: true })
+        }
+
+        setJson(res, 200, { data: { path: normalizedPath } })
+        return
+      }
+
       if (req.method === 'GET' && url.pathname === '/codex-api/project-root-suggestion') {
         const basePath = url.searchParams.get('basePath')?.trim() ?? ''
         if (!basePath) {

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -6,7 +6,7 @@ import { writeFile, stat } from 'node:fs/promises'
 import express, { type Express } from 'express'
 import { createCodexBridgeMiddleware } from './codexAppServerBridge.js'
 import { createAuthSession } from './authMiddleware.js'
-import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, isTextEditableFile, normalizeLocalPath } from './localBrowseUi.js'
+import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from './localBrowseUi.js'
 import { WebSocketServer, type WebSocket } from 'ws'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -121,7 +121,31 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     })
   })
 
-  // 5. Serve local files by path to preserve relative asset loading for HTML.
+  // 5. Return JSON directory listings for the integrated folder picker.
+  app.get('/codex-local-directories', async (req, res) => {
+    const rawPath = typeof req.query.path === 'string' ? req.query.path : ''
+    const showHidden = typeof req.query.showHidden === 'string'
+      && ['1', 'true', 'yes', 'on'].includes(req.query.showHidden.toLowerCase())
+    const localPath = normalizeLocalPath(rawPath)
+    if (!localPath || !isAbsolute(localPath)) {
+      res.status(400).json({ error: 'Expected absolute local directory path.' })
+      return
+    }
+
+    try {
+      const fileStat = await stat(localPath)
+      if (!fileStat.isDirectory()) {
+        res.status(400).json({ error: 'Expected directory path.' })
+        return
+      }
+      const data = await getLocalDirectoryListing(localPath, { showHidden })
+      res.status(200).json({ data })
+    } catch {
+      res.status(404).json({ error: 'Directory not found.' })
+    }
+  })
+
+  // 6. Serve local files by path to preserve relative asset loading for HTML.
   app.get('/codex-local-browse/*path', async (req, res) => {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
@@ -148,7 +172,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     }
   })
 
-  // 6. Edit text-like local files.
+  // 7. Edit text-like local files.
   app.get('/codex-local-edit/*path', async (req, res) => {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
@@ -191,12 +215,12 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
 
   const hasFrontendAssets = existsSync(spaEntryFile)
 
-  // 7. Static files from Vue build
+  // 8. Static files from Vue build
   if (hasFrontendAssets) {
     app.use(express.static(distDir))
   }
 
-  // 8. SPA fallback
+  // 9. SPA fallback
   app.use((_req, res) => {
     if (!hasFrontendAssets) {
       res

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -9,6 +9,21 @@ type DirectoryItem = {
   mtimeMs: number
 }
 
+export type LocalDirectoryListingEntry = {
+  name: string
+  path: string
+}
+
+export type LocalDirectoryListing = {
+  path: string
+  parentPath: string
+  entries: LocalDirectoryListingEntry[]
+}
+
+type LocalDirectoryListingOptions = {
+  showHidden?: boolean
+}
+
 const TEXT_EDITABLE_EXTENSIONS = new Set([
   '.txt', '.md', '.json', '.js', '.ts', '.tsx', '.jsx', '.css', '.scss',
   '.html', '.htm', '.xml', '.yml', '.yaml', '.log', '.csv', '.env', '.py',
@@ -65,6 +80,10 @@ export function decodeBrowsePath(rawPath: string): string {
 
 export function isTextEditablePath(pathValue: string): boolean {
   return TEXT_EDITABLE_EXTENSIONS.has(extname(pathValue).toLowerCase())
+}
+
+function isHiddenName(value: string): boolean {
+  return value.startsWith('.')
 }
 
 function looksLikeTextBuffer(buffer: Buffer): boolean {
@@ -145,6 +164,32 @@ async function getDirectoryItems(localPath: string): Promise<DirectoryItem[]> {
     if (!a.isDirectory && b.isDirectory) return 1
     return a.name.localeCompare(b.name)
   })
+}
+
+export async function getLocalDirectoryListing(
+  localPath: string,
+  options: LocalDirectoryListingOptions = {},
+): Promise<LocalDirectoryListing> {
+  const entries = await readdir(localPath, { withFileTypes: true })
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      path: join(localPath, entry.name),
+    }))
+    .filter((entry) => options.showHidden === true || !isHiddenName(entry.name))
+    .sort((a, b) => {
+      const aHidden = isHiddenName(a.name)
+      const bHidden = isHiddenName(b.name)
+      if (aHidden !== bHidden) return aHidden ? -1 : 1
+      return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' })
+    })
+
+  return {
+    path: localPath,
+    parentPath: dirname(localPath),
+    entries: directories,
+  }
 }
 
 export async function createDirectoryListingHtml(localPath: string): Promise<string> {
@@ -242,7 +287,9 @@ export async function createDirectoryListingHtml(localPath: string): Promise<str
           button.disabled = false;
           return;
         }
-        window.location.assign('/#/');
+        status.textContent = 'Folder opened. Returning to Codex...';
+        const nextUrl = '/?openProjectPath=' + encodeURIComponent(path) + '#/';
+        window.location.assign(nextUrl);
       } catch {
         status.textContent = 'Failed to open folder.';
         button.disabled = false;

--- a/tests.md
+++ b/tests.md
@@ -216,6 +216,37 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Return appearance and runtime selection to the previous user preference.
 
+### Feature: Home screen project picker improves project selection and creation UX
+
+#### Prerequisites
+- App is running from this repository.
+- Home/new-thread screen is open.
+- Access to the server filesystem used by codexUI.
+- At least one writable parent directory exists for creating a test folder.
+
+#### Steps
+1. On the home screen, verify the primary folder action is `Select folder`.
+2. Click `Select folder` and confirm codexUI opens an in-page folder picker card instead of navigating away from the home screen.
+3. Confirm the picker shows the current absolute folder with an `Open` action, a `Show hidden folders` toggle, a toggle-style `New folder` action, a folder filter input, and a scrollable single-line list of subfolders inside the same UI shell.
+4. Enter a substring in the filter input and verify the list narrows to folders whose names contain that text, while `..` remains available for navigation.
+5. When the current folder has a parent, confirm the first row in the list is `..`, use it to navigate upward, then browse into an existing subfolder and use the `Open` action without leaving the home screen.
+6. Confirm hidden folders are not shown by default, then enable `Show hidden folders` and verify hidden folders appear before regular folders in the list.
+7. Use `New folder` from inside the picker and confirm a compact inline create row appears below the controls without repeating the current directory path.
+8. Enter a single folder name and confirm the `Create` action sits on the same row as the text input.
+9. Click `New folder` again and confirm the inline create row collapses instead of showing a separate cancel action.
+10. Re-open the inline create row, submit a single folder name, and confirm codexUI creates the folder and navigates the picker into that new child directory without immediately opening it as the selected project.
+11. From that newly created directory, click `Open` and confirm it becomes the selected folder in codexUI.
+
+#### Expected Results
+- The home screen uses a single `Select folder` entry point for choosing or creating a local project.
+- Folder creation stays inside the same integrated picker card rather than using a separate browser-style or standalone create panel.
+- Large directory listings stay contained inside a scrollable picker area instead of overlapping the rest of the home screen or composer area.
+- Parent navigation appears as a `..` row in the list, folder names can be filtered by substring, and hidden folders remain hidden unless explicitly requested.
+- Creating a folder from the picker uses a compact single-row composer, can be dismissed by clicking `New folder` again, and creates the folder inside the current directory before navigating into it while keeping final project selection explicit via `Open`.
+
+#### Rollback/Cleanup
+- Delete any temporary test folder created during the manual check.
+
 ### Feature: pnpm dev script installs dependencies and starts Vite
 
 #### Prerequisites

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { createCodexBridgeMiddleware } from "./src/server/codexAppServerBridge";
-import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, isTextEditableFile, normalizeLocalPath } from "./src/server/localBrowseUi";
+import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from "./src/server/localBrowseUi";
 import tailwindcss from "@tailwindcss/vite";
 import { spawnSync } from "node:child_process";
 import { createReadStream, existsSync, readFileSync } from "node:fs";
@@ -226,6 +226,39 @@ export default defineConfig({
             res.end(JSON.stringify({ error: "File not found." }));
           });
           stream.pipe(res);
+        });
+        server.middlewares.use(async (req, res, next) => {
+          if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
+          const url = new URL(req.url, "http://localhost");
+          if (url.pathname !== "/codex-local-directories") return next();
+
+          const showHidden = ["1", "true", "yes", "on"].includes((url.searchParams.get("showHidden") ?? "").toLowerCase());
+          const localPath = normalizeLocalPath(url.searchParams.get("path") ?? "");
+          if (!localPath || !isAbsolute(localPath)) {
+            res.statusCode = 400;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ error: "Expected absolute local directory path." }));
+            return;
+          }
+
+          try {
+            const fileStat = await stat(localPath);
+            if (!fileStat.isDirectory()) {
+              res.statusCode = 400;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ error: "Expected directory path." }));
+              return;
+            }
+
+            const data = await getLocalDirectoryListing(localPath, { showHidden });
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ data }));
+          } catch {
+            res.statusCode = 404;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ error: "Directory not found." }));
+          }
         });
         server.middlewares.use(async (req, res, next) => {
           if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();


### PR DESCRIPTION
**Summary**

Improve the home-screen local project workflow with an integrated folder picker
that stays inside the existing UI.

This change lets users:
- browse local directories in place,
- navigate up and down the directory tree,
- filter folders by substring,
- optionally show hidden folders,
- create a new child folder inline,
- explicitly open the currently selected folder.

It also adds the supporting local directory listing and creation plumbing needed
for this picker to work in both production and local Vite development.

**Problem**

The local project flow on the home screen is confusing and fragmented.
Selecting an existing folder and creating a new one do not feel like parts of
the same task, and the folder selection experience is not well integrated into
the main UI.

**Solution**

Add a single `Select folder` flow on the home screen that handles both project
selection and project creation in one place.

The picker:
- stays inside the normal home-screen layout,
- uses `..` for parent navigation,
- keeps hidden folders off by default,
- supports filtering for large directories,
- creates new folders inline in the current directory,
- keeps final project selection explicit via `Open`.

The home layout was also adjusted so the picker can expand without overlapping
the composer area.

**Verification**

- `npx vue-tsc --noEmit`
- `npx vite build`
- `npx tsup`