### PR TITLE
fix(ui): cap delete-thread dialog height at 90vh; scroll body, pin action buttons

### DIFF
--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1917,7 +1917,7 @@ onBeforeUnmount(() => {
 }
 
 .rename-thread-subtitle {
-  @apply mt-1 mb-3 text-sm text-zinc-500 overflow-y-auto flex-1 min-h-0;
+  @apply mt-1 mb-3 text-sm text-zinc-500 overflow-y-auto flex-1 min-h-0 min-w-0 break-words;
 }
 
 .rename-thread-input {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1908,23 +1908,24 @@ onBeforeUnmount(() => {
 }
 
 .rename-thread-panel {
-  @apply w-full max-w-sm rounded-xl bg-white p-4 shadow-xl;
+  @apply w-full max-w-sm rounded-xl bg-white p-4 shadow-xl
+         max-h-[90vh] flex flex-col overflow-hidden;
 }
 
 .rename-thread-title {
-  @apply m-0 text-base font-semibold text-zinc-900;
+  @apply m-0 text-base font-semibold text-zinc-900 shrink-0;
 }
 
 .rename-thread-subtitle {
-  @apply mt-1 mb-3 text-sm text-zinc-500;
+  @apply mt-1 mb-3 text-sm text-zinc-500 overflow-y-auto flex-1 min-h-0;
 }
 
 .rename-thread-input {
-  @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+  @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500 shrink-0;
 }
 
 .rename-thread-actions {
-  @apply mt-3 flex items-center justify-end gap-2;
+  @apply mt-3 flex items-center justify-end gap-2 shrink-0;
 }
 
 .rename-thread-button {

--- a/tests.md
+++ b/tests.md
@@ -1994,3 +1994,38 @@ stays at `source: "NoValues"` permanently. Feature gate `505458` (worktree) retu
 
 #### Rollback/Cleanup
 - No persistent state is changed — closing or refreshing the tab resets the render window.
+
+### Fix: Delete/rename thread dialog height cap
+
+#### Prerequisites
+- App is running from this repository.
+- At least one thread exists with a long title (can be achieved by renaming a thread to a very long string).
+
+#### Steps — Delete button visibility
+
+1. Right-click (or long-press) a thread in the sidebar to open the context menu.
+2. Click **Delete**.
+3. Verify the confirmation dialog appears and the **Delete** / **Cancel** buttons are fully visible without scrolling the page.
+4. Repeat with a thread whose title is very long (50+ characters); confirm buttons remain visible.
+5. On a small viewport (e.g. browser DevTools device emulation at 375 × 667), repeat steps 1–4 and confirm the dialog never exceeds the screen height.
+
+#### Steps — Long title wrapping
+
+6. Rename a thread to a string with no spaces (e.g. `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`).
+7. Open the Delete dialog for that thread.
+8. Verify the long title in the subtitle area wraps onto multiple lines rather than overflowing or being clipped horizontally.
+9. If the title is long enough to fill the subtitle area, verify a vertical scrollbar appears within the subtitle, and the title, input, and buttons remain visible outside the scroll area.
+
+#### Steps — Rename dialog
+
+10. Open the Rename dialog for a thread with a long title.
+11. Confirm the rename input field, title text, and **Save** / **Cancel** buttons are all fully visible.
+12. Type a very long string into the rename input and confirm it does not push the buttons off screen.
+
+#### Expected Results
+- Dialog is capped at 90 vh; action buttons are always pinned at the bottom.
+- Long unbroken thread titles wrap within the subtitle area; no horizontal clipping.
+- Vertical scrollbar appears in the subtitle region if the title exceeds available height.
+
+#### Rollback/Cleanup
+- Rename any test threads back to original names if desired.


### PR DESCRIPTION
## Problem

The delete/rename thread dialog has no maximum height constraint. On screens where the thread name is very long, the dialog grows taller than the viewport and the action buttons (Delete / Cancel) are cut off — the user cannot confirm or cancel the deletion.

## Fix

- Add `max-h-[90vh]` and `flex flex-col overflow-hidden` to `.rename-thread-panel`
- Mark `.rename-thread-title` and `.rename-thread-actions` as `shrink-0` so they always stay visible
- Make `.rename-thread-subtitle` (the thread name display) `overflow-y-auto flex-1 min-h-0` so it scrolls when the name is very long
- Add `shrink-0` to `.rename-thread-input` (rename input field) so it is never squeezed

## Affected file

- `src/components/sidebar/SidebarThreadTree.vue` (CSS class definitions)