### PR TITLE
Add `--no-login` startup flag to skip forced Codex login

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ cloudflared tunnel --url http://localhost:<port>
 It prints the tunnel URL, terminal QR code, and password together in startup output.  
 Use `--no-tunnel` to disable this behavior.
 
+If you are using a provider or AI gateway that is already authenticated and do not want `codexapp` to force `codex login` during startup, use:
+
+```bash
+npx codexapp --no-login
+```
+
 ### Linux 🐧
 ```bash
 node -v   # should be 18+

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -438,7 +438,14 @@ async function addProjectOnly(projectPath: string): Promise<void> {
   await persistLaunchProject(trimmed)
 }
 
-async function startServer(options: { port: string; password: string | boolean; tunnel: boolean; open: boolean; projectPath?: string }) {
+async function startServer(options: {
+  port: string
+  password: string | boolean
+  tunnel: boolean
+  open: boolean
+  login: boolean
+  projectPath?: string
+}) {
   const version = await readCliVersion()
   const projectPath = options.projectPath?.trim() ?? ''
   if (projectPath.length > 0) {
@@ -453,7 +460,7 @@ async function startServer(options: { port: string; password: string | boolean; 
   if (codexCommand) {
     process.env.CODEXUI_CODEX_COMMAND = codexCommand
   }
-  if (!hasCodexAuth() && codexCommand) {
+  if (options.login && !hasCodexAuth() && codexCommand) {
     console.log('\nCodex is not logged in. Starting `codex login`...\n')
     runOrFail(codexCommand, ['login'], 'Codex login')
   }
@@ -555,9 +562,18 @@ program
   .option('--no-tunnel', 'disable cloudflared tunnel startup')
   .option('--open', 'open browser on startup', true)
   .option('--no-open', 'do not open browser on startup')
+  .option('--login', 'run automatic Codex login bootstrap', true)
+  .option('--no-login', 'skip automatic Codex login bootstrap')
   .action(async (
     projectPath: string | undefined,
-    opts: { port: string; password: string | boolean; tunnel: boolean; open: boolean; openProject?: string },
+    opts: {
+      port: string
+      password: string | boolean
+      tunnel: boolean
+      open: boolean
+      login: boolean
+      openProject?: string
+    },
   ) => {
     const rawArgv = process.argv.slice(2)
     const openProjectFlagIndex = rawArgv.findIndex((arg) => arg === '--open-project' || arg.startsWith('--open-project='))

--- a/tests.md
+++ b/tests.md
@@ -700,3 +700,27 @@ This file tracks manual regression and feature verification steps.
 - Turn off any network blocking, proxy rule, or backend breakpoint used to simulate the failure.
 - Remove any temporary attachments from the composer before continuing other tests.
 - Stop the app server when finished.
+
+### Feature: `--no-login` startup flag
+
+#### Prerequisites
+- `pnpm run build` has completed successfully in this repository.
+- A temporary empty `CODEX_HOME` directory is available so no `auth.json` file is present.
+- A temporary executable is available to stand in for the Codex CLI and record invocations.
+
+#### Steps
+1. Create a temporary directory for `CODEX_HOME` and confirm it does not contain `auth.json`.
+2. Create a fake Codex executable that supports `--version` and appends every invocation to a log file.
+3. Start `node dist-cli/index.js --no-login --no-open --no-tunnel --port 6011` with `CODEX_HOME` pointed at the empty temp directory and `CODEXUI_CODEX_COMMAND` pointed at the fake executable.
+4. Wait for the startup banner, stop the process, and inspect the fake executable log.
+5. Start `node dist-cli/index.js --no-open --no-tunnel --port 6012` with the same environment.
+6. Wait for the startup banner, stop the process, and inspect the log again.
+7. Run `node dist-cli/index.js --help` and confirm the help output includes `--no-login`.
+
+#### Expected Results
+- With `--no-login`, the server starts without attempting `codex login`.
+- Without `--no-login`, startup still invokes `codex login` when `auth.json` is missing.
+- The CLI help output documents the new flag.
+
+#### Rollback/Cleanup
+- Delete the temporary `CODEX_HOME`, fake Codex executable, and invocation log.


### PR DESCRIPTION
Fixes #25.

This change adds a `--no-login` CLI flag so `codexapp` can start without automatically running `codex login` when no local `auth.json` is present.

This is useful for setups that already authenticate through an API gateway or provider layer, where forcing an interactive Codex login is unnecessary and blocks startup.

**What changed**  
- Added `--no-login` to the CLI options
- Gated the automatic `codex login` bootstrap behind the new flag
- Kept the default behavior unchanged when the flag is not provided
- Updated `README.md`
- Added manual verification steps to `tests.md`

**Behavior**  
- Default: startup still runs `codex login` if local auth is missing
- With `--no-login`: startup skips the login bootstrap and starts the server normally

**Verification**  
- Confirmed `--help` shows `--no-login`
- Confirmed startup with `--no-login` does not invoke `codex login`
- Confirmed startup without the flag still invokes `codex login` when auth is missing