### PR TITLE
Fix issues #42 and #44, and improve settings panel usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,18 @@ Set these environment variables before starting `codexapp`:
 
 ```bash
 export TELEGRAM_BOT_TOKEN="<your-telegram-bot-token>"
+export TELEGRAM_ALLOWED_USER_IDS="<your-telegram-user-id>,<optional-second-id>"
 export TELEGRAM_DEFAULT_CWD="$PWD" # optional, defaults to current working directory
 npx codexapp
 ```
+
+`TELEGRAM_ALLOWED_USER_IDS` is required for safe access. Only allowlisted Telegram user IDs can use the bridge. If no allowed user IDs are configured, incoming Telegram messages are rejected.
+
+To find your Telegram user ID:
+
+1. Send a message to your bot.
+2. Run `curl "https://api.telegram.org/bot<your-telegram-bot-token>/getUpdates"`.
+3. Read `message.from.id` from the returned update payload.
 
 Bot commands:
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -68,9 +68,19 @@
             @export-thread="onExportThread" />
         </div>
 
-        <div v-if="!isSidebarCollapsed" class="sidebar-settings-area">
+        <div
+          v-if="!isSidebarCollapsed"
+          ref="settingsAreaRef"
+          class="sidebar-settings-area"
+          @click="onSettingsAreaClick"
+        >
           <Transition name="settings-panel">
-            <div v-if="isSettingsOpen" class="sidebar-settings-panel">
+            <div
+              v-if="isSettingsOpen"
+              ref="settingsPanelRef"
+              class="sidebar-settings-panel"
+              @click.stop
+            >
               <div class="sidebar-settings-account-section">
                 <div class="sidebar-settings-account-header">
                   <div class="sidebar-settings-account-header-main">
@@ -195,10 +205,49 @@
                   @update:model-value="onDictationLanguageChange"
                 />
               </div>
-              <button class="sidebar-settings-row" type="button" aria-live="polite" @click="onConnectTelegramBot">
+              <button class="sidebar-settings-row" type="button" aria-live="polite" @click="isTelegramConfigOpen = !isTelegramConfigOpen">
                 <span class="sidebar-settings-label">Telegram</span>
                 <span class="sidebar-settings-value">{{ telegramStatusText }}</span>
               </button>
+              <div v-if="isTelegramConfigOpen" class="sidebar-settings-telegram-panel">
+                <label class="sidebar-settings-field">
+                  <span class="sidebar-settings-field-label">Bot token</span>
+                  <input
+                    v-model="telegramBotTokenDraft"
+                    class="sidebar-settings-input"
+                    type="password"
+                    placeholder="123456:ABCDEF"
+                    autocomplete="off"
+                    spellcheck="false"
+                  >
+                </label>
+                <label class="sidebar-settings-field">
+                  <span class="sidebar-settings-field-label">Allowed Telegram user IDs</span>
+                  <textarea
+                    v-model="telegramAllowedUserIdsDraft"
+                    class="sidebar-settings-textarea"
+                    rows="3"
+                    placeholder="123456789&#10;987654321"
+                    spellcheck="false"
+                  />
+                </label>
+                <div class="sidebar-settings-field-help">
+                  Put one Telegram user ID per line or separate them with commas. Use `*` to allow all Telegram users. Unauthorized users will see their own ID in the rejection message so they can copy it here.
+                </div>
+                <div v-if="telegramConfigError" class="sidebar-settings-telegram-error">
+                  {{ telegramConfigError }}
+                </div>
+                <div class="sidebar-settings-telegram-actions">
+                  <button
+                    class="sidebar-settings-telegram-save"
+                    type="button"
+                    :disabled="isTelegramSaving"
+                    @click="saveTelegramConfig"
+                  >
+                    {{ isTelegramSaving ? 'Saving…' : 'Save Telegram config' }}
+                  </button>
+                </div>
+              </div>
               <div
                 v-if="showThreadContextBadge"
                 class="sidebar-settings-row sidebar-settings-context-row"
@@ -219,7 +268,12 @@
               </div>
             </div>
           </Transition>
-          <button class="sidebar-settings-button" type="button" @click="isSettingsOpen = !isSettingsOpen">
+          <button
+            ref="settingsButtonRef"
+            class="sidebar-settings-button"
+            type="button"
+            @click.stop="isSettingsOpen = !isSettingsOpen"
+          >
             <IconTablerSettings class="sidebar-settings-icon" />
             <span>Settings</span>
             <span class="sidebar-settings-button-version">
@@ -592,6 +646,7 @@ import {
   getAccounts,
   createLocalDirectory,
   getHomeDirectory,
+  getTelegramConfig,
   getProjectRootSuggestion,
   getTelegramStatus,
   getWorkspaceRootsState,
@@ -839,6 +894,9 @@ const isSidebarCollapsed = ref(loadSidebarCollapsed())
 const sidebarSearchQuery = ref('')
 const isSidebarSearchVisible = ref(false)
 const sidebarSearchInputRef = ref<HTMLInputElement | null>(null)
+const settingsAreaRef = ref<HTMLElement | null>(null)
+const settingsPanelRef = ref<HTMLElement | null>(null)
+const settingsButtonRef = ref<HTMLElement | null>(null)
 const serverMatchedThreadIds = ref<string[] | null>(null)
 let threadSearchTimer: ReturnType<typeof setTimeout> | null = null
 const defaultNewProjectName = ref('New Project (1)')
@@ -878,6 +936,11 @@ const dictationLanguage = ref(loadDictationLanguagePref())
 const dictationLanguageOptions = computed(() => buildDictationLanguageOptions())
 
 const showGithubTrendingProjects = ref(loadBoolPref(GITHUB_TRENDING_PROJECTS_KEY, false))
+const isTelegramConfigOpen = ref(false)
+const telegramBotTokenDraft = ref('')
+const telegramAllowedUserIdsDraft = ref('')
+const telegramConfigError = ref('')
+const isTelegramSaving = ref(false)
 const isCreateFolderOpen = ref(false)
 const createFolderDraft = ref('')
 const createFolderError = ref('')
@@ -897,6 +960,7 @@ const telegramStatus = ref<TelegramStatus>({
   mappedChats: 0,
   mappedThreads: 0,
   allowedUsers: 0,
+  allowAllUsers: false,
   lastError: '',
 })
 const mobileHiddenAtMs = ref<number | null>(null)
@@ -1165,12 +1229,16 @@ const contentStyle = computed(() => {
 const telegramStatusText = computed(() => {
   if (!telegramStatus.value.configured) return 'Not configured'
   const base = telegramStatus.value.active ? 'Online' : 'Configured (offline)'
-  const mapped = `${telegramStatus.value.mappedChats} chat(s), ${telegramStatus.value.mappedThreads} thread(s), ${telegramStatus.value.allowedUsers} allowed user(s)`
+  const allowlist = telegramStatus.value.allowAllUsers
+    ? 'allow all users'
+    : `${telegramStatus.value.allowedUsers} allowed user(s)`
+  const mapped = `${telegramStatus.value.mappedChats} chat(s), ${telegramStatus.value.mappedThreads} thread(s), ${allowlist}`
   const error = telegramStatus.value.lastError ? `, error: ${telegramStatus.value.lastError}` : ''
   return `${base}, ${mapped}${error}`
 })
 
 onMounted(() => {
+  document.addEventListener('pointerdown', onDocumentPointerDown)
   window.addEventListener('keydown', onWindowKeyDown)
   document.addEventListener('visibilitychange', onDocumentVisibilityChange)
   window.addEventListener('pageshow', onWindowPageShow)
@@ -1181,6 +1249,7 @@ onMounted(() => {
   void loadHomeDirectory()
   void loadWorkspaceRootOptionsState()
   void refreshDefaultProjectName()
+  void refreshTelegramConfig()
   void refreshTelegramStatus()
   if (showGithubTrendingProjects.value) {
     void loadTrendingProjects()
@@ -1188,6 +1257,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  document.removeEventListener('pointerdown', onDocumentPointerDown)
   window.removeEventListener('keydown', onWindowKeyDown)
   document.removeEventListener('visibilitychange', onDocumentVisibilityChange)
   window.removeEventListener('pageshow', onWindowPageShow)
@@ -1263,8 +1333,62 @@ async function refreshTelegramStatus(): Promise<void> {
       mappedChats: 0,
       mappedThreads: 0,
       allowedUsers: 0,
+      allowAllUsers: false,
       lastError: message,
     }
+  }
+}
+
+async function refreshTelegramConfig(): Promise<void> {
+  try {
+    const config = await getTelegramConfig()
+    telegramBotTokenDraft.value = config.botToken
+    telegramAllowedUserIdsDraft.value = config.allowedUserIds.map((value) => String(value)).join('\n')
+    telegramConfigError.value = ''
+  } catch (error) {
+    telegramConfigError.value = error instanceof Error ? error.message : 'Failed to load Telegram configuration'
+  }
+}
+
+function parseTelegramAllowedUserIdsInput(value: string): Array<number | '*'> {
+  const rawEntries = value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim().replace(/^(telegram|tg):/i, '').trim())
+    .filter(Boolean)
+  const allowAllUsers = rawEntries.includes('*')
+  const normalizedUserIds = Array.from(new Set(rawEntries
+    .filter((entry) => /^-?\d+$/.test(entry))
+    .map((entry) => Number.parseInt(entry, 10))))
+  return allowAllUsers ? ['*', ...normalizedUserIds] : normalizedUserIds
+}
+
+async function saveTelegramConfig(): Promise<void> {
+  const botToken = telegramBotTokenDraft.value.trim()
+  const allowedUserIds = parseTelegramAllowedUserIdsInput(telegramAllowedUserIdsDraft.value)
+  if (!botToken) {
+    telegramConfigError.value = 'Telegram bot token is required.'
+    return
+  }
+  if (allowedUserIds.length === 0) {
+    telegramConfigError.value = 'At least one allowed Telegram user ID or * is required.'
+    return
+  }
+
+  isTelegramSaving.value = true
+  telegramConfigError.value = ''
+  try {
+    await configureTelegramBot(botToken, allowedUserIds)
+    telegramAllowedUserIdsDraft.value = allowedUserIds.map((value) => String(value)).join('\n')
+    await Promise.all([
+      refreshTelegramConfig(),
+      refreshTelegramStatus(),
+    ])
+    window.alert('Telegram bot configured. Only allowlisted Telegram users can use the bridge.')
+  } catch (error) {
+    telegramConfigError.value = error instanceof Error ? error.message : 'Failed to connect Telegram bot'
+    void refreshTelegramStatus()
+  } finally {
+    isTelegramSaving.value = false
   }
 }
 
@@ -1658,11 +1782,33 @@ function setSidebarCollapsed(nextValue: boolean): void {
 
 function onWindowKeyDown(event: KeyboardEvent): void {
   if (event.defaultPrevented) return
+  if (event.key === 'Escape' && isSettingsOpen.value) {
+    isSettingsOpen.value = false
+    return
+  }
   if (!event.ctrlKey && !event.metaKey) return
   if (event.shiftKey || event.altKey) return
   if (event.key.toLowerCase() !== 'b') return
   event.preventDefault()
   setSidebarCollapsed(!isSidebarCollapsed.value)
+}
+
+function onDocumentPointerDown(event: PointerEvent): void {
+  if (!isSettingsOpen.value) return
+  const target = event.target
+  if (!(target instanceof Node)) return
+  if (settingsPanelRef.value?.contains(target)) return
+  if (settingsButtonRef.value?.contains(target)) return
+  isSettingsOpen.value = false
+}
+
+function onSettingsAreaClick(event: MouseEvent): void {
+  if (!isSettingsOpen.value) return
+  const target = event.target
+  if (!(target instanceof Node)) return
+  if (settingsPanelRef.value?.contains(target)) return
+  if (settingsButtonRef.value?.contains(target)) return
+  isSettingsOpen.value = false
 }
 
 function onDocumentVisibilityChange(): void {
@@ -1757,37 +1903,6 @@ function onGithubTipsScopeChange(nextValue: string): void {
   const scope = allowed.has(nextValue as GithubTipsScope) ? (nextValue as GithubTipsScope) : 'trending-daily'
   if (githubTipsScope.value === scope) return
   githubTipsScope.value = scope
-}
-
-function onConnectTelegramBot(): void {
-  if (typeof window === 'undefined') return
-  const botToken = window.prompt('Telegram bot token')
-  if (!botToken || !botToken.trim()) return
-  const allowedUserIdsInput = window.prompt('Allowed Telegram user IDs (comma-separated)')
-  if (!allowedUserIdsInput || !allowedUserIdsInput.trim()) {
-    window.alert('At least one Telegram user ID is required.')
-    return
-  }
-  const allowedUserIds = Array.from(new Set(allowedUserIdsInput
-    .split(',')
-    .map((value) => value.trim().replace(/^(telegram|tg):/i, '').trim())
-    .filter((value) => /^-?\d+$/.test(value))
-    .map((value) => Number.parseInt(value, 10))))
-  if (allowedUserIds.length === 0) {
-    window.alert('No valid Telegram user IDs were provided.')
-    return
-  }
-
-  void configureTelegramBot(botToken.trim(), allowedUserIds)
-    .then(() => {
-      window.alert('Telegram bot configured. Only allowlisted Telegram users can use the bridge.')
-      void refreshTelegramStatus()
-    })
-    .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : 'Failed to connect Telegram bot'
-      window.alert(message)
-      void refreshTelegramStatus()
-    })
 }
 
 function onSelectTrendingProjectTip(project: GithubTrendingProject): void {
@@ -3241,7 +3356,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-panel {
-  @apply mb-1 rounded-lg border border-zinc-200 bg-white overflow-hidden;
+  @apply mb-1 max-h-[min(70vh,36rem)] overflow-y-auto rounded-lg border border-zinc-200 bg-white;
 }
 
 .sidebar-settings-row {
@@ -3266,6 +3381,47 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .sidebar-settings-row + .sidebar-settings-row {
   @apply border-t border-zinc-100;
+}
+
+.sidebar-settings-telegram-panel {
+  @apply border-t border-zinc-100 bg-zinc-50/70 px-3 py-3;
+}
+
+.sidebar-settings-field {
+  @apply flex flex-col gap-1.5;
+}
+
+.sidebar-settings-field + .sidebar-settings-field {
+  @apply mt-3;
+}
+
+.sidebar-settings-field-label {
+  @apply text-xs font-medium text-zinc-700;
+}
+
+.sidebar-settings-input,
+.sidebar-settings-textarea {
+  @apply w-full rounded-md border border-zinc-200 bg-white px-2.5 py-2 text-sm text-zinc-800 outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200;
+}
+
+.sidebar-settings-textarea {
+  @apply min-h-20 resize-y font-mono text-xs;
+}
+
+.sidebar-settings-field-help {
+  @apply mt-2 text-xs leading-5 text-zinc-500;
+}
+
+.sidebar-settings-telegram-error {
+  @apply mt-2 rounded-md bg-rose-50 px-2.5 py-2 text-xs text-rose-700;
+}
+
+.sidebar-settings-telegram-actions {
+  @apply mt-3 flex items-center justify-end;
+}
+
+.sidebar-settings-telegram-save {
+  @apply rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-default disabled:opacity-60;
 }
 
 .sidebar-settings-account-section {

--- a/src/App.vue
+++ b/src/App.vue
@@ -539,6 +539,7 @@
                   :thread-token-usage="selectedThreadTokenUsage"
                   :codex-quota="codexQuota"
                   :is-turn-in-progress="false"
+                  :is-stop-pending="false"
                   :is-interrupting-turn="false" :send-with-enter="sendWithEnter" :in-progress-submit-mode="inProgressSendMode"
                   :dictation-click-to-toggle="dictationClickToToggle" :dictation-auto-send="dictationAutoSend"
                   :dictation-language="dictationLanguage"
@@ -598,7 +599,9 @@
                     :skills="installedSkills"
                     :thread-token-usage="selectedThreadTokenUsage"
                     :codex-quota="codexQuota"
-                    :is-turn-in-progress="isSelectedThreadInProgress" :is-interrupting-turn="isInterruptingTurn"
+                    :is-turn-in-progress="isSelectedThreadInProgress"
+                    :is-stop-pending="isSelectedThreadInterruptPending"
+                    :is-interrupting-turn="isInterruptingTurn"
                     :has-queue-above="selectedThreadQueuedMessages.length > 0"
                     :send-with-enter="sendWithEnter" :in-progress-submit-mode="inProgressSendMode"
                     :dictation-click-to-toggle="dictationClickToToggle" :dictation-auto-send="dictationAutoSend"
@@ -834,6 +837,7 @@ const {
   isLoadingMessages,
   isSendingMessage,
   isInterruptingTurn,
+  isSelectedThreadInterruptPending,
   isUpdatingSpeedMode,
   refreshAll,
   refreshSkills,

--- a/src/App.vue
+++ b/src/App.vue
@@ -896,6 +896,7 @@ const telegramStatus = ref<TelegramStatus>({
   active: false,
   mappedChats: 0,
   mappedThreads: 0,
+  allowedUsers: 0,
   lastError: '',
 })
 const mobileHiddenAtMs = ref<number | null>(null)
@@ -1164,7 +1165,7 @@ const contentStyle = computed(() => {
 const telegramStatusText = computed(() => {
   if (!telegramStatus.value.configured) return 'Not configured'
   const base = telegramStatus.value.active ? 'Online' : 'Configured (offline)'
-  const mapped = `${telegramStatus.value.mappedChats} chat(s), ${telegramStatus.value.mappedThreads} thread(s)`
+  const mapped = `${telegramStatus.value.mappedChats} chat(s), ${telegramStatus.value.mappedThreads} thread(s), ${telegramStatus.value.allowedUsers} allowed user(s)`
   const error = telegramStatus.value.lastError ? `, error: ${telegramStatus.value.lastError}` : ''
   return `${base}, ${mapped}${error}`
 })
@@ -1261,6 +1262,7 @@ async function refreshTelegramStatus(): Promise<void> {
       active: false,
       mappedChats: 0,
       mappedThreads: 0,
+      allowedUsers: 0,
       lastError: message,
     }
   }
@@ -1761,10 +1763,24 @@ function onConnectTelegramBot(): void {
   if (typeof window === 'undefined') return
   const botToken = window.prompt('Telegram bot token')
   if (!botToken || !botToken.trim()) return
+  const allowedUserIdsInput = window.prompt('Allowed Telegram user IDs (comma-separated)')
+  if (!allowedUserIdsInput || !allowedUserIdsInput.trim()) {
+    window.alert('At least one Telegram user ID is required.')
+    return
+  }
+  const allowedUserIds = Array.from(new Set(allowedUserIdsInput
+    .split(',')
+    .map((value) => value.trim().replace(/^(telegram|tg):/i, '').trim())
+    .filter((value) => /^-?\d+$/.test(value))
+    .map((value) => Number.parseInt(value, 10))))
+  if (allowedUserIds.length === 0) {
+    window.alert('No valid Telegram user IDs were provided.')
+    return
+  }
 
-  void configureTelegramBot(botToken.trim())
+  void configureTelegramBot(botToken.trim(), allowedUserIds)
     .then(() => {
-      window.alert('Telegram bot configured. Open the bot DM and send /start.')
+      window.alert('Telegram bot configured. Only allowlisted Telegram users can use the bridge.')
       void refreshTelegramStatus()
     })
     .catch((error: unknown) => {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -122,7 +122,13 @@ export type TelegramStatus = {
   mappedChats: number
   mappedThreads: number
   allowedUsers: number
+  allowAllUsers: boolean
   lastError: string
+}
+
+export type TelegramConfig = {
+  botToken: string
+  allowedUserIds: Array<number | '*'>
 }
 
 export type GithubTrendingProject = {
@@ -1737,7 +1743,7 @@ export async function searchThreads(
 
 export async function configureTelegramBot(
   botToken: string,
-  allowedUserIds: number[],
+  allowedUserIds: Array<number | '*'>,
 ): Promise<void> {
   const response = await fetch('/codex-api/telegram/configure-bot', {
     method: 'POST',
@@ -1751,6 +1757,38 @@ export async function configureTelegramBot(
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to connect Telegram bot')
     throw new Error(message)
+  }
+}
+
+export async function getTelegramConfig(): Promise<TelegramConfig> {
+  const response = await fetch('/codex-api/telegram/config')
+  const payload = await response.json()
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to load Telegram configuration')
+    throw new Error(message)
+  }
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  const rawAllowedUserIds = Array.isArray(data.allowedUserIds) ? data.allowedUserIds : []
+  const allowedUserIds: Array<number | '*'> = []
+  for (const value of rawAllowedUserIds) {
+    if (value === '*') {
+      allowedUserIds.push('*')
+      continue
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      allowedUserIds.push(Math.trunc(value))
+    }
+  }
+  return {
+    botToken: typeof data.botToken === 'string' ? data.botToken : '',
+    allowedUserIds,
   }
 }
 
@@ -1775,6 +1813,7 @@ export async function getTelegramStatus(): Promise<TelegramStatus> {
     mappedChats: typeof data.mappedChats === 'number' ? data.mappedChats : 0,
     mappedThreads: typeof data.mappedThreads === 'number' ? data.mappedThreads : 0,
     allowedUsers: typeof data.allowedUsers === 'number' ? data.allowedUsers : 0,
+    allowAllUsers: data.allowAllUsers === true,
     lastError: typeof data.lastError === 'string' ? data.lastError : '',
   }
 }

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -121,6 +121,7 @@ export type TelegramStatus = {
   active: boolean
   mappedChats: number
   mappedThreads: number
+  allowedUsers: number
   lastError: string
 }
 
@@ -1736,12 +1737,14 @@ export async function searchThreads(
 
 export async function configureTelegramBot(
   botToken: string,
+  allowedUserIds: number[],
 ): Promise<void> {
   const response = await fetch('/codex-api/telegram/configure-bot', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       botToken,
+      allowedUserIds,
     }),
   })
   const payload = await response.json()
@@ -1771,6 +1774,7 @@ export async function getTelegramStatus(): Promise<TelegramStatus> {
     active: data.active === true,
     mappedChats: typeof data.mappedChats === 'number' ? data.mappedChats : 0,
     mappedThreads: typeof data.mappedThreads === 'number' ? data.mappedThreads : 0,
+    allowedUsers: typeof data.allowedUsers === 'number' ? data.allowedUsers : 0,
     lastError: typeof data.lastError === 'string' ? data.lastError : '',
   }
 }

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -313,11 +313,13 @@
             v-if="isTurnInProgress && !hasSubmitContent"
             class="thread-composer-stop"
             type="button"
-            aria-label="Stop"
-            :disabled="disabled || !activeThreadId || isInterruptingTurn"
+            :aria-label="isStopPending ? 'Saving thread before stop is available' : 'Stop'"
+            :title="isStopPending ? 'Saving thread before stop is available' : 'Stop'"
+            :disabled="disabled || !activeThreadId || isInterruptingTurn || isStopPending"
             @click="onInterrupt"
           >
-            <IconTablerPlayerStopFilled class="thread-composer-stop-icon" />
+            <span v-if="isStopPending" class="thread-composer-stop-spinner" aria-hidden="true" />
+            <IconTablerPlayerStopFilled v-else class="thread-composer-stop-icon" />
           </button>
           <button
             v-else
@@ -405,6 +407,7 @@ const props = defineProps<{
   threadTokenUsage?: UiThreadTokenUsage | null
   codexQuota?: UiRateLimitSnapshot | null
   isTurnInProgress?: boolean
+  isStopPending?: boolean
   isInterruptingTurn?: boolean
   isUpdatingSpeedMode?: boolean
   disabled?: boolean
@@ -2142,6 +2145,10 @@ watch(
 
 .thread-composer-stop-icon {
   @apply h-5 w-5;
+}
+
+.thread-composer-stop-spinner {
+  @apply h-5 w-5 rounded-full border-2 border-current border-t-transparent animate-spin;
 }
 
 .thread-composer-hidden-input {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1008,6 +1008,9 @@ export function useDesktopState() {
   const turnActivityByThreadId = ref<Record<string, TurnActivityState>>({})
   const turnErrorByThreadId = ref<Record<string, TurnErrorState>>({})
   const activeTurnIdByThreadId = ref<Record<string, string>>({})
+  const interruptBlockedUntilPersistedByThreadId = ref<Record<string, boolean>>({})
+  const threadListedByServerById = ref<Record<string, boolean>>({})
+  const persistedUserMessageByThreadId = ref<Record<string, boolean>>({})
   const pendingServerRequestsByThreadId = ref<Record<string, UiServerRequest[]>>({})
   const pendingTurnRequestByThreadId = ref<Record<string, PendingTurnRequest>>({})
   const codexRateLimit = ref<UiRateLimitSnapshot | null>(null)
@@ -1049,6 +1052,11 @@ export function useDesktopState() {
   const selectedThreadScrollState = computed<ThreadScrollState | null>(
     () => scrollStateByThreadId.value[selectedThreadId.value] ?? null,
   )
+  const isSelectedThreadInterruptPending = computed(() => {
+    const threadId = selectedThreadId.value
+    if (!threadId) return false
+    return interruptBlockedUntilPersistedByThreadId.value[threadId] === true
+  })
   const selectedThreadServerRequests = computed<UiServerRequest[]>(() => {
     const rows: UiServerRequest[] = []
     const selected = selectedThreadId.value
@@ -1588,6 +1596,12 @@ export function useDesktopState() {
     turnActivityByThreadId.value = pruneThreadStateMap(turnActivityByThreadId.value, activeThreadIds)
     turnErrorByThreadId.value = pruneThreadStateMap(turnErrorByThreadId.value, activeThreadIds)
     activeTurnIdByThreadId.value = pruneThreadStateMap(activeTurnIdByThreadId.value, activeThreadIds)
+    interruptBlockedUntilPersistedByThreadId.value = pruneThreadStateMap(
+      interruptBlockedUntilPersistedByThreadId.value,
+      activeThreadIds,
+    )
+    threadListedByServerById.value = pruneThreadStateMap(threadListedByServerById.value, activeThreadIds)
+    persistedUserMessageByThreadId.value = pruneThreadStateMap(persistedUserMessageByThreadId.value, activeThreadIds)
     threadTokenUsageByThreadId.value = pruneThreadStateMap(threadTokenUsageByThreadId.value, activeThreadIds)
     eventUnreadByThreadId.value = pruneThreadStateMap(eventUnreadByThreadId.value, activeThreadIds)
     inProgressById.value = pruneThreadStateMap(inProgressById.value, activeThreadIds)
@@ -1643,8 +1657,79 @@ export function useDesktopState() {
       }
     } else {
       inProgressById.value = omitKey(inProgressById.value, threadId)
+      clearInterruptPersistenceGate(threadId)
     }
     applyThreadFlags()
+  }
+
+  function clearInterruptPersistenceGate(threadId: string): void {
+    if (!threadId) return
+    if (interruptBlockedUntilPersistedByThreadId.value[threadId]) {
+      interruptBlockedUntilPersistedByThreadId.value = omitKey(interruptBlockedUntilPersistedByThreadId.value, threadId)
+    }
+    if (threadListedByServerById.value[threadId]) {
+      threadListedByServerById.value = omitKey(threadListedByServerById.value, threadId)
+    }
+    if (persistedUserMessageByThreadId.value[threadId]) {
+      persistedUserMessageByThreadId.value = omitKey(persistedUserMessageByThreadId.value, threadId)
+    }
+  }
+
+  function blockInterruptUntilThreadIsPersisted(threadId: string): void {
+    if (!threadId) return
+    interruptBlockedUntilPersistedByThreadId.value = {
+      ...interruptBlockedUntilPersistedByThreadId.value,
+      [threadId]: true,
+    }
+    if (threadListedByServerById.value[threadId]) {
+      threadListedByServerById.value = omitKey(threadListedByServerById.value, threadId)
+    }
+    if (persistedUserMessageByThreadId.value[threadId]) {
+      persistedUserMessageByThreadId.value = omitKey(persistedUserMessageByThreadId.value, threadId)
+    }
+  }
+
+  function maybeUnblockInterruptForPersistedThread(threadId: string): void {
+    if (!threadId) return
+    if (interruptBlockedUntilPersistedByThreadId.value[threadId] !== true) return
+    if (threadListedByServerById.value[threadId] !== true) return
+    if (persistedUserMessageByThreadId.value[threadId] !== true) return
+    clearInterruptPersistenceGate(threadId)
+  }
+
+  function markServerListedThreads(serverThreadIds: Set<string>): void {
+    const pendingThreadIds = Object.keys(interruptBlockedUntilPersistedByThreadId.value)
+    if (pendingThreadIds.length === 0) return
+
+    let nextListedState = threadListedByServerById.value
+    let changed = false
+    for (const threadId of pendingThreadIds) {
+      if (!serverThreadIds.has(threadId) || nextListedState[threadId] === true) continue
+      nextListedState = {
+        ...nextListedState,
+        [threadId]: true,
+      }
+      changed = true
+    }
+
+    if (!changed) return
+    threadListedByServerById.value = nextListedState
+    for (const threadId of pendingThreadIds) {
+      maybeUnblockInterruptForPersistedThread(threadId)
+    }
+  }
+
+  function markThreadMessagesPersisted(threadId: string, messages: UiMessage[]): void {
+    if (!threadId) return
+    if (interruptBlockedUntilPersistedByThreadId.value[threadId] !== true) return
+    if (!messages.some((message) => message.role === 'user')) return
+    if (persistedUserMessageByThreadId.value[threadId] !== true) {
+      persistedUserMessageByThreadId.value = {
+        ...persistedUserMessageByThreadId.value,
+        [threadId]: true,
+      }
+    }
+    maybeUnblockInterruptForPersistedThread(threadId)
   }
 
   function markThreadUnreadByEvent(threadId: string): void {
@@ -3266,6 +3351,7 @@ export function useDesktopState() {
       }
 
       const orderedGroups = orderGroupsByProjectOrder(visibleGroups, projectOrder.value)
+      markServerListedThreads(new Set(flattenThreads(orderedGroups).map((thread) => thread.id)))
       const mergedWithInProgress = mergeIncomingWithLocalInProgressThreads(
         sourceGroups.value,
         orderedGroups,
@@ -3319,6 +3405,7 @@ export function useDesktopState() {
       }
 
       const { messages: nextMessages, inProgress, activeTurnId, turnIndexByTurnId } = detail
+      markThreadMessagesPersisted(threadId, nextMessages)
       replaceTurnIndexLookupForThread(threadId, turnIndexByTurnId)
       rebindLiveFileChangeTurnIndices(threadId)
       const previousPersisted = persistedMessagesByThreadId.value[threadId] ?? []
@@ -3712,6 +3799,7 @@ export function useDesktopState() {
       if (!threadId) return ''
 
       insertOptimisticThread(threadId, targetCwd, nextText || '[Image]')
+      blockInterruptUntilThreadIsPersisted(threadId)
       resumedThreadById.value = {
         ...resumedThreadById.value,
         [threadId]: true,
@@ -3901,6 +3989,7 @@ export function useDesktopState() {
     const threadId = selectedThreadId.value
     if (!threadId) return
     if (inProgressById.value[threadId] !== true) return
+    if (interruptBlockedUntilPersistedByThreadId.value[threadId] === true) return
     let turnId = activeTurnIdByThreadId.value[threadId]
     if (!turnId) {
       const { activeTurnId } = await getThreadDetail(threadId)
@@ -4347,6 +4436,9 @@ export function useDesktopState() {
     turnSummaryByThreadId.value = {}
     turnErrorByThreadId.value = {}
     activeTurnIdByThreadId.value = {}
+    interruptBlockedUntilPersistedByThreadId.value = {}
+    threadListedByServerById.value = {}
+    persistedUserMessageByThreadId.value = {}
     queuedMessagesByThreadId.value = {}
     queueProcessingByThreadId.value = {}
     codexRateLimit.value = null
@@ -4392,6 +4484,7 @@ export function useDesktopState() {
     selectedThread,
     selectedThreadTokenUsage,
     selectedThreadScrollState,
+    isSelectedThreadInterruptPending,
     selectedThreadServerRequests,
     selectedLiveOverlay,
     codexQuota,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1623,7 +1623,7 @@ let sessionIndexThreadTitleCacheState: SessionIndexThreadTitleCacheState = {
 type TelegramBridgeConfigState = {
   botToken: string
   chatIds: number[]
-  allowedUserIds: number[]
+  allowedUserIds: Array<number | '*'>
 }
 
 function normalizeThreadTitleCache(value: unknown): ThreadTitleCache {
@@ -1885,7 +1885,8 @@ function normalizeTelegramBridgeConfig(value: unknown): TelegramBridgeConfigStat
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
     .map((value) => Math.trunc(value)))).slice(0, 50)
   const rawAllowedUserIds = Array.isArray(record.allowedUserIds) ? record.allowedUserIds : []
-  const allowedUserIds = Array.from(new Set(rawAllowedUserIds
+  const allowAllUsers = rawAllowedUserIds.some((value) => typeof value === 'string' && value.trim() === '*')
+  const normalizedAllowedUserIds = Array.from(new Set(rawAllowedUserIds
     .map((value) => {
       if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value)
       if (typeof value === 'string') {
@@ -1897,6 +1898,9 @@ function normalizeTelegramBridgeConfig(value: unknown): TelegramBridgeConfigStat
       return Number.NaN
     })
     .filter((value) => Number.isFinite(value)))).slice(0, 100)
+  const allowedUserIds: Array<number | '*'> = allowAllUsers
+    ? ['*' as const, ...normalizedAllowedUserIds]
+    : normalizedAllowedUserIds
   return { botToken, chatIds, allowedUserIds }
 }
 
@@ -3678,6 +3682,17 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           allowedUserIds: config.allowedUserIds,
         })
         setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/telegram/config') {
+        const config = await readTelegramBridgeConfig()
+        setJson(res, 200, {
+          data: {
+            botToken: config.botToken,
+            allowedUserIds: config.allowedUserIds,
+          },
+        })
         return
       }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1623,6 +1623,7 @@ let sessionIndexThreadTitleCacheState: SessionIndexThreadTitleCacheState = {
 type TelegramBridgeConfigState = {
   botToken: string
   chatIds: number[]
+  allowedUserIds: number[]
 }
 
 function normalizeThreadTitleCache(value: unknown): ThreadTitleCache {
@@ -1877,13 +1878,26 @@ async function writeWorkspaceRootsState(nextState: WorkspaceRootsState): Promise
 
 function normalizeTelegramBridgeConfig(value: unknown): TelegramBridgeConfigState {
   const record = asRecord(value)
-  if (!record) return { botToken: '', chatIds: [] }
+  if (!record) return { botToken: '', chatIds: [], allowedUserIds: [] }
   const botToken = typeof record.botToken === 'string' ? record.botToken.trim() : ''
   const rawChatIds = Array.isArray(record.chatIds) ? record.chatIds : []
   const chatIds = Array.from(new Set(rawChatIds
     .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
     .map((value) => Math.trunc(value)))).slice(0, 50)
-  return { botToken, chatIds }
+  const rawAllowedUserIds = Array.isArray(record.allowedUserIds) ? record.allowedUserIds : []
+  const allowedUserIds = Array.from(new Set(rawAllowedUserIds
+    .map((value) => {
+      if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value)
+      if (typeof value === 'string') {
+        const normalized = value.trim().replace(/^(telegram|tg):/i, '').trim()
+        if (/^-?\d+$/.test(normalized)) {
+          return Number.parseInt(normalized, 10)
+        }
+      }
+      return Number.NaN
+    })
+    .filter((value) => Number.isFinite(value)))).slice(0, 100)
+  return { botToken, chatIds, allowedUserIds }
 }
 
 async function readTelegramBridgeConfig(): Promise<TelegramBridgeConfigState> {
@@ -1893,7 +1907,7 @@ async function readTelegramBridgeConfig(): Promise<TelegramBridgeConfigState> {
     const payload = asRecord(JSON.parse(raw)) ?? {}
     return normalizeTelegramBridgeConfig(payload)
   } catch {
-    return { botToken: '', chatIds: [] }
+    return { botToken: '', chatIds: [], allowedUserIds: [] }
   }
 }
 
@@ -1903,6 +1917,7 @@ async function writeTelegramBridgeConfig(nextState: TelegramBridgeConfigState): 
   await writeFile(telegramConfigPath, JSON.stringify({
     botToken: normalized.botToken,
     chatIds: normalized.chatIds,
+    allowedUserIds: normalized.allowedUserIds,
   }), 'utf8')
 }
 
@@ -2830,6 +2845,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
     .then((config) => {
       if (!config.botToken) return
       telegramBridge.configureToken(config.botToken)
+      telegramBridge.configureAllowedUserIds(config.allowedUserIds)
       telegramBridge.start()
     })
     .catch(() => {})
@@ -3638,17 +3654,28 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       if (req.method === 'POST' && url.pathname === '/codex-api/telegram/configure-bot') {
         const payload = asRecord(await readJsonBody(req))
         const botToken = typeof payload?.botToken === 'string' ? payload.botToken.trim() : ''
+        const rawAllowedUserIds = Array.isArray(payload?.allowedUserIds) ? payload.allowedUserIds : []
         if (!botToken) {
           setJson(res, 400, { error: 'Missing botToken' })
           return
         }
+        const config = normalizeTelegramBridgeConfig({
+          botToken,
+          allowedUserIds: rawAllowedUserIds,
+        })
+        if (config.allowedUserIds.length === 0) {
+          setJson(res, 400, { error: 'At least one allowed Telegram user ID is required' })
+          return
+        }
 
-        telegramBridge.configureToken(botToken)
+        telegramBridge.configureToken(config.botToken)
+        telegramBridge.configureAllowedUserIds(config.allowedUserIds)
         telegramBridge.start()
         const existingConfig = await readTelegramBridgeConfig()
         await writeTelegramBridgeConfig({
-          botToken,
+          botToken: config.botToken,
           chatIds: existingConfig.chatIds,
+          allowedUserIds: config.allowedUserIds,
         })
         setJson(res, 200, { ok: true })
         return

--- a/src/server/telegramThreadBridge.ts
+++ b/src/server/telegramThreadBridge.ts
@@ -5,6 +5,9 @@ type TelegramUpdate = {
   message?: {
     message_id?: number
     text?: string
+    from?: {
+      id?: number
+    }
     chat?: {
       id?: number
     }
@@ -12,6 +15,9 @@ type TelegramUpdate = {
   callback_query?: {
     id?: string
     data?: string
+    from?: {
+      id?: number
+    }
     message?: {
       chat?: {
         id?: number
@@ -34,6 +40,7 @@ export type TelegramBridgeStatus = {
   active: boolean
   mappedChats: number
   mappedThreads: number
+  allowedUsers: number
   lastError: string
 }
 
@@ -62,10 +69,29 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback
 }
 
+function normalizeTelegramUserIds(values: unknown): number[] {
+  const rawValues = Array.isArray(values) ? values : []
+  return Array.from(new Set(rawValues
+    .map((value) => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value)
+      }
+      if (typeof value === 'string' && value.trim().length > 0) {
+        const normalized = value.trim().replace(/^(telegram|tg):/i, '').trim()
+        if (/^-?\d+$/.test(normalized)) {
+          return Number.parseInt(normalized, 10)
+        }
+      }
+      return Number.NaN
+    })
+    .filter((value) => Number.isFinite(value)))).slice(0, 100)
+}
+
 export class TelegramThreadBridge {
   private token: string
   private readonly appServer: AppServerLike
   private readonly defaultCwd: string
+  private allowedUserIds = new Set<number>()
   private readonly threadIdByChatId = new Map<number, string>()
   private readonly chatIdsByThreadId = new Map<string, Set<number>>()
   private readonly lastForwardedTurnByThreadId = new Map<string, string>()
@@ -79,6 +105,12 @@ export class TelegramThreadBridge {
     this.appServer = appServer
     this.token = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? ''
     this.defaultCwd = process.env.TELEGRAM_DEFAULT_CWD?.trim() ?? process.cwd()
+    this.allowedUserIds = new Set(normalizeTelegramUserIds(
+      (process.env.TELEGRAM_ALLOWED_USER_IDS ?? '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ))
     this.onChatSeen = options.onChatSeen
   }
 
@@ -151,8 +183,13 @@ export class TelegramThreadBridge {
       active: this.active,
       mappedChats: this.threadIdByChatId.size,
       mappedThreads: this.chatIdsByThreadId.size,
+      allowedUsers: this.allowedUserIds.size,
       lastError: this.lastError,
     }
+  }
+
+  configureAllowedUserIds(allowedUserIds: unknown): void {
+    this.allowedUserIds = new Set(normalizeTelegramUserIds(allowedUserIds))
   }
 
   connectThread(threadId: string, chatId: number, token?: string): void {
@@ -217,8 +254,13 @@ export class TelegramThreadBridge {
 
     const message = update.message
     const chatId = message?.chat?.id
+    const senderId = message?.from?.id
     const text = message?.text?.trim()
     if (typeof chatId !== 'number' || !text) return
+    if (!this.isAllowedSender(senderId)) {
+      await this.sendTelegramMessage(chatId, this.unauthorizedMessage())
+      return
+    }
     this.markChatSeen(chatId)
 
     if (text === '/start') {
@@ -256,6 +298,16 @@ export class TelegramThreadBridge {
     const callbackId = typeof callbackQuery.id === 'string' ? callbackQuery.id : ''
     const data = typeof callbackQuery.data === 'string' ? callbackQuery.data : ''
     const chatId = callbackQuery.message?.chat?.id
+    const senderId = callbackQuery.from?.id
+    if (!this.isAllowedSender(senderId)) {
+      if (callbackId) {
+        await this.answerCallbackQuery(callbackId, 'Unauthorized sender')
+      }
+      if (typeof chatId === 'number') {
+        await this.sendTelegramMessage(chatId, this.unauthorizedMessage())
+      }
+      return
+    }
     if (typeof chatId === 'number') {
       this.markChatSeen(chatId)
     }
@@ -279,6 +331,16 @@ export class TelegramThreadBridge {
     if (history) {
       await this.sendTelegramMessage(chatId, history)
     }
+  }
+
+  private isAllowedSender(senderId: unknown): senderId is number {
+    return typeof senderId === 'number'
+      && Number.isFinite(senderId)
+      && this.allowedUserIds.has(Math.trunc(senderId))
+  }
+
+  private unauthorizedMessage(): string {
+    return 'Unauthorized sender. Add this Telegram user ID to the bot allowlist before using the bridge.'
   }
 
   private async answerCallbackQuery(callbackQueryId: string, text: string): Promise<void> {

--- a/src/server/telegramThreadBridge.ts
+++ b/src/server/telegramThreadBridge.ts
@@ -41,6 +41,7 @@ export type TelegramBridgeStatus = {
   mappedChats: number
   mappedThreads: number
   allowedUsers: number
+  allowAllUsers: boolean
   lastError: string
 }
 
@@ -69,9 +70,15 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback
 }
 
-function normalizeTelegramUserIds(values: unknown): number[] {
+type NormalizedTelegramAllowlist = {
+  allowAllUsers: boolean
+  allowedUserIds: number[]
+}
+
+function normalizeTelegramAllowlist(values: unknown): NormalizedTelegramAllowlist {
   const rawValues = Array.isArray(values) ? values : []
-  return Array.from(new Set(rawValues
+  const allowAllUsers = rawValues.some((value) => typeof value === 'string' && value.trim() === '*')
+  const allowedUserIds = Array.from(new Set(rawValues
     .map((value) => {
       if (typeof value === 'number' && Number.isFinite(value)) {
         return Math.trunc(value)
@@ -85,12 +92,14 @@ function normalizeTelegramUserIds(values: unknown): number[] {
       return Number.NaN
     })
     .filter((value) => Number.isFinite(value)))).slice(0, 100)
+  return { allowAllUsers, allowedUserIds }
 }
 
 export class TelegramThreadBridge {
   private token: string
   private readonly appServer: AppServerLike
   private readonly defaultCwd: string
+  private allowAllUsers = false
   private allowedUserIds = new Set<number>()
   private readonly threadIdByChatId = new Map<number, string>()
   private readonly chatIdsByThreadId = new Map<string, Set<number>>()
@@ -105,12 +114,12 @@ export class TelegramThreadBridge {
     this.appServer = appServer
     this.token = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? ''
     this.defaultCwd = process.env.TELEGRAM_DEFAULT_CWD?.trim() ?? process.cwd()
-    this.allowedUserIds = new Set(normalizeTelegramUserIds(
+    this.configureAllowedUserIds(
       (process.env.TELEGRAM_ALLOWED_USER_IDS ?? '')
         .split(',')
         .map((value) => value.trim())
         .filter(Boolean),
-    ))
+    )
     this.onChatSeen = options.onChatSeen
   }
 
@@ -184,12 +193,15 @@ export class TelegramThreadBridge {
       mappedChats: this.threadIdByChatId.size,
       mappedThreads: this.chatIdsByThreadId.size,
       allowedUsers: this.allowedUserIds.size,
+      allowAllUsers: this.allowAllUsers,
       lastError: this.lastError,
     }
   }
 
   configureAllowedUserIds(allowedUserIds: unknown): void {
-    this.allowedUserIds = new Set(normalizeTelegramUserIds(allowedUserIds))
+    const normalized = normalizeTelegramAllowlist(allowedUserIds)
+    this.allowAllUsers = normalized.allowAllUsers
+    this.allowedUserIds = new Set(normalized.allowedUserIds)
   }
 
   connectThread(threadId: string, chatId: number, token?: string): void {
@@ -258,7 +270,7 @@ export class TelegramThreadBridge {
     const text = message?.text?.trim()
     if (typeof chatId !== 'number' || !text) return
     if (!this.isAllowedSender(senderId)) {
-      await this.sendTelegramMessage(chatId, this.unauthorizedMessage())
+      await this.sendTelegramMessage(chatId, this.unauthorizedMessage(senderId))
       return
     }
     this.markChatSeen(chatId)
@@ -301,10 +313,10 @@ export class TelegramThreadBridge {
     const senderId = callbackQuery.from?.id
     if (!this.isAllowedSender(senderId)) {
       if (callbackId) {
-        await this.answerCallbackQuery(callbackId, 'Unauthorized sender')
+        await this.answerCallbackQuery(callbackId, this.unauthorizedCallbackMessage(senderId))
       }
       if (typeof chatId === 'number') {
-        await this.sendTelegramMessage(chatId, this.unauthorizedMessage())
+        await this.sendTelegramMessage(chatId, this.unauthorizedMessage(senderId))
       }
       return
     }
@@ -334,13 +346,26 @@ export class TelegramThreadBridge {
   }
 
   private isAllowedSender(senderId: unknown): senderId is number {
+    if (this.allowAllUsers) {
+      return typeof senderId === 'number' && Number.isFinite(senderId)
+    }
     return typeof senderId === 'number'
       && Number.isFinite(senderId)
       && this.allowedUserIds.has(Math.trunc(senderId))
   }
 
-  private unauthorizedMessage(): string {
-    return 'Unauthorized sender. Add this Telegram user ID to the bot allowlist before using the bridge.'
+  private unauthorizedMessage(senderId: unknown): string {
+    const normalizedSenderId = typeof senderId === 'number' && Number.isFinite(senderId)
+      ? String(Math.trunc(senderId))
+      : 'unknown'
+    return `Unauthorized sender.\n\nYour Telegram user ID: ${normalizedSenderId}\nAdd this ID to the bot allowlist before using the bridge.`
+  }
+
+  private unauthorizedCallbackMessage(senderId: unknown): string {
+    if (typeof senderId === 'number' && Number.isFinite(senderId)) {
+      return `Unauthorized: ${String(Math.trunc(senderId))}`
+    }
+    return 'Unauthorized sender'
   }
 
   private async answerCallbackQuery(callbackQueryId: string, text: string): Promise<void> {

--- a/tests.md
+++ b/tests.md
@@ -24,16 +24,18 @@ This file tracks manual regression and feature verification steps.
 #### Prerequisites
 - App server is running from this repository.
 - A valid Telegram bot token is available.
+- At least one Telegram user ID is available for allowlisting.
 - Access to `~/.codex/` on the host machine.
 
 #### Steps
-1. In the app UI, open Telegram connection and submit a bot token.
+1. In the app UI, open Telegram connection and submit a bot token plus one or more allowed Telegram user IDs.
 2. Verify file `~/.codex/telegram-bridge.json` exists.
-3. Open `~/.codex/telegram-bridge.json` and confirm it contains a `botToken` field.
+3. Open `~/.codex/telegram-bridge.json` and confirm it contains `botToken` and `allowedUserIds` fields.
 4. Restart the app server and call Telegram status endpoint from UI to confirm it still reports configured.
 
 #### Expected Results
 - Telegram token is persisted in `~/.codex/telegram-bridge.json`.
+- Telegram allowlisted user IDs are persisted in `~/.codex/telegram-bridge.json`.
 - Telegram bridge remains configured after restart.
 
 #### Rollback/Cleanup
@@ -56,10 +58,31 @@ This file tracks manual regression and feature verification steps.
 #### Expected Results
 - `chatIds` is written after Telegram DM activity.
 - `chatIds` persists across bot reconfiguration.
-- `botToken` and `chatIds` are both present in `~/.codex/telegram-bridge.json`.
+- `botToken`, `chatIds`, and `allowedUserIds` are all present in `~/.codex/telegram-bridge.json`.
 
 #### Rollback/Cleanup
 - Remove `chatIds` or delete `~/.codex/telegram-bridge.json` to clear persisted chat targets.
+
+### Feature: Telegram bridge rejects unauthorized senders
+
+#### Prerequisites
+- App server is running from this repository.
+- Telegram bot is configured with a known `allowedUserIds` entry.
+- One Telegram account is allowlisted and one separate Telegram account is not.
+
+#### Steps
+1. From the allowlisted Telegram account, send `/start` to the bot.
+2. Confirm the bot responds normally.
+3. From the non-allowlisted Telegram account, send `/start` to the same bot.
+4. From the non-allowlisted account, send a normal text prompt.
+
+#### Expected Results
+- The allowlisted account can use the Telegram bridge normally.
+- The non-allowlisted account receives an unauthorized response.
+- No thread is created or updated for the non-allowlisted account.
+
+#### Rollback/Cleanup
+- Remove test chat mappings from `~/.codex/telegram-bridge.json` if needed.
 
 ### Feature: Skills dropdown closes after selection in composer
 


### PR DESCRIPTION
修复 issue #42 和 #44，并顺手修了设置列表无法滚动的显示问题。

修复如下：

1. 新线程首条消息在服务端确认持久化前禁止 Stop
- 等待期间 Stop 按钮显示转圈动效
- 服务端确认后再解锁 Stop
- 不影响已有线程的正常中断流程

2. 使设置列表可以滚动，并且点击列表外任意位置即可退出设置列表

3. 增加 Telegram 用户白名单功能
- 只有白名单内的 ID 可以正常访问 Bot
- 其他用户输入内容则显示未验证，并显示用户 ID 以便其将自己的 ID 加入白名单
- 可以在 WebUI 设置列表中修改白名单
- 支持通过在白名单中添加 `*` 来使 Bot 对所有人开放（危险）
- 如果需要关闭 Telegram Bot 功能，直接把 Bot token 改成错误值如 `123456` 即可

验证：
- `corepack pnpm run build:frontend`
- `corepack pnpm run build:cli`
