### PR TITLE
perf(ui): lazy render message window — show last 50, load earlier on scroll

### DIFF
--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -3874,6 +3874,7 @@ async function loadMoreAbove(): Promise<void> {
   if (!container || !hasMoreAbove.value || isLoadingMore.value) return
 
   isLoadingMore.value = true
+  const threadIdAtStart = props.activeThreadId
 
   const prevScrollHeight = container.scrollHeight
   const prevScrollTop = container.scrollTop
@@ -3882,10 +3883,11 @@ async function loadMoreAbove(): Promise<void> {
 
   await nextTick()
 
-  // Restore relative scroll position so the viewport doesn't jump.
-  container.scrollTop = prevScrollTop + (container.scrollHeight - prevScrollHeight)
-
-  isLoadingMore.value = false
+  // Discard scroll restoration if the thread changed while we were awaiting.
+  if (props.activeThreadId === threadIdAtStart) {
+    container.scrollTop = prevScrollTop + (container.scrollHeight - prevScrollHeight)
+    isLoadingMore.value = false
+  }
 }
 
 defineExpose({
@@ -4014,6 +4016,7 @@ watch(
     localScrollState.value = null
     autoFollowOutput.value = true
     modalImageUrl.value = ''
+    isLoadingMore.value = false
     // Apply immediately for cached threads where isLoading never toggles.
     renderWindowStart.value = Math.max(0, props.messages.length - RENDER_WINDOW_SIZE)
   },

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -3943,6 +3943,15 @@ watch(
       ]),
     )
 
+    // While following output, advance the window start to keep rendered count bounded.
+    // When the user scrolls up (autoFollowOutput = false) we stop trimming so they
+    // can read history and use "Load earlier messages" to go further back.
+    if (autoFollowOutput.value) {
+      const desired = Math.max(0, next.length - RENDER_WINDOW_SIZE)
+      if (desired > renderWindowStart.value) {
+        renderWindowStart.value = desired
+      }
+    }
 
     await scheduleScrollRestore()
   },

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -10,7 +10,17 @@
     </p>
 
     <ul v-else ref="conversationListRef" class="conversation-list" @scroll="onConversationScroll">
-      <template v-for="message in messages" :key="message.id">
+      <li v-if="hasMoreAbove" class="conversation-load-more">
+        <button
+          type="button"
+          class="load-more-button"
+          :disabled="isLoadingMore"
+          @click="loadMoreAbove"
+        >
+          {{ isLoadingMore ? 'Loading…' : 'Load earlier messages' }}
+        </button>
+      </li>
+      <template v-for="message in visibleMessages" :key="message.id">
       <li
         v-if="!hiddenGroupedCommandIds.has(message.id) && !hiddenFileChangeMessageIds.has(message.id)"
         class="conversation-item"
@@ -1239,6 +1249,16 @@ const trackedPendingImages = new WeakSet<HTMLImageElement>()
 const failedMarkdownImageKeys = ref<Set<string>>(new Set())
 const highlightJsModule = ref<HighlightJsModule | null>(null)
 let highlightJsLoader: Promise<void> | null = null
+
+const RENDER_WINDOW_SIZE = 50
+const LOAD_MORE_CHUNK = 30
+const LOAD_MORE_SCROLL_THRESHOLD_PX = 200
+
+const renderWindowStart = ref(0)
+const isLoadingMore = ref(false)
+
+const visibleMessages = computed(() => props.messages.slice(renderWindowStart.value))
+const hasMoreAbove = computed(() => renderWindowStart.value > 0)
 
 const showJumpToLatestButton = computed(
   () => !autoFollowOutput.value && (props.messages.length > 0 || props.pendingRequests.length > 0 || Boolean(props.liveOverlay)),
@@ -3849,6 +3869,25 @@ function jumpToLatest(): void {
   scheduleBottomLock(4)
 }
 
+async function loadMoreAbove(): Promise<void> {
+  const container = conversationListRef.value
+  if (!container || !hasMoreAbove.value || isLoadingMore.value) return
+
+  isLoadingMore.value = true
+
+  const prevScrollHeight = container.scrollHeight
+  const prevScrollTop = container.scrollTop
+
+  renderWindowStart.value = Math.max(0, renderWindowStart.value - LOAD_MORE_CHUNK)
+
+  await nextTick()
+
+  // Restore relative scroll position so the viewport doesn't jump.
+  container.scrollTop = prevScrollTop + (container.scrollHeight - prevScrollHeight)
+
+  isLoadingMore.value = false
+}
+
 defineExpose({
   jumpToLatest,
 })
@@ -3954,6 +3993,7 @@ watch(
   () => props.isLoading,
   async (loading) => {
     if (loading) return
+    renderWindowStart.value = Math.max(0, props.messages.length - RENDER_WINDOW_SIZE)
     await scheduleScrollRestore()
   },
 )
@@ -3964,6 +4004,8 @@ watch(
     localScrollState.value = null
     autoFollowOutput.value = true
     modalImageUrl.value = ''
+    // Apply immediately for cached threads where isLoading never toggles.
+    renderWindowStart.value = Math.max(0, props.messages.length - RENDER_WINDOW_SIZE)
   },
   { flush: 'post' },
 )
@@ -3973,6 +4015,9 @@ function onConversationScroll(): void {
   if (!container || props.isLoading) return
   autoFollowOutput.value = isAtBottom(container)
   emitScrollState(container)
+  if (hasMoreAbove.value && !isLoadingMore.value && container.scrollTop < LOAD_MORE_SCROLL_THRESHOLD_PX) {
+    void loadMoreAbove()
+  }
 }
 
 const failedMarkdownImages = ref(new Set<string>())
@@ -4036,6 +4081,18 @@ onBeforeUnmount(() => {
 
 .conversation-list {
   @apply h-full min-h-0 list-none m-0 px-2 sm:px-6 py-0 overflow-y-auto overflow-x-visible flex flex-col gap-2 sm:gap-3;
+}
+
+.conversation-load-more {
+  @apply flex justify-center py-3 m-0;
+}
+
+.load-more-button {
+  @apply px-4 py-1.5 text-xs rounded-full border border-slate-300 dark:border-slate-600
+         text-slate-500 dark:text-slate-400 bg-transparent
+         hover:bg-slate-100 dark:hover:bg-slate-800
+         disabled:opacity-40 disabled:cursor-not-allowed
+         transition-colors cursor-pointer;
 }
 
 .conversation-item {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -3943,14 +3943,15 @@ watch(
       ]),
     )
 
-    // While following output, advance the window start to keep rendered count bounded.
-    // When the user scrolls up (autoFollowOutput = false) we stop trimming so they
-    // can read history and use "Load earlier messages" to go further back.
+    // Keep renderWindowStart in bounds whenever the message list changes length.
+    // Following output: always pin the window to the last RENDER_WINDOW_SIZE messages so
+    //   the rendered count stays bounded (handles both growth and shrink/rollback).
+    // Scrolled up: only clamp downward so renderWindowStart never exceeds the list length
+    //   (prevents visibleMessages from becoming empty after a rollback).
     if (autoFollowOutput.value) {
-      const desired = Math.max(0, next.length - RENDER_WINDOW_SIZE)
-      if (desired > renderWindowStart.value) {
-        renderWindowStart.value = desired
-      }
+      renderWindowStart.value = Math.max(0, next.length - RENDER_WINDOW_SIZE)
+    } else {
+      renderWindowStart.value = Math.min(renderWindowStart.value, Math.max(0, next.length - 1))
     }
 
     await scheduleScrollRestore()

--- a/tests.md
+++ b/tests.md
@@ -1945,3 +1945,52 @@ stays at `source: "NoValues"` permanently. Feature gate `505458` (worktree) retu
 
 #### Rollback/Cleanup
 - Reset `GitHub trending projects` setting to your preferred state.
+
+### Feature: Lazy message rendering (windowed conversation)
+
+#### Prerequisites
+- App is running from this repository.
+- A thread exists with more than 50 messages (send many short messages, or use a long-running session).
+
+#### Steps — initial load window
+
+1. Open a thread with 60+ messages.
+2. Observe that the conversation list does **not** show all messages immediately — only the most recent ~50 are rendered.
+3. Verify the latest messages are visible and the chat is scrolled to the bottom.
+4. Confirm a "Load earlier messages" button appears at the top of the visible list.
+
+#### Steps — scroll-triggered load
+
+5. Scroll up slowly toward the top of the conversation list.
+6. When the scroll position reaches within ~200 px of the top, verify that the previous 30 messages appear automatically above the current ones.
+7. Confirm the viewport does **not** jump — the messages you were reading stay in view.
+8. Repeat scrolling up to verify additional chunks load on demand.
+9. Once all messages are loaded, verify the "Load earlier messages" button disappears.
+
+#### Steps — manual load button
+
+10. Reload the page and open the same long thread.
+11. Click "Load earlier messages" button without scrolling.
+12. Verify 30 older messages are prepended and scroll position is preserved.
+
+#### Steps — live session growth
+
+13. Start an active Codex session (or send many messages in quick succession).
+14. Let the conversation exceed 50 messages while staying scrolled to the bottom.
+15. Verify the rendered count stays bounded (top of the DOM list advances as new messages arrive).
+16. Scroll up and confirm "Load earlier messages" works to reveal trimmed messages.
+
+#### Steps — rollback / message shrink
+
+17. In a thread with a turn that can be rolled back, trigger a rollback.
+18. Verify the conversation does **not** go blank — messages still render after the list shrinks.
+19. Confirm `renderWindowStart` recovers gracefully and earlier messages remain accessible.
+
+#### Expected Results
+- Only ≤50 messages are in the DOM on initial load.
+- Scrolling to the top (or clicking the button) appends older messages without a viewport jump.
+- During live output, the rendered window stays bounded; old messages are trimmed from the top while the user follows the bottom.
+- After a rollback the conversation remains visible; no blank screen.
+
+#### Rollback/Cleanup
+- No persistent state is changed — closing or refreshing the tab resets the render window.


### PR DESCRIPTION
## Problem

All messages in a thread are rendered into the DOM at once. Long sessions with hundreds of messages cause slow initial render, high memory usage, and scroll jank. The problem also grows unboundedly during an active session as new messages keep arriving.

## Solution

Render only a fixed window of messages (`RENDER_WINDOW_SIZE = 50`) at a time, always anchored to the end of the list so live messages are always visible.

### On load / thread switch

`renderWindowStart` is set to `max(0, messages.length - 50)` so only the most recent 50 messages are rendered initially.

### During an active session

The `messages` watcher advances `renderWindowStart` whenever `autoFollowOutput` is true (user is following the bottom), keeping the rendered count bounded at 50 even as new messages stream in. When the user scrolls up, `autoFollowOutput` becomes false and trimming stops.

### Loading earlier messages

- **Automatic**: scrolling within 200 px of the top triggers loading 30 more messages.
- **Manual**: a "Load earlier messages" button appears at the top of the list when there are hidden messages above.

Scroll position is preserved across each load by saving `scrollHeight` before the render update and restoring `scrollTop += ΔscrollHeight` after `nextTick()`, so the viewport never jumps.

## Changes

`src/components/content/ThreadConversation.vue` only — no server or API changes.

- `RENDER_WINDOW_SIZE = 50`, `LOAD_MORE_CHUNK = 30`
- `renderWindowStart` ref + `visibleMessages` computed (`messages.slice(renderWindowStart)`)
- `hasMoreAbove` computed drives the "Load earlier messages" button visibility
- `loadMoreAbove()` — prepend chunk, restore scroll position
- `onConversationScroll` — auto-trigger load when near top
- `messages` watcher — trim top when following output
- `isLoading` / `activeThreadId` watchers — reset window on thread switch
- CSS for the load-more button