### PR TITLE
Fix folder picker root paths and error handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -302,7 +302,7 @@
                       :class="{ 'new-thread-folder-action-primary': isCreateFolderOpen }"
                       type="button"
                       :aria-pressed="isCreateFolderOpen"
-                      :disabled="!existingFolderBrowsePath || !!existingFolderError || isExistingFolderLoading || isOpeningExistingFolder || isCreatingFolder"
+                      :disabled="!existingFolderBrowsePath || isExistingFolderLoading || isOpeningExistingFolder || isCreatingFolder || (!!existingFolderError && !isCreateFolderOpen)"
                       @click="onOpenCreateFolderPanel"
                     >
                       New folder
@@ -336,12 +336,22 @@
                     type="text"
                     placeholder="Filter folders..."
                   />
-                  <p v-if="existingFolderError" class="new-thread-open-folder-error">{{ existingFolderError }}</p>
-                  <p v-else-if="isExistingFolderLoading" class="new-thread-open-folder-status">Loading folders…</p>
-                  <p v-else-if="existingFolderFilteredEntries.length === 0" class="new-thread-open-folder-status">
+                  <div v-if="existingFolderError" class="new-thread-open-folder-error-actions">
+                    <p class="new-thread-open-folder-error">{{ existingFolderError }}</p>
+                    <button
+                      class="new-thread-folder-action"
+                      type="button"
+                      :disabled="isExistingFolderLoading || isOpeningExistingFolder"
+                      @click="onRetryExistingFolderBrowse"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                  <p v-if="isExistingFolderLoading" class="new-thread-open-folder-status">Loading folders…</p>
+                  <p v-else-if="!existingFolderError && existingFolderFilteredEntries.length === 0" class="new-thread-open-folder-status">
                     {{ existingFolderFilter.trim() ? 'No folders match this filter.' : 'No subfolders found here.' }}
                   </p>
-                  <ul v-else class="new-thread-open-folder-list">
+                  <ul v-else-if="existingFolderFilteredEntries.length > 0" class="new-thread-open-folder-list">
                     <li v-for="entry in existingFolderFilteredEntries" :key="entry.key" class="new-thread-open-folder-item">
                       <button
                         class="new-thread-open-folder-item-main"
@@ -1732,6 +1742,12 @@ function onToggleHiddenFolders(): void {
   void loadExistingFolderListing(currentPath)
 }
 
+function onRetryExistingFolderBrowse(): void {
+  const currentPath = existingFolderBrowsePath.value.trim()
+  if (!isExistingFolderPickerOpen.value || !currentPath || isExistingFolderLoading.value) return
+  void loadExistingFolderListing(currentPath)
+}
+
 async function onConfirmExistingFolder(path = existingFolderBrowsePath.value): Promise<void> {
   const targetPath = path.trim()
   if (!targetPath) return
@@ -1762,6 +1778,10 @@ async function onConfirmExistingFolder(path = existingFolderBrowsePath.value): P
 
 async function onOpenCreateFolderPanel(): Promise<void> {
   createFolderError.value = ''
+  if (isCreateFolderOpen.value) {
+    onCloseCreateFolderPanel()
+    return
+  }
   if (!isExistingFolderPickerOpen.value) {
     const startPath = newThreadCwd.value.trim() || await resolveProjectBaseDirectory()
     if (!startPath) return
@@ -1771,10 +1791,6 @@ async function onOpenCreateFolderPanel(): Promise<void> {
     if (existingFolderError.value) return
   }
   if (existingFolderError.value) return
-  if (isCreateFolderOpen.value) {
-    onCloseCreateFolderPanel()
-    return
-  }
   createFolderDraft.value = defaultNewProjectName.value
   isCreateFolderOpen.value = true
   void nextTick(() => createFolderInputRef.value?.focus())
@@ -1927,7 +1943,7 @@ async function loadExistingFolderListing(path: string): Promise<void> {
   } catch (error) {
     if (requestId !== existingFolderBrowseRequestId) return
     existingFolderError.value = error instanceof Error ? error.message : 'Failed to load local folders.'
-    existingFolderParentPath.value = ''
+    existingFolderParentPath.value = getPathParent(existingFolderBrowsePath.value)
     existingFolderEntries.value = []
     onCloseCreateFolderPanel()
   } finally {
@@ -2006,14 +2022,6 @@ function collapsePathSegments(rawSegments: readonly string[]): string[] {
     segments.push(segment)
   }
   return segments
-}
-
-function getPathLeafName(path: string): string {
-  const trimmed = path.trim().replace(/\/+$/, '')
-  if (!trimmed) return ''
-  const slashIndex = trimmed.lastIndexOf('/')
-  if (slashIndex < 0) return trimmed
-  return trimmed.slice(slashIndex + 1)
 }
 
 function onSelectModel(modelId: string): void {
@@ -2824,6 +2832,10 @@ async function submitFirstMessageForNewThread(
 
 .new-thread-open-folder-error {
   @apply m-0 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700;
+}
+
+.new-thread-open-folder-error-actions {
+  @apply flex flex-wrap items-start gap-2;
 }
 
 .new-thread-open-folder-list {

--- a/tests.md
+++ b/tests.md
@@ -282,7 +282,9 @@ This file tracks manual regression and feature verification steps.
 9. Click `New folder` again and confirm the inline create row collapses instead of showing a separate cancel action.
 10. Re-open the inline create row, submit a single folder name, and confirm codexUI creates the folder and navigates the picker into that new child directory without immediately opening it as the selected project.
 11. From that newly created directory, click `Open` and confirm it becomes the selected folder in codexUI.
-12. Trigger a folder-listing failure for the current path if possible (for example by navigating to a directory that becomes unreadable), then confirm `New folder` is disabled and folder creation cannot proceed until the listing succeeds again.
+12. Trigger a folder-listing failure for the current path if possible (for example by navigating to a directory that becomes unreadable), then confirm the picker keeps the error visible, shows a `Retry` action, and still exposes `..` when a parent directory is known.
+13. If the inline `New folder` row was open before the listing failure, confirm the same `New folder` button now closes that row instead of becoming permanently disabled.
+14. Use `Retry` after restoring access or connectivity and confirm the current folder listing reloads without leaving the picker.
 
 #### Expected Results
 - The home screen uses a single `Select folder` entry point for choosing or creating a local project.
@@ -290,7 +292,7 @@ This file tracks manual regression and feature verification steps.
 - Large directory listings stay contained inside a scrollable picker area instead of overlapping the rest of the home screen or composer area.
 - Parent navigation appears as a `..` row in the list, folder names can be filtered by substring, and hidden folders remain hidden unless explicitly requested.
 - Creating a folder from the picker uses a compact single-row composer, can be dismissed by clicking `New folder` again, and creates the folder inside the current directory before navigating into it while keeping final project selection explicit via `Open`.
-- When the current folder cannot be listed, the picker keeps the error visible and blocks folder creation until the browse state is valid again.
+- When the current folder cannot be listed, the picker keeps the error visible, offers an in-panel `Retry` path, preserves parent navigation when possible, and blocks folder creation until the browse state is valid again.
 
 #### Rollback/Cleanup
 - Delete any temporary test folder created during the manual check.


### PR DESCRIPTION
Preserve root separators when joining picker paths so Unix root and Windows drive roots produce consistent child paths.

Keep folder-listing errors visible instead of clearing them when the create panel opens. Disable folder creation while the current browse path is in an error state, and collapse the inline create row after browse failures.

Update the manual picker test notes to cover the error-state behavior.

Addresses review comments from #29 