### PR TITLE
feat: OpenCode Zen provider integration with chat-completions proxy

### DIFF
--- a/DYMANIC_INSTRUCTIONS.md
+++ b/DYMANIC_INSTRUCTIONS.md
@@ -1,3 +1,1 @@
-show actuall error when unexpected status 401 Unauthorized:
 
-lets use proxy that we implemented in our other branch

--- a/DYMANIC_INSTRUCTIONS.md
+++ b/DYMANIC_INSTRUCTIONS.md
@@ -1,1 +1,3 @@
+show actuall error when unexpected status 401 Unauthorized:
 
+lets use proxy that we implemented in our other branch

--- a/DYNAMIC_INSTRUCTIONS.md
+++ b/DYNAMIC_INSTRUCTIONS.md
@@ -1,1 +1,0 @@
-its possible force use only same profile threads so no need use merge or cache

--- a/src/App.vue
+++ b/src/App.vue
@@ -2676,10 +2676,23 @@ async function onProviderChange(provider: string): Promise<void> {
       freeModeEnabled.value = result.enabled
     } else if (provider === 'opencode-zen') {
       selectedProvider.value = 'opencode-zen'
+      if (opencodeZenKey.value.trim()) {
+        await setCustomProvider('', opencodeZenKey.value.trim(), {
+          wireApi: 'chat',
+          provider: 'opencode-zen',
+        })
+        freeModeEnabled.value = true
+      }
     } else if (provider === 'custom') {
       selectedProvider.value = 'custom'
+      if (customEndpointUrl.value.trim() && customEndpointKey.value.trim()) {
+        await setCustomProvider(customEndpointUrl.value.trim(), customEndpointKey.value.trim(), {
+          wireApi: customEndpointWireApi.value,
+        })
+        freeModeEnabled.value = true
+      }
     }
-    await refreshAll({ includeSelectedThreadMessages: false })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
   } catch {
     // Silently fail — state unchanged
   } finally {
@@ -2697,7 +2710,7 @@ async function saveCustomEndpoint(): Promise<void> {
       wireApi: customEndpointWireApi.value,
     })
     freeModeEnabled.value = true
-    await refreshAll({ includeSelectedThreadMessages: false })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
   } catch {
     // Silently fail
   } finally {
@@ -2716,7 +2729,7 @@ async function saveOpencodeZen(): Promise<void> {
       provider: 'opencode-zen',
     })
     freeModeEnabled.value = true
-    await refreshAll({ includeSelectedThreadMessages: false })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
   } catch {
     // Silently fail
   } finally {

--- a/src/App.vue
+++ b/src/App.vue
@@ -206,6 +206,9 @@
                   <option value="custom">Custom endpoint</option>
                 </select>
               </div>
+              <div v-if="providerError" class="sidebar-settings-row sidebar-settings-error">
+                {{ providerError }}
+              </div>
               <div v-if="selectedProvider === 'openrouter'" class="sidebar-settings-row sidebar-settings-row--input">
                 <div class="sidebar-settings-provider-info">
                   <span class="sidebar-settings-label">OpenRouter API key</span>
@@ -1063,6 +1066,7 @@ const freeModeCustomKey = ref('')
 const freeModeHasCustomKey = ref(false)
 const freeModeCustomKeyMasked = ref<string | null>(null)
 const freeModeCustomKeySaving = ref(false)
+const providerError = ref('')
 const selectedProvider = ref<'codex' | 'openrouter' | 'opencode-zen' | 'custom'>('codex')
 const customEndpointUrl = ref('')
 const customEndpointKey = ref('')
@@ -2690,12 +2694,13 @@ async function onProviderChange(provider: string): Promise<void> {
         freeModeEnabled.value = true
       }
     }
+    providerError.value = ''
     await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
     if (route.name === 'thread') {
       void router.push({ name: 'home' })
     }
-  } catch {
-    // Silently fail — state unchanged
+  } catch (err) {
+    providerError.value = err instanceof Error ? err.message : 'Failed to switch provider'
   } finally {
     freeModeLoading.value = false
   }
@@ -2707,13 +2712,14 @@ async function saveCustomEndpoint(): Promise<void> {
   if (!url) return
   freeModeCustomKeySaving.value = true
   try {
+    providerError.value = ''
     await setCustomProvider(url, customEndpointKey.value.trim(), {
       wireApi: customEndpointWireApi.value,
     })
     freeModeEnabled.value = true
     await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
-  } catch {
-    // Silently fail
+  } catch (err) {
+    providerError.value = err instanceof Error ? err.message : 'Failed to save custom endpoint'
   } finally {
     freeModeCustomKeySaving.value = false
   }
@@ -2725,14 +2731,15 @@ async function saveOpencodeZen(): Promise<void> {
   if (!key) return
   freeModeCustomKeySaving.value = true
   try {
+    providerError.value = ''
     await setCustomProvider('', key, {
       wireApi: 'chat',
       provider: 'opencode-zen',
     })
     freeModeEnabled.value = true
     await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
-  } catch {
-    // Silently fail
+  } catch (err) {
+    providerError.value = err instanceof Error ? err.message : 'Failed to save OpenCode Zen config'
   } finally {
     freeModeCustomKeySaving.value = false
   }
@@ -3820,6 +3827,10 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .sidebar-settings-row--input {
   @apply flex flex-col gap-1 py-1.5;
+}
+
+.sidebar-settings-error {
+  @apply text-xs text-red-600 bg-red-50 rounded px-2 py-1.5 break-words;
 }
 
 .sidebar-settings-key-group {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2676,13 +2676,11 @@ async function onProviderChange(provider: string): Promise<void> {
       freeModeEnabled.value = result.enabled
     } else if (provider === 'opencode-zen') {
       selectedProvider.value = 'opencode-zen'
-      if (opencodeZenKey.value.trim()) {
-        await setCustomProvider('', opencodeZenKey.value.trim(), {
-          wireApi: 'chat',
-          provider: 'opencode-zen',
-        })
-        freeModeEnabled.value = true
-      }
+      await setCustomProvider('', opencodeZenKey.value.trim(), {
+        wireApi: 'chat',
+        provider: 'opencode-zen',
+      })
+      freeModeEnabled.value = true
     } else if (provider === 'custom') {
       selectedProvider.value = 'custom'
       if (customEndpointUrl.value.trim() && customEndpointKey.value.trim()) {
@@ -2692,7 +2690,7 @@ async function onProviderChange(provider: string): Promise<void> {
         freeModeEnabled.value = true
       }
     }
-    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
   } catch {
     // Silently fail — state unchanged
   } finally {
@@ -2710,7 +2708,7 @@ async function saveCustomEndpoint(): Promise<void> {
       wireApi: customEndpointWireApi.value,
     })
     freeModeEnabled.value = true
-    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
   } catch {
     // Silently fail
   } finally {
@@ -2729,7 +2727,7 @@ async function saveOpencodeZen(): Promise<void> {
       provider: 'opencode-zen',
     })
     freeModeEnabled.value = true
-    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true })
+    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
   } catch {
     // Silently fail
   } finally {

--- a/src/App.vue
+++ b/src/App.vue
@@ -202,6 +202,7 @@
                 >
                   <option value="codex">Codex</option>
                   <option value="openrouter">OpenRouter</option>
+                  <option value="opencode-zen">OpenCode Zen</option>
                   <option value="custom">Custom endpoint</option>
                 </select>
               </div>
@@ -243,6 +244,32 @@
                   </template>
                 </div>
               </div>
+              <div v-if="selectedProvider === 'opencode-zen'" class="sidebar-settings-row sidebar-settings-row--input">
+                <div class="sidebar-settings-provider-info">
+                  <span class="sidebar-settings-label">OpenCode Zen API key</span>
+                  <a
+                    class="sidebar-settings-provider-link"
+                    href="https://opencode.ai/auth"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >Get API key</a>
+                </div>
+                <div class="sidebar-settings-key-group">
+                  <input
+                    v-model="opencodeZenKey"
+                    class="sidebar-settings-key-input"
+                    type="password"
+                    placeholder="sk-..."
+                    @keydown.enter="saveOpencodeZen"
+                  />
+                  <button
+                    class="sidebar-settings-key-save"
+                    type="button"
+                    :disabled="freeModeCustomKeySaving || !opencodeZenKey.trim()"
+                    @click="saveOpencodeZen"
+                  >{{ freeModeCustomKeySaving ? '...' : 'Save' }}</button>
+                </div>
+              </div>
               <div v-if="selectedProvider === 'custom'" class="sidebar-settings-row sidebar-settings-row--input">
                 <span class="sidebar-settings-label">Custom endpoint URL</span>
                 <div class="sidebar-settings-key-group">
@@ -269,6 +296,16 @@
                     :disabled="freeModeCustomKeySaving || !customEndpointUrl.trim()"
                     @click="saveCustomEndpoint"
                   >{{ freeModeCustomKeySaving ? '...' : 'Save' }}</button>
+                </div>
+                <div class="sidebar-settings-row sidebar-settings-row--select" style="margin-top: 4px; padding: 0">
+                  <span class="sidebar-settings-label">API format</span>
+                  <select
+                    v-model="customEndpointWireApi"
+                    class="sidebar-settings-provider-select"
+                  >
+                    <option value="responses">Responses API</option>
+                    <option value="chat">Chat Completions</option>
+                  </select>
                 </div>
               </div>
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="SETTINGS_HELP.dictationLanguage">
@@ -1026,9 +1063,11 @@ const freeModeCustomKey = ref('')
 const freeModeHasCustomKey = ref(false)
 const freeModeCustomKeyMasked = ref<string | null>(null)
 const freeModeCustomKeySaving = ref(false)
-const selectedProvider = ref<'codex' | 'openrouter' | 'custom'>('codex')
+const selectedProvider = ref<'codex' | 'openrouter' | 'opencode-zen' | 'custom'>('codex')
 const customEndpointUrl = ref('')
 const customEndpointKey = ref('')
+const customEndpointWireApi = ref<'responses' | 'chat'>('responses')
+const opencodeZenKey = ref('')
 const isTelegramConfigOpen = ref(false)
 const telegramBotTokenDraft = ref('')
 const telegramAllowedUserIdsDraft = ref('')
@@ -2635,6 +2674,8 @@ async function onProviderChange(provider: string): Promise<void> {
       selectedProvider.value = 'openrouter'
       const result = await setFreeMode(true)
       freeModeEnabled.value = result.enabled
+    } else if (provider === 'opencode-zen') {
+      selectedProvider.value = 'opencode-zen'
     } else if (provider === 'custom') {
       selectedProvider.value = 'custom'
     }
@@ -2652,7 +2693,28 @@ async function saveCustomEndpoint(): Promise<void> {
   if (!url) return
   freeModeCustomKeySaving.value = true
   try {
-    await setCustomProvider(url, customEndpointKey.value.trim())
+    await setCustomProvider(url, customEndpointKey.value.trim(), {
+      wireApi: customEndpointWireApi.value,
+    })
+    freeModeEnabled.value = true
+    await refreshAll({ includeSelectedThreadMessages: false })
+  } catch {
+    // Silently fail
+  } finally {
+    freeModeCustomKeySaving.value = false
+  }
+}
+
+async function saveOpencodeZen(): Promise<void> {
+  if (freeModeCustomKeySaving.value) return
+  const key = opencodeZenKey.value.trim()
+  if (!key) return
+  freeModeCustomKeySaving.value = true
+  try {
+    await setCustomProvider('', key, {
+      wireApi: 'chat',
+      provider: 'opencode-zen',
+    })
     freeModeEnabled.value = true
     await refreshAll({ includeSelectedThreadMessages: false })
   } catch {
@@ -2700,9 +2762,12 @@ async function loadFreeModeStatus(): Promise<void> {
     freeModeHasCustomKey.value = status.customKey ?? false
     freeModeCustomKeyMasked.value = status.maskedKey ?? null
     if (status.enabled) {
-      if (status.provider === 'custom') {
+      if (status.provider === 'opencode-zen') {
+        selectedProvider.value = 'opencode-zen'
+      } else if (status.provider === 'custom') {
         selectedProvider.value = 'custom'
         customEndpointUrl.value = status.customBaseUrl ?? ''
+        customEndpointWireApi.value = status.wireApi === 'chat' ? 'chat' : 'responses'
       } else {
         selectedProvider.value = 'openrouter'
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -2691,6 +2691,9 @@ async function onProviderChange(provider: string): Promise<void> {
       }
     }
     await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
+    if (route.name === 'thread') {
+      void router.push({ name: 'home' })
+    }
   } catch {
     // Silently fail — state unchanged
   } finally {

--- a/src/api/codexErrors.ts
+++ b/src/api/codexErrors.ts
@@ -26,6 +26,8 @@ export class CodexApiError extends Error {
 }
 
 export function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'string' && payload.length > 0) return payload
+
   const record = asRecord(payload)
   if (!record) return fallback
 
@@ -36,6 +38,9 @@ export function extractErrorMessage(payload: unknown, fallback: string): string 
   if (nested && typeof nested.message === 'string' && nested.message.length > 0) {
     return nested.message
   }
+
+  if (typeof record.message === 'string' && record.message.length > 0) return record.message
+  if (typeof record.detail === 'string' && record.detail.length > 0) return record.detail
 
   return fallback
 }

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1180,7 +1180,7 @@ export async function startThreadTurn(
     if (typeof effort === 'string' && effort.length > 0) {
       params.effort = effort
     }
-    if (collaborationMode) {
+    if (collaborationMode && collaborationMode !== 'default') {
       const collaborationModeSettings = await resolveCollaborationModeSettings(collaborationMode, normalizedModel, effort)
       params.collaborationMode = {
         mode: collaborationMode,

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1244,8 +1244,9 @@ export interface FreeModeStatus {
   currentModel: string | null
   customKey: boolean
   maskedKey: string | null
-  provider?: 'openrouter' | 'custom'
+  provider?: 'openrouter' | 'custom' | 'opencode-zen'
   customBaseUrl?: string
+  wireApi?: 'responses' | 'chat' | null
 }
 
 export async function getFreeModeStatus(): Promise<FreeModeStatus> {
@@ -1271,11 +1272,20 @@ export async function setFreeModeCustomKey(key: string): Promise<{ ok: boolean; 
   return await response.json() as { ok: boolean; customKey: boolean }
 }
 
-export async function setCustomProvider(baseUrl: string, apiKey: string): Promise<{ ok: boolean }> {
+export async function setCustomProvider(
+  baseUrl: string,
+  apiKey: string,
+  options?: { wireApi?: 'responses' | 'chat'; provider?: 'custom' | 'opencode-zen' },
+): Promise<{ ok: boolean }> {
   const response = await fetch('/codex-api/free-mode/custom-provider', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ baseUrl, apiKey }),
+    body: JSON.stringify({
+      baseUrl,
+      apiKey,
+      wireApi: options?.wireApi,
+      provider: options?.provider,
+    }),
   })
   return await response.json() as { ok: boolean }
 }

--- a/src/api/codexRpcClient.ts
+++ b/src/api/codexRpcClient.ts
@@ -47,15 +47,19 @@ export async function rpcCall<T>(method: string, params?: unknown): Promise<T> {
   }
 
   let payload: unknown = null
+  let rawText: string | null = null
   try {
-    payload = await response.json()
+    rawText = await response.text()
+    payload = JSON.parse(rawText)
   } catch {
     payload = null
   }
 
   if (!response.ok) {
+    const detail = extractErrorMessage(payload, '') || rawText?.slice(0, 500) || ''
+    const prefix = `RPC ${method} failed with HTTP ${response.status}`
     throw new CodexApiError(
-      extractErrorMessage(payload, `RPC ${method} failed with HTTP ${response.status}`),
+      detail ? `${prefix}: ${detail}` : prefix,
       {
         code: 'http_error',
         method,

--- a/src/components/content/ComposerDropdown.vue
+++ b/src/components/content/ComposerDropdown.vue
@@ -43,7 +43,7 @@
             </button>
           </li>
           <li v-if="filteredOptions.length === 0" class="composer-dropdown-empty">
-            No matching projects
+            {{ emptyText }}
           </li>
         </ul>
 
@@ -100,6 +100,7 @@ const props = defineProps<{
   addActionMode?: 'inline' | 'event'
   defaultAddValue?: string
   addPlaceholder?: string
+  emptyLabel?: string
 }>()
 
 const emit = defineEmits<{
@@ -129,6 +130,7 @@ const searchPlaceholderText = computed(() => props.searchPlaceholder?.trim() || 
 const addActionLabelText = computed(() => props.addActionLabel?.trim() || 'Add new project')
 const addActionMode = computed(() => props.addActionMode ?? 'inline')
 const addPlaceholderText = computed(() => props.addPlaceholder?.trim() || 'Project name or absolute path')
+const emptyText = computed(() => props.emptyLabel?.trim() || 'No results')
 const filteredOptions = computed(() => {
   const query = searchQuery.value.trim().toLowerCase()
   if (!query) return props.options

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -250,6 +250,8 @@
             placeholder="Model"
             open-direction="up"
             :disabled="disabled || !activeThreadId || models.length === 0 || isTurnInProgress"
+            enable-search
+            search-placeholder="Search models..."
             @update:model-value="onModelSelect"
           />
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1370,9 +1370,11 @@ export function useDesktopState() {
       const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const nextModelIds = [...modelIds]
-      for (const modelId of [normalizedSelectedModelId, normalizedConfiguredModelId]) {
-        if (modelId && !nextModelIds.includes(modelId)) {
-          nextModelIds.push(modelId)
+      if (!options?.providerChanged) {
+        for (const modelId of [normalizedSelectedModelId, normalizedConfiguredModelId]) {
+          if (modelId && !nextModelIds.includes(modelId)) {
+            nextModelIds.push(modelId)
+          }
         }
       }
       availableModelIds.value = nextModelIds

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1383,6 +1383,10 @@ export function useDesktopState() {
       if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
         if (options?.providerChanged && nextModelIds.length > 0) {
           setSelectedModelId(nextModelIds[0])
+          const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
+          nextModelMap[NEW_THREAD_COLLABORATION_MODE_CONTEXT] = nextModelIds[0]
+          selectedModelIdByContext.value = nextModelMap
+          saveSelectedModelMap(selectedModelIdByContext.value)
         } else if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
           setSelectedModelId(currentConfig.model)
         } else if (nextModelIds.length > 0) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1360,7 +1360,7 @@ export function useDesktopState() {
     return [`Mode: ${modeLabel}`, `Model: ${modelLabel}`, `Thinking: ${effortLabel}`, `Speed: ${speedLabel}`]
   }
 
-  async function refreshModelPreferences(): Promise<void> {
+  async function refreshModelPreferences(options?: { providerChanged?: boolean }): Promise<void> {
     try {
       const [modelIds, currentConfig] = await Promise.all([
         getAvailableModelIds(),
@@ -1378,8 +1378,10 @@ export function useDesktopState() {
       availableModelIds.value = nextModelIds
 
       const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
-      if (!normalizedSelectedModelId || !currentModelInNewList) {
-        if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
+      if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
+        if (options?.providerChanged && nextModelIds.length > 0) {
+          setSelectedModelId(nextModelIds[0])
+        } else if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
           setSelectedModelId(currentConfig.model)
         } else if (nextModelIds.length > 0) {
           setSelectedModelId(nextModelIds[0])
@@ -3477,7 +3479,7 @@ export function useDesktopState() {
   }
 
   async function refreshAll(
-    options: { includeSelectedThreadMessages?: boolean; awaitAncillaryRefreshes?: boolean } = {},
+    options: { includeSelectedThreadMessages?: boolean; awaitAncillaryRefreshes?: boolean; providerChanged?: boolean } = {},
   ) {
     error.value = ''
     const includeSelectedThreadMessages = options.includeSelectedThreadMessages !== false
@@ -3486,7 +3488,7 @@ export function useDesktopState() {
     try {
       await loadThreads()
       const ancillaryRefresh = Promise.allSettled([
-        refreshModelPreferences(),
+        refreshModelPreferences({ providerChanged: options.providerChanged }),
         refreshRateLimits(),
         refreshCollaborationModes(),
         refreshSkills(),

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1377,7 +1377,8 @@ export function useDesktopState() {
       }
       availableModelIds.value = nextModelIds
 
-      if (!normalizedSelectedModelId) {
+      const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
+      if (!normalizedSelectedModelId || !currentModelInNewList) {
         if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
           setSelectedModelId(currentConfig.model)
         } else if (nextModelIds.length > 0) {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -23,6 +23,7 @@ import {
   getFreeModels,
   FREE_MODE_STATE_FILE,
   getFreeModeConfigArgs,
+  getFreeModeEnvVars,
   type FreeModeState,
 } from './freeMode.js'
 import { getSpawnInvocation } from '../utils/commandInvocation.js'
@@ -2170,29 +2171,35 @@ class AppServerProcess {
     return codexCommand
   }
 
-  private buildAppServerArgs(): string[] {
+  private buildAppServerConfig(): { args: string[]; env: Record<string, string> } {
     const args = [
       'app-server',
       '-c', 'approval_policy="never"',
       '-c', 'sandbox_mode="danger-full-access"',
     ]
+    let extraEnv: Record<string, string> = {}
     const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
     try {
       const raw = readFileSync(statePath, 'utf8')
       const state = JSON.parse(raw) as FreeModeState
       args.push(...getFreeModeConfigArgs(state))
+      extraEnv = getFreeModeEnvVars(state)
     } catch {
       // No free-mode state or invalid — use defaults
     }
-    return args
+    return { args, env: extraEnv }
   }
 
   private start(): void {
     if (this.process) return
 
     this.stopping = false
-    const invocation = getSpawnInvocation(this.getCodexCommand(), this.buildAppServerArgs())
-    const proc = spawn(invocation.command, invocation.args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    const config = this.buildAppServerConfig()
+    const invocation = getSpawnInvocation(this.getCodexCommand(), config.args)
+    const spawnEnv = Object.keys(config.env).length > 0
+      ? { ...process.env, ...config.env }
+      : undefined
+    const proc = spawn(invocation.command, invocation.args, { stdio: ['pipe', 'pipe', 'pipe'], ...(spawnEnv ? { env: spawnEnv } : {}) })
     this.process = proc
 
     proc.stdout.setEncoding('utf8')

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -26,6 +26,7 @@ import {
   getFreeModeEnvVars,
   type FreeModeState,
 } from './freeMode.js'
+import { handleZenProxyRequest } from './zenProxy.js'
 import { getSpawnInvocation } from '../utils/commandInvocation.js'
 import {
   resolveCodexCommand,
@@ -2178,11 +2179,12 @@ class AppServerProcess {
       '-c', 'sandbox_mode="danger-full-access"',
     ]
     let extraEnv: Record<string, string> = {}
+    const serverPort = parseInt(process.env.CODEXUI_SERVER_PORT ?? '', 10) || undefined
     const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
     try {
       const raw = readFileSync(statePath, 'utf8')
       const state = JSON.parse(raw) as FreeModeState
-      args.push(...getFreeModeConfigArgs(state))
+      args.push(...getFreeModeConfigArgs(state, serverPort))
       extraEnv = getFreeModeEnvVars(state)
     } catch {
       // No free-mode state or invalid — use defaults
@@ -2898,6 +2900,18 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       const url = new URL(req.url, 'http://localhost')
+
+      if (url.pathname === '/codex-api/zen-proxy/v1/responses' && req.method === 'POST') {
+        const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
+        let bearerToken = ''
+        try {
+          const state = JSON.parse(readFileSync(statePath, 'utf8')) as FreeModeState
+          bearerToken = state.apiKey ?? ''
+        } catch { /* use empty */ }
+        handleZenProxyRequest(req, res, bearerToken)
+        return
+      }
+
       if (url.pathname.startsWith('/codex-api/free-mode')) {
         const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3340,14 +3340,16 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
                 const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
                 if (resp.ok) {
                   const json = await resp.json() as { data?: Array<{ id: string }> }
-                  const ids = (json.data ?? []).map(m => m.id).filter(Boolean)
-                  setJson(res, 200, { data: ids, exclusive: true, source: 'opencode-zen' })
+                  const allIds = (json.data ?? []).map(m => m.id).filter(Boolean)
+                  const freeIds = allIds.filter(id => id.endsWith('-free') || id === 'big-pickle')
+                  const paidIds = allIds.filter(id => !id.endsWith('-free') && id !== 'big-pickle')
+                  setJson(res, 200, { data: [...freeIds, ...paidIds], exclusive: true, source: 'opencode-zen' })
                   return
                 }
               } catch {
                 // OpenCode Zen model fetch failed
               }
-              setJson(res, 200, { data: ['big-pickle'], exclusive: true, source: 'opencode-zen' })
+              setJson(res, 200, { data: ['big-pickle', 'minimax-m2.5-free', 'nemotron-3-super-free', 'trinity-large-preview-free'], exclusive: true, source: 'opencode-zen' })
               return
             }
             if (fmState.provider === 'custom' && fmState.customBaseUrl) {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2953,6 +2953,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               maskedKey,
               provider: state.provider ?? 'openrouter',
               customBaseUrl: state.customBaseUrl ?? null,
+              wireApi: state.wireApi ?? null,
             })
           } catch (error) {
             setJson(res, 500, { error: getErrorMessage(error, 'Failed to read free mode status') })
@@ -3007,7 +3008,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             const body = await readJsonBody(req) as Record<string, unknown> | null
             const baseUrl = typeof body?.baseUrl === 'string' ? body.baseUrl.trim() : ''
             const apiKey = typeof body?.apiKey === 'string' ? body.apiKey.trim() : ''
-            if (!baseUrl) {
+            const wireApi = body?.wireApi === 'chat' ? 'chat' as const : 'responses' as const
+            const providerType = body?.provider === 'opencode-zen' ? 'opencode-zen' as const : 'custom' as const
+            if (providerType === 'custom' && !baseUrl) {
               setJson(res, 400, { error: 'baseUrl is required' })
               return
             }
@@ -3016,8 +3019,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               apiKey: apiKey || 'dummy',
               model: '',
               customKey: true,
-              provider: 'custom',
-              customBaseUrl: baseUrl,
+              provider: providerType,
+              customBaseUrl: providerType === 'custom' ? baseUrl : undefined,
+              wireApi,
             }
             await writeFile(statePath, JSON.stringify(state), 'utf8')
             appServer.dispose()
@@ -3319,6 +3323,26 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         try {
           const fmState = JSON.parse(readFileSync(join(getCodexHomeDir(), FREE_MODE_STATE_FILE), 'utf8')) as FreeModeState
           if (fmState.enabled) {
+            if (fmState.provider === 'opencode-zen') {
+              try {
+                const modelsUrl = 'https://opencode.ai/zen/v1/models'
+                const headers: Record<string, string> = {}
+                if (fmState.apiKey && fmState.apiKey !== 'dummy') {
+                  headers['Authorization'] = `Bearer ${fmState.apiKey}`
+                }
+                const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
+                if (resp.ok) {
+                  const json = await resp.json() as { data?: Array<{ id: string }> }
+                  const ids = (json.data ?? []).map(m => m.id).filter(Boolean)
+                  setJson(res, 200, { data: ids, exclusive: true, source: 'opencode-zen' })
+                  return
+                }
+              } catch {
+                // OpenCode Zen model fetch failed
+              }
+              setJson(res, 200, { data: ['big-pickle'], exclusive: true, source: 'opencode-zen' })
+              return
+            }
             if (fmState.provider === 'custom' && fmState.customBaseUrl) {
               try {
                 const modelsUrl = fmState.customBaseUrl.replace(/\/+$/, '') + '/models'

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2935,7 +2935,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
                 return
               }
 
-              const state: FreeModeState = { enabled: true, apiKey, model: FREE_MODE_DEFAULT_MODEL, provider: 'openrouter' }
+              const prev = readFreeModeState()
+              const prevKeys = prev.providerKeys ?? {}
+              if (prev.provider && prev.apiKey) {
+                prevKeys[prev.provider] = prev.apiKey
+              }
+              const state: FreeModeState = { enabled: true, apiKey, model: FREE_MODE_DEFAULT_MODEL, provider: 'openrouter', providerKeys: prevKeys }
               await writeFile(statePath, JSON.stringify(state), 'utf8')
               appServer.dispose()
               const freeModels = await getFreeModels()
@@ -2947,7 +2952,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
                 models: freeModels,
               })
             } else {
-              const state: FreeModeState = { enabled: false, apiKey: null, model: FREE_MODE_DEFAULT_MODEL }
+              const prev = readFreeModeState()
+              const prevKeys = prev.providerKeys ?? {}
+              if (prev.provider && prev.apiKey) {
+                prevKeys[prev.provider] = prev.apiKey
+              }
+              const state: FreeModeState = { enabled: false, apiKey: null, model: FREE_MODE_DEFAULT_MODEL, providerKeys: prevKeys }
               await writeFile(statePath, JSON.stringify(state), 'utf8')
               appServer.dispose()
               setJson(res, 200, { ok: true, enabled: false })
@@ -3035,14 +3045,24 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               setJson(res, 400, { error: 'baseUrl is required' })
               return
             }
+            const current = readFreeModeState()
+            const prevKeys = current.providerKeys ?? {}
+            if (current.provider && current.apiKey) {
+              prevKeys[current.provider] = current.apiKey
+            }
+            const resolvedKey = apiKey || prevKeys[providerType] || ''
+            if (resolvedKey) {
+              prevKeys[providerType] = resolvedKey
+            }
             const state: FreeModeState = {
               enabled: true,
-              apiKey: apiKey || 'dummy',
+              apiKey: resolvedKey,
               model: '',
               customKey: true,
               provider: providerType,
               customBaseUrl: providerType === 'custom' ? baseUrl : undefined,
               wireApi,
+              providerKeys: prevKeys,
             }
             await writeFile(statePath, JSON.stringify(state), 'utf8')
             appServer.dispose()

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -165,17 +165,23 @@ export function getFreeModeEnvVars(state: FreeModeState): Record<string, string>
   return {}
 }
 
-export function getFreeModeConfigArgs(state: FreeModeState): string[] {
+export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number): string[] {
   if (!state.enabled || !state.apiKey) return []
 
   if (state.provider === 'opencode-zen') {
-    const wireApi = state.wireApi || 'chat'
+    const baseUrl = serverPort
+      ? `http://127.0.0.1:${serverPort}/codex-api/zen-proxy/v1`
+      : OPENCODE_ZEN_BASE_URL
+    const wireApi = serverPort ? 'responses' : (state.wireApi || 'chat')
+    const authArgs: string[] = serverPort
+      ? ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`]
+      : ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.env_key="OPENCODE_ZEN_API_KEY"`]
     return [
       '-c', `model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.name="OpenCode Zen"`,
-      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${OPENCODE_ZEN_BASE_URL}"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${baseUrl}"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.wire_api="${wireApi}"`,
-      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.env_key="OPENCODE_ZEN_API_KEY"`,
+      ...authArgs,
     ]
   }
 

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -149,16 +149,17 @@ export interface FreeModeState {
   provider?: 'openrouter' | 'custom' | 'opencode-zen'
   customBaseUrl?: string
   wireApi?: WireApi
+  providerKeys?: Record<string, string>
 }
 
 export function getFreeModeEnvVars(state: FreeModeState): Record<string, string> {
-  if (!state.enabled || !state.apiKey) return {}
+  if (!state.enabled) return {}
 
-  if (state.provider === 'opencode-zen') {
+  if (state.provider === 'opencode-zen' && state.apiKey) {
     return { OPENCODE_ZEN_API_KEY: state.apiKey }
   }
 
-  if (state.provider === 'custom' && state.customBaseUrl) {
+  if (state.provider === 'custom' && state.customBaseUrl && state.apiKey) {
     return { CUSTOM_ENDPOINT_API_KEY: state.apiKey }
   }
 
@@ -166,7 +167,7 @@ export function getFreeModeEnvVars(state: FreeModeState): Record<string, string>
 }
 
 export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number): string[] {
-  if (!state.enabled || !state.apiKey) return []
+  if (!state.enabled) return []
 
   if (state.provider === 'opencode-zen') {
     const baseUrl = serverPort
@@ -196,6 +197,7 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
     ]
   }
 
+  if (!state.apiKey) return []
   return [
     '-c', `model="${state.model}"`,
     '-c', `model_provider="${FREE_MODE_PROVIDER_ID}"`,

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -151,6 +151,20 @@ export interface FreeModeState {
   wireApi?: WireApi
 }
 
+export function getFreeModeEnvVars(state: FreeModeState): Record<string, string> {
+  if (!state.enabled || !state.apiKey) return {}
+
+  if (state.provider === 'opencode-zen') {
+    return { OPENCODE_ZEN_API_KEY: state.apiKey }
+  }
+
+  if (state.provider === 'custom' && state.customBaseUrl) {
+    return { CUSTOM_ENDPOINT_API_KEY: state.apiKey }
+  }
+
+  return {}
+}
+
 export function getFreeModeConfigArgs(state: FreeModeState): string[] {
   if (!state.enabled || !state.apiKey) return []
 
@@ -161,7 +175,7 @@ export function getFreeModeConfigArgs(state: FreeModeState): string[] {
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.name="OpenCode Zen"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${OPENCODE_ZEN_BASE_URL}"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.wire_api="${wireApi}"`,
-      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="${state.apiKey}"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.env_key="OPENCODE_ZEN_API_KEY"`,
     ]
   }
 
@@ -172,7 +186,7 @@ export function getFreeModeConfigArgs(state: FreeModeState): string[] {
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.name="Custom Endpoint"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.base_url="${state.customBaseUrl}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.wire_api="${wireApi}"`,
-      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.experimental_bearer_token="${state.apiKey}"`,
+      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.env_key="CUSTOM_ENDPOINT_API_KEY"`,
     ]
   }
 

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -136,25 +136,42 @@ export const FREE_MODE_DEFAULT_MODEL = 'openrouter/free'
 export const FREE_MODE_STATE_FILE = 'webui-free-mode.json'
 
 export const CUSTOM_PROVIDER_ID = 'custom-endpoint'
+export const OPENCODE_ZEN_PROVIDER_ID = 'opencode-zen'
+export const OPENCODE_ZEN_BASE_URL = 'https://opencode.ai/zen/v1'
+
+export type WireApi = 'responses' | 'chat'
 
 export interface FreeModeState {
   enabled: boolean
   apiKey: string | null
   model: string
   customKey?: boolean
-  provider?: 'openrouter' | 'custom'
+  provider?: 'openrouter' | 'custom' | 'opencode-zen'
   customBaseUrl?: string
+  wireApi?: WireApi
 }
 
 export function getFreeModeConfigArgs(state: FreeModeState): string[] {
   if (!state.enabled || !state.apiKey) return []
 
+  if (state.provider === 'opencode-zen') {
+    const wireApi = state.wireApi || 'chat'
+    return [
+      '-c', `model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.name="OpenCode Zen"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${OPENCODE_ZEN_BASE_URL}"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.wire_api="${wireApi}"`,
+      '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="${state.apiKey}"`,
+    ]
+  }
+
   if (state.provider === 'custom' && state.customBaseUrl) {
+    const wireApi = state.wireApi || 'responses'
     return [
       '-c', `model_provider="${CUSTOM_PROVIDER_ID}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.name="Custom Endpoint"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.base_url="${state.customBaseUrl}"`,
-      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.wire_api="responses"`,
+      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.wire_api="${wireApi}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.experimental_bearer_token="${state.apiKey}"`,
     ]
   }

--- a/src/server/zenProxy.ts
+++ b/src/server/zenProxy.ts
@@ -1,0 +1,238 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+
+const ZEN_UPSTREAM = 'https://opencode.ai/zen/v1'
+
+interface ResponsesApiInput {
+  type: string
+  role?: string
+  content?: string | Array<{ type: string; text?: string }>
+  text?: string
+}
+
+interface ResponsesApiRequest {
+  model: string
+  input: string | ResponsesApiInput[]
+  instructions?: string
+  temperature?: number
+  top_p?: number
+  max_output_tokens?: number
+  stream?: boolean
+  [key: string]: unknown
+}
+
+interface ChatMessage {
+  role: string
+  content: string
+}
+
+interface ChatCompletionsRequest {
+  model: string
+  messages: ChatMessage[]
+  temperature?: number
+  top_p?: number
+  max_tokens?: number
+  stream?: boolean
+  [key: string]: unknown
+}
+
+function responsesInputToMessages(input: string | ResponsesApiInput[], instructions?: string): ChatMessage[] {
+  const messages: ChatMessage[] = []
+  if (instructions) {
+    messages.push({ role: 'system', content: instructions })
+  }
+  if (typeof input === 'string') {
+    messages.push({ role: 'user', content: input })
+    return messages
+  }
+  for (const item of input) {
+    if (item.type === 'message' && item.role && item.content) {
+      const text = typeof item.content === 'string'
+        ? item.content
+        : item.content
+            .filter((c) => c.type === 'input_text' && c.text)
+            .map((c) => c.text)
+            .join('\n')
+      const role = item.role === 'developer' ? 'system' : item.role
+      messages.push({ role, content: text })
+    }
+  }
+  return messages
+}
+
+function chatCompletionToResponsesFormat(chatResponse: Record<string, unknown>, model: string): Record<string, unknown> {
+  const choices = (chatResponse.choices ?? []) as Array<{
+    message?: { content?: string; reasoning?: string; reasoning_details?: Array<{ text?: string }> }
+    index?: number
+    finish_reason?: string
+  }>
+  const output: Array<Record<string, unknown>> = []
+  for (const choice of choices) {
+    if (!choice.message?.content) continue
+    output.push({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: choice.message.content }],
+      status: 'completed',
+    })
+  }
+  const usage = chatResponse.usage as Record<string, number> | undefined
+  return {
+    id: chatResponse.id ?? `resp_${Date.now()}`,
+    object: 'response',
+    created_at: chatResponse.created ?? Math.floor(Date.now() / 1000),
+    status: 'completed',
+    model,
+    output,
+    usage: usage ? {
+      input_tokens: usage.prompt_tokens ?? 0,
+      output_tokens: usage.completion_tokens ?? 0,
+      total_tokens: usage.total_tokens ?? 0,
+    } : undefined,
+  }
+}
+
+function readRequestBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks)))
+    req.on('error', reject)
+  })
+}
+
+function forwardStreamingResponse(
+  upstreamRes: IncomingMessage,
+  res: ServerResponse,
+  model: string,
+): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  })
+
+  let buffer = ''
+  const contentParts: string[] = []
+  let responseId = `resp_${Date.now()}`
+
+  res.write(`data: {"type":"response.created","response":{"id":"${responseId}","object":"response","status":"in_progress","model":"${model}","output":[]}}\n\n`)
+  res.write(`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant","content":[],"status":"in_progress"}}\n\n`)
+  res.write(`data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}\n\n`)
+
+  upstreamRes.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString()
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue
+      const data = line.slice(6).trim()
+      if (data === '[DONE]') continue
+      try {
+        const parsed = JSON.parse(data) as {
+          id?: string
+          choices?: Array<{ delta?: { content?: string; reasoning?: string } }>
+        }
+        if (parsed.id) responseId = `resp_${parsed.id}`
+        const delta = parsed.choices?.[0]?.delta
+        if (delta?.content) {
+          contentParts.push(delta.content)
+          const escaped = JSON.stringify(delta.content).slice(1, -1)
+          res.write(`data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"${escaped}"}\n\n`)
+        }
+      } catch {
+        // skip malformed SSE chunks
+      }
+    }
+  })
+
+  upstreamRes.on('end', () => {
+    const fullText = contentParts.join('')
+    const escapedFull = JSON.stringify(fullText).slice(1, -1)
+    res.write(`data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"${escapedFull}"}\n\n`)
+    res.write(`data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"${escapedFull}"}}\n\n`)
+    res.write(`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"${escapedFull}"}],"status":"completed"}}\n\n`)
+    res.write(`data: {"type":"response.completed","response":{"id":"${responseId}","object":"response","status":"completed","model":"${model}","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"${escapedFull}"}],"status":"completed"}]}}\n\n`)
+    res.end()
+  })
+
+  upstreamRes.on('error', () => {
+    if (!res.writableEnded) res.end()
+  })
+}
+
+export function handleZenProxyRequest(req: IncomingMessage, res: ServerResponse, bearerToken: string): void {
+  void (async () => {
+    try {
+      const body = await readRequestBody(req)
+      const parsed = JSON.parse(body.toString()) as ResponsesApiRequest
+      const isStreaming = parsed.stream === true
+      const messages = responsesInputToMessages(parsed.input, parsed.instructions)
+
+      const chatReq: ChatCompletionsRequest = {
+        model: parsed.model,
+        messages,
+        stream: isStreaming,
+      }
+      if (parsed.temperature != null) chatReq.temperature = parsed.temperature
+      if (parsed.top_p != null) chatReq.top_p = parsed.top_p
+      if (parsed.max_output_tokens != null) chatReq.max_tokens = parsed.max_output_tokens
+
+      const payload = JSON.stringify(chatReq)
+      const url = new URL(`${ZEN_UPSTREAM}/chat/completions`)
+
+      const proxyReq = httpsRequest({
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+          'Authorization': `Bearer ${bearerToken}`,
+        },
+      }, (upstreamRes) => {
+        if (isStreaming) {
+          forwardStreamingResponse(upstreamRes, res, parsed.model)
+          return
+        }
+
+        const chunks: Buffer[] = []
+        upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk))
+        upstreamRes.on('end', () => {
+          try {
+            const upstream = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+            if (upstream.error) {
+              res.writeHead(upstreamRes.statusCode ?? 500, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify(upstream))
+              return
+            }
+            const translated = chatCompletionToResponsesFormat(upstream, parsed.model)
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify(translated))
+          } catch {
+            res.writeHead(502, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: { message: 'Bad gateway: failed to parse upstream response' } }))
+          }
+        })
+      })
+
+      proxyReq.on('error', (error) => {
+        if (!res.headersSent) {
+          res.writeHead(502, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: { message: `Proxy error: ${error.message}` } }))
+        }
+      })
+
+      proxyReq.write(payload)
+      proxyReq.end()
+    } catch (error) {
+      if (!res.headersSent) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: { message } }))
+      }
+    }
+  })()
+}

--- a/src/server/zenProxy.ts
+++ b/src/server/zenProxy.ts
@@ -193,7 +193,9 @@ export function handleZenProxyRequest(req: IncomingMessage, res: ServerResponse,
           'Authorization': `Bearer ${bearerToken}`,
         },
       }, (upstreamRes) => {
-        if (isStreaming) {
+        const upstreamStatus = upstreamRes.statusCode ?? 500
+
+        if (isStreaming && upstreamStatus >= 200 && upstreamStatus < 300) {
           forwardStreamingResponse(upstreamRes, res, parsed.model)
           return
         }
@@ -201,10 +203,11 @@ export function handleZenProxyRequest(req: IncomingMessage, res: ServerResponse,
         const chunks: Buffer[] = []
         upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk))
         upstreamRes.on('end', () => {
+          const rawBody = Buffer.concat(chunks).toString()
           try {
-            const upstream = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
-            if (upstream.error) {
-              res.writeHead(upstreamRes.statusCode ?? 500, { 'Content-Type': 'application/json' })
+            const upstream = JSON.parse(rawBody) as Record<string, unknown>
+            if (upstream.error || upstreamStatus >= 400) {
+              res.writeHead(upstreamStatus, { 'Content-Type': 'application/json' })
               res.end(JSON.stringify(upstream))
               return
             }
@@ -212,8 +215,9 @@ export function handleZenProxyRequest(req: IncomingMessage, res: ServerResponse,
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify(translated))
           } catch {
-            res.writeHead(502, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify({ error: { message: 'Bad gateway: failed to parse upstream response' } }))
+            const detail = rawBody.slice(0, 500).trim()
+            res.writeHead(upstreamStatus >= 400 ? upstreamStatus : 502, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: { message: detail || 'Bad gateway: failed to parse upstream response' } }))
           }
         })
       })

--- a/tests.md
+++ b/tests.md
@@ -2426,3 +2426,30 @@ When switching providers, the model dropdown should only show models from the ne
 
 #### Rollback/Cleanup
 - No permanent changes needed
+
+---
+
+### Zen Proxy Port Resolution When Vite Auto-Increments
+
+#### Feature/Change Name
+When the default Vite port (5173) is occupied, the zen-proxy URL must use the actual listening port, not the configured default.
+
+#### Prerequisites/Setup
+1. Another process already occupying port 5173
+2. Dev server started (will auto-bind to 5174 or next available)
+3. OpenCode Zen provider configured with API key
+
+#### Steps
+1. Start any process on port 5173 (e.g., another dev server)
+2. Run `pnpm run dev` — Vite auto-binds to 5174
+3. Open the app at `http://localhost:5174`
+4. Switch to "OpenCode Zen" provider, enter API key, save
+5. Send a message using big-pickle or any OpenCode Zen model
+
+#### Expected Results
+- The zen-proxy request goes to `http://127.0.0.1:5174/codex-api/zen-proxy/v1/responses` (actual port)
+- No 404 errors referencing port 5173
+- Message receives a successful response from the model
+
+#### Rollback/Cleanup
+- Stop the extra process on port 5173 if it was started for testing

--- a/tests.md
+++ b/tests.md
@@ -2453,3 +2453,31 @@ When the default Vite port (5173) is occupied, the zen-proxy URL must use the ac
 
 #### Rollback/Cleanup
 - Stop the extra process on port 5173 if it was started for testing
+
+---
+
+### Model List Search / Filter
+
+#### Feature/Change Name
+Search/filter input in the model selection dropdown.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Any provider configured with available models
+
+#### Steps
+1. Open any thread or new-thread view
+2. Click the model selector button in the composer bar
+3. Observe the search input at the top of the dropdown
+4. Type a partial model name (e.g., "pickle")
+5. Observe filtered results
+
+#### Expected Results
+- A text input with placeholder "Search models..." appears at the top of the dropdown
+- Typing filters the model list to only matching models (case-insensitive, matches label or value)
+- Clearing the search shows all models again
+- Pressing Escape clears the search text first, then closes the dropdown on second press
+- "No results" shown when no models match the query
+
+#### Rollback/Cleanup
+- No permanent changes needed

--- a/tests.md
+++ b/tests.md
@@ -2399,3 +2399,30 @@ Use `env_key` instead of `experimental_bearer_token` for API key injection when 
 #### Rollback/Cleanup
 - Switch provider back to "Codex"
 - No permanent changes to `~/.codex/config.toml`
+
+---
+
+### Provider Switch Model List Isolation
+
+#### Feature/Change Name
+When switching providers, the model dropdown should only show models from the new provider — no stale models from the previous provider should leak into the list.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://localhost:5173`
+2. Access to at least two providers (e.g., "Codex" and "OpenRouter")
+
+#### Steps
+1. Open the app sidebar settings
+2. Select "OpenRouter" provider — model list should show OpenRouter free models (e.g., `openrouter/free`, `google/gemma-3-27b-it:free`)
+3. Select a model like `openrouter/free`
+4. Switch provider back to "Codex"
+5. Open the model dropdown
+
+#### Expected Results
+- Model list shows only Codex models (e.g., `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`)
+- No OpenRouter models (e.g., `openrouter/free`) appear in the list
+- Selected model auto-switches to the first Codex model
+- Switching back to OpenRouter shows only OpenRouter models again
+
+#### Rollback/Cleanup
+- No permanent changes needed

--- a/tests.md
+++ b/tests.md
@@ -2301,3 +2301,57 @@ Test Codex CLI with Big Pickle model via OpenCode Zen provider.
 - To restore latest Codex CLI: `npm install -g @openai/codex@latest`
 - Remove `[model_providers.opencode-zen]` and `[profiles.pickle]` from `~/.codex/config.toml`.
 - Remove API key from environment.
+
+---
+
+### OpenCode Zen Provider & Wire API Selector in codexui
+
+#### Feature/Change Name
+OpenCode Zen as built-in provider + API format selector for custom endpoints
+
+#### Prerequisites/Setup
+- Project built (`pnpm run build`)
+- Dev server running (`pnpm run dev`)
+- OpenCode Zen API key (from https://opencode.ai/auth)
+
+#### Step-by-Step Actions
+
+**Test 1: Select OpenCode Zen provider**
+1. Open the app in browser
+2. Click the provider dropdown in the sidebar settings
+3. Select "OpenCode Zen"
+4. Verify: An API key input field appears with "Get API key" link
+5. Enter a valid OpenCode Zen API key (sk-...)
+6. Click "Save"
+7. Verify: Provider is saved, model list fetches from OpenCode Zen `/models` endpoint
+8. Send a message — it should use `wire_api = "chat"` (Chat Completions API)
+
+**Test 2: Select Custom endpoint with API format selector**
+1. Select "Custom endpoint" from the provider dropdown
+2. Enter a custom base URL (e.g., `https://opencode.ai/zen/v1`)
+3. Enter an API key
+4. Verify: An "API format" dropdown appears with "Responses API" (default) and "Chat Completions"
+5. Select "Chat Completions"
+6. Click "Save"
+7. Verify: Provider is saved with `wireApi = "chat"`
+8. Refresh the page — verify the API format dropdown retains "Chat Completions"
+
+**Test 3: Provider persistence**
+1. Select "OpenCode Zen", enter key, save
+2. Refresh the page
+3. Verify: Provider dropdown shows "OpenCode Zen" (not "Codex" or "OpenRouter")
+
+**Test 4: Switch back to Codex**
+1. From OpenCode Zen, select "Codex" provider
+2. Verify: Free mode is disabled, standard Codex flow resumes
+
+#### Expected Results
+- OpenCode Zen appears in provider dropdown alongside Codex/OpenRouter/Custom
+- OpenCode Zen defaults to `wire_api = "chat"` (Chat Completions API)
+- Custom endpoints show an API format selector; default is "Responses API"
+- Provider selection and wireApi are persisted in `~/.codex/webui-free-mode.json`
+- Model list for OpenCode Zen is fetched from `https://opencode.ai/zen/v1/models`
+
+#### Rollback/Cleanup
+- Switch provider back to "Codex" to disable free mode
+- No config files outside the project are modified (state stored in `~/.codex/webui-free-mode.json`)

--- a/tests.md
+++ b/tests.md
@@ -2355,3 +2355,47 @@ OpenCode Zen as built-in provider + API format selector for custom endpoints
 #### Rollback/Cleanup
 - Switch provider back to "Codex" to disable free mode
 - No config files outside the project are modified (state stored in `~/.codex/webui-free-mode.json`)
+
+### env_key Authentication for Custom Providers (codex CLI v0.93.0)
+
+#### Feature/Change
+Use `env_key` instead of `experimental_bearer_token` for API key injection when spawning the codex `app-server` subprocess. API keys are passed as environment variables to the subprocess rather than CLI config arguments.
+
+#### Prerequisites/Setup
+- codex CLI v0.93.0 installed
+- Dev server running (`pnpm run dev`)
+- OpenCode Zen API key: any valid key from opencode.ai
+
+#### Step-by-Step Actions
+
+**Test 1: OpenCode Zen with big-pickle model**
+1. Open Settings, select "OpenCode Zen" provider
+2. Enter a valid API key, save
+3. In the model dropdown, select `big-pickle`
+4. Type "say SUCCESSTEST in one word" and click Send
+5. Wait for response (typically 3-5 seconds)
+6. Verify: AI responds with "SUCCESSTEST"
+
+**Test 2: Verify env var is set on subprocess**
+1. After step 1-2 above, run: `ps -p $(pgrep -f "codex app-server" | tail -1) -E | tr ' ' '\n' | grep OPENCODE`
+2. Verify: `OPENCODE_ZEN_API_KEY=sk-...` appears in the process environment
+
+**Test 3: Model mismatch causes 401 (expected)**
+1. With OpenCode Zen provider active, select a paid model like `gpt-5.4-mini`
+2. Send a message
+3. Verify: 401 Unauthorized error appears (OpenCode Zen returns 401 for paid models without billing)
+4. Switch to `big-pickle` and retry — should succeed
+
+**Test 4: wire_api deprecation awareness**
+1. Run: `OPENCODE_ZEN_API_KEY="<key>" codex -c 'model_providers.oz.wire_api="chat"' -c 'model_providers.oz.base_url="https://opencode.ai/zen/v1"' -c 'model_providers.oz.env_key="OPENCODE_ZEN_API_KEY"' -c 'model_provider="oz"' -m big-pickle exec "say hi"`
+2. Verify: Warning about `wire_api="chat"` being deprecated appears, but command succeeds
+
+#### Expected Results
+- API key is passed via `OPENCODE_ZEN_API_KEY` env var (not `experimental_bearer_token`)
+- `big-pickle` model works and returns responses
+- Paid models return 401 (billing-related, not auth-related)
+- `wire_api="chat"` still works but shows deprecation warning
+
+#### Rollback/Cleanup
+- Switch provider back to "Codex"
+- No permanent changes to `~/.codex/config.toml`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
     {
       name: "codex-bridge",
       configureServer(server) {
+        process.env.CODEXUI_SERVER_PORT = String(server.config.server.port ?? 5173);
         const bridge = createCodexBridgeMiddleware();
         const httpServer = server.httpServer;
         if (httpServer) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -132,6 +132,12 @@ export default defineConfig({
         const bridge = createCodexBridgeMiddleware();
         const httpServer = server.httpServer;
         if (httpServer) {
+          httpServer.once("listening", () => {
+            const addr = httpServer.address();
+            if (addr && typeof addr === "object" && addr.port) {
+              process.env.CODEXUI_SERVER_PORT = String(addr.port);
+            }
+          });
           const hostScope = httpServer as typeof httpServer & {
             [WS_UPGRADE_ATTACHED_KEY]?: boolean;
           };


### PR DESCRIPTION
## Summary
- Add OpenCode Zen as a first-class provider with API key management
- Implement a responses-to-chat-completions proxy (`zenProxy.ts`) that translates the Codex CLI's Responses API calls to Chat Completions API calls for OpenCode Zen
- Fix provider switching: model lists now properly refresh and isolate per-provider, preventing stale model leakage across providers
- Fix new-thread model context to correctly reset when providers are switched
- Fix Vite port auto-increment: zen-proxy URL now uses the actual listening port instead of the configured default (5173)
- Sort free models first in the OpenCode Zen model dropdown
- Show actual error bodies instead of generic "401 Unauthorized" messages

## Changes
- `src/server/zenProxy.ts` — new proxy that converts Responses API → Chat Completions API
- `src/server/freeMode.ts` — OpenCode Zen provider config, env vars, CLI args
- `src/server/codexAppServerBridge.ts` — zen-proxy route handler, provider-models endpoint improvements
- `src/App.vue` — OpenCode Zen provider selection, API key management, wire API selector
- `src/composables/useDesktopState.ts` — model list isolation on provider switch, new-thread context reset
- `src/api/codexGateway.ts` — provider-models fetching for custom providers
- `vite.config.ts` — fix port resolution using httpServer.address() on listening event

## Test plan
- [x] Switch to OpenCode Zen → enter API key → save → model list shows Zen models (free first)
- [x] Select big-pickle → create new thread → send "hi" → receive valid response
- [x] Switch to Codex → model list shows only Codex models (no stale Zen models)
- [x] Switch back to OpenCode Zen → models update correctly
- [x] New threads auto-select correct model for active provider
- [x] When Vite auto-increments port (e.g. 5173→5174), zen-proxy requests hit the correct port
- [x] Verified with Playwright automation and direct curl tests


Made with [Cursor](https://cursor.com)