### PR TITLE
Improve local file link validation and add inline text file preview/edit UX

### DIFF
--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -161,6 +161,12 @@ export type LocalDirectoryListing = {
   entries: LocalDirectoryEntry[]
 }
 
+export type LocalPathProbeEntry = {
+  path: string
+  exists: boolean
+  isDirectory: boolean
+}
+
 function normalizeGithubProjectDescription(fullName: string, rawDescription: string): string {
   const description = rawDescription.trim()
   if (!description) return ''
@@ -1644,6 +1650,49 @@ export async function listLocalDirectories(path: string, options?: { showHidden?
       return name && entryPath ? [{ name, path: entryPath }] : []
     }),
   }
+}
+
+export async function probeLocalPaths(paths: string[]): Promise<LocalPathProbeEntry[]> {
+  const normalizedPaths = Array.from(new Set(
+    paths
+      .map((pathValue) => normalizePathForUi(pathValue).trim())
+      .filter((pathValue) => pathValue.length > 0),
+  ))
+
+  if (normalizedPaths.length === 0) return []
+
+  const response = await fetch('/codex-api/local-paths/probe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ paths: normalizedPaths }),
+  })
+  const payload = await readJsonResponse(response)
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to probe local paths')
+    throw new Error(message)
+  }
+
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  const entriesRaw = Array.isArray(data.entries) ? data.entries : []
+
+  return entriesRaw.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+    const entry = item as Record<string, unknown>
+    const path = typeof entry.path === 'string' ? normalizePathForUi(entry.path) : ''
+    if (!path) return []
+    return [{
+      path,
+      exists: entry.exists === true,
+      isDirectory: entry.isDirectory === true,
+    }]
+  })
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -299,16 +299,19 @@
                         <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                         <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                        <a
-                          v-else-if="segment.kind === 'file'"
-                          class="message-file-link"
-                          :href="toBrowseUrl(segment.path)"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          :title="segment.path"
-                        >
-                          {{ segment.displayPath }}
-                        </a>
+                        <template v-else-if="segment.kind === 'file'">
+                          <a
+                            v-if="confirmedBrowseUrl(segment.path)"
+                            class="message-file-link"
+                            :href="confirmedBrowseUrl(segment.path)"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            :title="segment.path"
+                          >
+                            {{ segment.displayPath }}
+                          </a>
+                          <span v-else>{{ segment.fallbackText }}</span>
+                        </template>
                         <a
                           v-else-if="segment.kind === 'url'"
                           class="message-file-link"
@@ -333,16 +336,19 @@
                         <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                         <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                        <a
-                          v-else-if="segment.kind === 'file'"
-                          class="message-file-link"
-                          :href="toBrowseUrl(segment.path)"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          :title="segment.path"
-                        >
-                          {{ segment.displayPath }}
-                        </a>
+                        <template v-else-if="segment.kind === 'file'">
+                          <a
+                            v-if="confirmedBrowseUrl(segment.path)"
+                            class="message-file-link"
+                            :href="confirmedBrowseUrl(segment.path)"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            :title="segment.path"
+                          >
+                            {{ segment.displayPath }}
+                          </a>
+                          <span v-else>{{ segment.fallbackText }}</span>
+                        </template>
                         <a
                           v-else-if="segment.kind === 'url'"
                           class="message-file-link"
@@ -362,16 +368,19 @@
                         <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                         <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                        <a
-                          v-else-if="segment.kind === 'file'"
-                          class="message-file-link"
-                          :href="toBrowseUrl(segment.path)"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          :title="segment.path"
-                        >
-                          {{ segment.displayPath }}
-                        </a>
+                        <template v-else-if="segment.kind === 'file'">
+                          <a
+                            v-if="confirmedBrowseUrl(segment.path)"
+                            class="message-file-link"
+                            :href="confirmedBrowseUrl(segment.path)"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            :title="segment.path"
+                          >
+                            {{ segment.displayPath }}
+                          </a>
+                          <span v-else>{{ segment.fallbackText }}</span>
+                        </template>
                         <a
                           v-else-if="segment.kind === 'url'"
                           class="message-file-link"
@@ -399,16 +408,19 @@
                             <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                             <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                             <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                            <a
-                              v-else-if="segment.kind === 'file'"
-                              class="message-file-link"
-                              :href="toBrowseUrl(segment.path)"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              :title="segment.path"
-                            >
-                              {{ segment.displayPath }}
-                            </a>
+                            <template v-else-if="segment.kind === 'file'">
+                              <a
+                                v-if="confirmedBrowseUrl(segment.path)"
+                                class="message-file-link"
+                                :href="confirmedBrowseUrl(segment.path)"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                :title="segment.path"
+                              >
+                                {{ segment.displayPath }}
+                              </a>
+                              <span v-else>{{ segment.fallbackText }}</span>
+                            </template>
                             <a
                               v-else-if="segment.kind === 'url'"
                               class="message-file-link"
@@ -448,16 +460,19 @@
                                 <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                                 <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                                 <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                                <a
-                                  v-else-if="segment.kind === 'file'"
-                                  class="message-file-link"
-                                  :href="toBrowseUrl(segment.path)"
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  :title="segment.path"
-                                >
-                                  {{ segment.displayPath }}
-                                </a>
+                                <template v-else-if="segment.kind === 'file'">
+                                  <a
+                                    v-if="confirmedBrowseUrl(segment.path)"
+                                    class="message-file-link"
+                                    :href="confirmedBrowseUrl(segment.path)"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    :title="segment.path"
+                                  >
+                                    {{ segment.displayPath }}
+                                  </a>
+                                  <span v-else>{{ segment.fallbackText }}</span>
+                                </template>
                                 <a
                                   v-else-if="segment.kind === 'url'"
                                   class="message-file-link"
@@ -486,16 +501,19 @@
                                 <strong v-else-if="segment.kind === 'bold'" class="message-bold-text">{{ segment.value }}</strong>
                                 <em v-else-if="segment.kind === 'italic'" class="message-italic-text">{{ segment.value }}</em>
                                 <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
-                                <a
-                                  v-else-if="segment.kind === 'file'"
-                                  class="message-file-link"
-                                  :href="toBrowseUrl(segment.path)"
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  :title="segment.path"
-                                >
-                                  {{ segment.displayPath }}
-                                </a>
+                                <template v-else-if="segment.kind === 'file'">
+                                  <a
+                                    v-if="confirmedBrowseUrl(segment.path)"
+                                    class="message-file-link"
+                                    :href="confirmedBrowseUrl(segment.path)"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    :title="segment.path"
+                                  >
+                                    {{ segment.displayPath }}
+                                  </a>
+                                  <span v-else>{{ segment.fallbackText }}</span>
+                                </template>
                                 <a
                                   v-else-if="segment.kind === 'url'"
                                   class="message-file-link"
@@ -832,6 +850,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { probeLocalPaths } from '../../api/codexGateway'
 import type { ThreadScrollState, UiFileChange, UiLiveOverlay, UiMessage, UiPlanStep, UiServerRequest } from '../../types/codex'
 import { useMobile } from '../../composables/useMobile'
 
@@ -857,6 +876,7 @@ const fileLinkContextMenuX = ref(0)
 const fileLinkContextMenuY = ref(0)
 const fileLinkContextBrowseUrl = ref('')
 const fileLinkContextEditUrl = ref('')
+const localPathProbeResults = ref<Record<string, boolean>>({})
 const { isMobile } = useMobile()
 
 function parsePlanFromMessageText(text: string): { explanation: string; steps: UiPlanStep[] } | null {
@@ -1219,7 +1239,7 @@ type InlineSegment =
   | { kind: 'strikethrough'; value: string }
   | { kind: 'code'; value: string }
   | { kind: 'url'; value: string; href: string }
-  | { kind: 'file'; value: string; path: string; displayPath: string; downloadName: string }
+  | { kind: 'file'; value: string; path: string; displayPath: string; fallbackText: string; downloadName: string }
 type TaskListItem = {
   text: string
   checked: boolean
@@ -1249,10 +1269,14 @@ const trackedPendingImages = new WeakSet<HTMLImageElement>()
 const failedMarkdownImageKeys = ref<Set<string>>(new Set())
 const highlightJsModule = ref<HighlightJsModule | null>(null)
 let highlightJsLoader: Promise<void> | null = null
+const localPathProbeTimestamps = new Map<string, number>()
+const pendingLocalPathProbes = new Set<string>()
+let localPathProbeGeneration = 0
 
 const RENDER_WINDOW_SIZE = 50
 const LOAD_MORE_CHUNK = 30
 const LOAD_MORE_SCROLL_THRESHOLD_PX = 200
+const LOCAL_PATH_PROBE_TTL_MS = 15_000
 
 const renderWindowStart = ref(0)
 const isLoadingMore = ref(false)
@@ -2150,6 +2174,7 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
           value: token,
           path: ref.path,
           displayPath: token,
+          fallbackText: token,
           downloadName: getBasename(ref.path),
         })
         if (trailing) {
@@ -2265,6 +2290,14 @@ function applyInlineMarkdownMarkers(segments: InlineSegment[]): InlineSegment[] 
   return next
 }
 
+function fileLinkFallbackText(displayPath: string, originalTarget: string): string {
+  const normalizedDisplayPath = displayPath.trim()
+  const normalizedTarget = originalTarget.trim()
+  if (!normalizedDisplayPath) return normalizedTarget
+  if (!normalizedTarget || normalizedDisplayPath === normalizedTarget) return normalizedDisplayPath
+  return `${normalizedDisplayPath} (${normalizedTarget})`
+}
+
 function splitTextByFileUrls(text: string): InlineSegment[] {
   const segments: InlineSegment[] = []
   let cursor = 0
@@ -2339,11 +2372,13 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     } else {
       const ref = parseFileReference(target)
       if (ref) {
+        const displayPath = label || target
         segments.push({
           kind: 'file',
           value: target,
           path: ref.path,
-          displayPath: label || target,
+          displayPath,
+          fallbackText: fileLinkFallbackText(displayPath, target),
           downloadName: getBasename(ref.path),
         })
       } else {
@@ -2428,11 +2463,13 @@ function parseInlineSegments(text: string): InlineSegment[] {
         } else {
           const markdownFileReference = parseFileReference(markdownLink.target)
           if (markdownFileReference) {
+            const displayPath = markdownLink.label || markdownLink.target
             segments.push({
               kind: 'file',
               value: markdownLink.target,
               path: markdownFileReference.path,
-              displayPath: markdownLink.label || markdownLink.target,
+              displayPath,
+              fallbackText: fileLinkFallbackText(displayPath, markdownLink.target),
               downloadName: getBasename(markdownFileReference.path),
             })
           } else {
@@ -2456,6 +2493,7 @@ function parseInlineSegments(text: string): InlineSegment[] {
             value: token,
             path: fileReference.path,
             displayPath,
+            fallbackText: displayPath,
             downloadName: getBasename(fileReference.path),
           })
         } else {
@@ -2475,6 +2513,20 @@ function parseInlineSegments(text: string): InlineSegment[] {
   }
 
   return segments
+}
+
+function resolveAbsoluteLocalPath(pathValue: string): string {
+  const normalized = pathValue.trim()
+  if (!normalized) return ''
+
+  const parsed = parseFileReference(normalized)
+  const candidatePath = parsed?.path ?? normalized
+  const resolved = normalizePathDots(normalizePathSeparators(resolveRelativePath(candidatePath, props.cwd)))
+  if (!resolved) return ''
+  if (resolved.startsWith('/') || /^[A-Za-z]:\//u.test(resolved)) {
+    return resolved
+  }
+  return ''
 }
 
 function toRenderableImageUrl(value: string): string {
@@ -2504,22 +2556,19 @@ function toRenderableImageUrl(value: string): string {
 }
 
 function toBrowseUrl(pathValue: string): string {
-  const normalized = pathValue.trim()
-  if (!normalized) return '#'
-  const looksLikeAbsolutePath = (candidate: string): boolean => (
-    candidate.startsWith('/') || /^[A-Za-z]:[\\/]/u.test(candidate)
-  )
-
-  const parsed = parseFileReference(normalized)
-  const candidatePath = parsed?.path ?? normalized
-  const resolved = resolveRelativePath(candidatePath, props.cwd)
-
-  if (looksLikeAbsolutePath(resolved)) {
+  const resolved = resolveAbsoluteLocalPath(pathValue)
+  if (resolved) {
     const normalizedResolved = resolved.startsWith('/') ? resolved : `/${resolved}`
     return `/codex-local-browse${encodeURI(normalizedResolved)}`
   }
-
   return '#'
+}
+
+function confirmedBrowseUrl(pathValue: string): string {
+  const resolved = resolveAbsoluteLocalPath(pathValue)
+  if (!resolved || localPathProbeResults.value[resolved] !== true) return ''
+  const normalizedResolved = resolved.startsWith('/') ? resolved : `/${resolved}`
+  return `/codex-local-browse${encodeURI(normalizedResolved)}`
 }
 
 const fileLinkContextMenuStyle = computed(() => ({
@@ -3221,6 +3270,129 @@ function parseMessageBlocks(text: string): MessageBlock[] {
   return blocks.length > 0 ? blocks : [{ kind: 'paragraph', value: text }]
 }
 
+function collectInlineLocalPathCandidates(text: string, output: Set<string>): void {
+  for (const segment of parseInlineSegments(text)) {
+    if (segment.kind !== 'file') continue
+    const resolved = resolveAbsoluteLocalPath(segment.path)
+    if (resolved) output.add(resolved)
+  }
+}
+
+function collectLocalPathCandidatesFromListItem(item: ListItem, output: Set<string>): void {
+  for (const paragraph of item.paragraphs) {
+    collectInlineLocalPathCandidates(paragraph, output)
+  }
+  for (const child of item.children ?? []) {
+    collectLocalPathCandidatesFromBlock(child, output)
+  }
+}
+
+function collectLocalPathCandidatesFromBlock(block: MessageBlock, output: Set<string>): void {
+  if (block.kind === 'paragraph' || block.kind === 'heading' || block.kind === 'blockquote') {
+    collectInlineLocalPathCandidates(block.value, output)
+    return
+  }
+  if (block.kind === 'unorderedList' || block.kind === 'orderedList') {
+    for (const item of block.items) {
+      collectLocalPathCandidatesFromListItem(item, output)
+    }
+    return
+  }
+  if (block.kind === 'taskList') {
+    for (const item of block.items) {
+      collectInlineLocalPathCandidates(item.text, output)
+    }
+    return
+  }
+  if (block.kind === 'table') {
+    for (const header of block.headers) {
+      collectInlineLocalPathCandidates(header, output)
+    }
+    for (const row of block.rows) {
+      for (const cell of row) {
+        collectInlineLocalPathCandidates(cell, output)
+      }
+    }
+  }
+}
+
+function collectLocalPathCandidatesFromMessage(message: UiMessage, output: Set<string>): void {
+  const collectRenderedText = (text: string): void => {
+    if (!text.trim()) return
+    for (const block of parseMessageBlocks(text)) {
+      collectLocalPathCandidatesFromBlock(block, output)
+    }
+  }
+
+  if (isPlanMessage(message)) {
+    const explanation = readPlanExplanation(message)
+    const steps = readPlanSteps(message)
+    if (explanation) collectRenderedText(explanation)
+    if (steps.length > 0) {
+      for (const step of steps) {
+        if (step.step) collectRenderedText(step.step)
+      }
+      return
+    }
+    collectRenderedText(message.text)
+    return
+  }
+
+  collectRenderedText(message.text)
+}
+
+const visibleInlineLocalPathCandidates = computed(() => {
+  const next = new Set<string>()
+  for (const message of visibleMessages.value) {
+    collectLocalPathCandidatesFromMessage(message, next)
+  }
+  return Array.from(next)
+})
+
+async function ensureLocalPathProbeResults(paths: string[]): Promise<void> {
+  const generation = localPathProbeGeneration
+  const now = Date.now()
+  const pathsToProbe = paths.filter((pathValue) => {
+    if (pendingLocalPathProbes.has(pathValue)) return false
+    const lastProbedAt = localPathProbeTimestamps.get(pathValue) ?? 0
+    return (now - lastProbedAt) > LOCAL_PATH_PROBE_TTL_MS
+  })
+
+  if (pathsToProbe.length === 0) return
+
+  for (const pathValue of pathsToProbe) {
+    pendingLocalPathProbes.add(pathValue)
+  }
+
+  try {
+    const entries = await probeLocalPaths(pathsToProbe)
+    if (generation !== localPathProbeGeneration) return
+
+    const nextResults = { ...localPathProbeResults.value }
+    const seen = new Set<string>()
+    const probedAt = Date.now()
+    for (const entry of entries) {
+      nextResults[entry.path] = entry.exists
+      localPathProbeTimestamps.set(entry.path, probedAt)
+      seen.add(entry.path)
+    }
+
+    for (const pathValue of pathsToProbe) {
+      if (seen.has(pathValue)) continue
+      nextResults[pathValue] = false
+      localPathProbeTimestamps.set(pathValue, probedAt)
+    }
+
+    localPathProbeResults.value = nextResults
+  } catch {
+    // Leave unresolved paths as plain text if probing fails.
+  } finally {
+    for (const pathValue of pathsToProbe) {
+      pendingLocalPathProbes.delete(pathValue)
+    }
+  }
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/gu, '&amp;')
@@ -3272,7 +3444,11 @@ function renderInlineSegmentsAsHtml(text: string): string {
         return `<s class="message-strikethrough-text">${escapeHtml(segment.value)}</s>`
       }
       if (segment.kind === 'file') {
-        return `<a class="message-file-link" href="${escapeHtml(toBrowseUrl(segment.path))}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(segment.path)}">${escapeHtml(segment.displayPath)}</a>`
+        const browseUrl = confirmedBrowseUrl(segment.path)
+        if (!browseUrl) {
+          return escapeHtml(segment.fallbackText)
+        }
+        return `<a class="message-file-link" href="${escapeHtml(browseUrl)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(segment.path)}">${escapeHtml(segment.displayPath)}</a>`
       }
       if (segment.kind === 'url') {
         return `<a class="message-file-link" href="${escapeHtml(segment.href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(segment.href)}">${escapeHtml(segment.value)}</a>`
@@ -3970,6 +4146,14 @@ watch(
 )
 
 watch(
+  visibleInlineLocalPathCandidates,
+  (paths) => {
+    void ensureLocalPathProbeResults(paths)
+  },
+  { immediate: true },
+)
+
+watch(
   activeCommandMessageId,
   (nextId, prevId) => {
     if (!prevId || prevId === nextId) return
@@ -4017,6 +4201,10 @@ watch(
     autoFollowOutput.value = true
     modalImageUrl.value = ''
     isLoadingMore.value = false
+    localPathProbeGeneration += 1
+    localPathProbeResults.value = {}
+    localPathProbeTimestamps.clear()
+    pendingLocalPathProbes.clear()
     // Apply immediately for cached threads where isLoading never toggles.
     renderWindowStart.value = Math.max(0, props.messages.length - RENDER_WINDOW_SIZE)
   },

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -1,12 +1,22 @@
 import { fileURLToPath } from 'node:url'
-import { dirname, extname, isAbsolute, join } from 'node:path'
+import { basename, dirname, extname, isAbsolute, join } from 'node:path'
 import type { Server as HttpServer, IncomingMessage } from 'node:http'
 import { existsSync } from 'node:fs'
 import { writeFile, stat } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
 import express, { type Express } from 'express'
 import { createCodexBridgeMiddleware } from './codexAppServerBridge.js'
 import { createAuthSession } from './authMiddleware.js'
-import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from './localBrowseUi.js'
+import {
+  createDirectoryListingHtml,
+  createTextEditorHtml,
+  createTextPreviewHtml,
+  decodeBrowsePath,
+  getLocalDirectoryListing,
+  getLocalTextFileMetadata,
+  isTextEditableFile,
+  normalizeLocalPath,
+} from './localBrowseUi.js'
 import { WebSocketServer, type WebSocket } from 'ws'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -72,6 +82,41 @@ function readWildcardPathParam(value: unknown): string {
   return ''
 }
 
+function readBooleanQueryFlag(value: unknown): boolean {
+  return typeof value === 'string' && ['1', 'true', 'yes', 'on'].includes(value.toLowerCase())
+}
+
+function localFileErrorResponse(error: unknown): { status: number, body: { error: string } } {
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : ''
+  const statusCode = typeof error === 'object' && error !== null && 'statusCode' in error
+    ? Number((error as { statusCode?: unknown }).statusCode)
+    : NaN
+
+  if (code === 'ENOENT' || statusCode === 404) {
+    return { status: 404, body: { error: 'File not found.' } }
+  }
+  if (code === 'EACCES' || code === 'EPERM' || statusCode === 403) {
+    return { status: 403, body: { error: 'Access denied.' } }
+  }
+  return { status: 500, body: { error: 'Failed to read file.' } }
+}
+
+function sendLocalFileJsonError(
+  res: express.Response,
+  error: unknown,
+): void {
+  if (res.headersSent) return
+  const response = localFileErrorResponse(error)
+  res.status(response.status).json(response.body)
+}
+
+function attachmentContentDisposition(pathValue: string): string {
+  const fileName = basename(pathValue).replace(/["\\]/gu, '_')
+  return `attachment; filename="${fileName}"`
+}
+
 export function createServer(options: ServerOptions = {}): ServerInstance {
   const app = express()
   const bridge = createCodexBridgeMiddleware()
@@ -108,24 +153,104 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     })
   })
 
-  // 4. Serve local files inline for direct file open.
-  app.get('/codex-local-file', (req, res) => {
+  // 4. Probe local paths so the client only linkifies paths that exist on the server.
+  app.post('/codex-api/local-paths/probe', express.json({ limit: '64kb' }), async (req, res) => {
+    const body = req.body && typeof req.body === 'object' && !Array.isArray(req.body)
+      ? (req.body as Record<string, unknown>)
+      : {}
+    const rawPaths = Array.isArray(body.paths) ? body.paths : []
+    const normalizedPaths: string[] = []
+    const seen = new Set<string>()
+
+    for (const candidate of rawPaths.slice(0, 200)) {
+      if (typeof candidate !== 'string') continue
+      const normalized = normalizeLocalPath(candidate)
+      if (!normalized || seen.has(normalized)) continue
+      seen.add(normalized)
+      normalizedPaths.push(normalized)
+    }
+
+    const entries = await Promise.all(normalizedPaths.map(async (pathValue) => {
+      if (!isAbsolute(pathValue)) {
+        return {
+          path: pathValue,
+          exists: false,
+          isDirectory: false,
+        }
+      }
+
+      try {
+        const fileStat = await stat(pathValue)
+        return {
+          path: pathValue,
+          exists: true,
+          isDirectory: fileStat.isDirectory(),
+        }
+      } catch {
+        return {
+          path: pathValue,
+          exists: false,
+          isDirectory: false,
+        }
+      }
+    }))
+
+    res.status(200).json({ data: { entries } })
+  })
+
+  // 5. Serve local files inline or as forced downloads.
+  app.get('/codex-local-file', async (req, res) => {
     const rawPath = typeof req.query.path === 'string' ? req.query.path : ''
     const localPath = normalizeLocalPath(rawPath)
+    const wantsDownload = readBooleanQueryFlag(req.query.download)
     if (!localPath || !isAbsolute(localPath)) {
       res.status(400).json({ error: 'Expected absolute local file path.' })
       return
     }
 
-    res.setHeader('Cache-Control', 'private, no-store')
-    res.setHeader('Content-Disposition', 'inline')
-    res.sendFile(localPath, { dotfiles: 'allow' }, (error) => {
-      if (!error) return
-      if (!res.headersSent) res.status(404).json({ error: 'File not found.' })
-    })
+    try {
+      const fileStat = await stat(localPath)
+      if (!fileStat.isFile()) {
+        res.status(400).json({ error: 'Expected file path.' })
+        return
+      }
+
+      const textMetadata = await getLocalTextFileMetadata(localPath)
+      res.setHeader('Cache-Control', 'private, no-store')
+
+      if (wantsDownload) {
+        res.setHeader('Content-Disposition', attachmentContentDisposition(localPath))
+        res.sendFile(localPath, { dotfiles: 'allow' }, (error) => {
+          if (!error) return
+          sendLocalFileJsonError(res, error)
+        })
+        return
+      }
+
+      if (textMetadata) {
+        const stream = createReadStream(localPath, { encoding: 'utf8' })
+        stream.on('open', () => {
+          res.status(200).type('text/plain; charset=utf-8')
+        })
+        stream.on('error', (error) => {
+          stream.destroy()
+          sendLocalFileJsonError(res, error)
+        })
+        stream.pipe(res)
+        return
+      }
+
+      res.setHeader('Content-Disposition', 'inline')
+      res.sendFile(localPath, { dotfiles: 'allow' }, (error) => {
+        if (!error) return
+        sendLocalFileJsonError(res, error)
+      })
+    } catch (error) {
+      sendLocalFileJsonError(res, error)
+    }
   })
 
-  // 5. Return JSON directory listings for the integrated folder picker.
+  // 6. Return JSON directory listings for the integrated folder picker.
   app.get('/codex-local-directories', async (req, res) => {
     const rawPath = typeof req.query.path === 'string' ? req.query.path : ''
     const showHidden = typeof req.query.showHidden === 'string'
@@ -149,7 +274,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     }
   })
 
-  // 6. Serve local files by path to preserve relative asset loading for HTML.
+  // 7. Serve local files by path with directory listings and text previews.
   app.get('/codex-local-browse/*path', async (req, res) => {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
@@ -168,6 +293,14 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
         return
       }
 
+      const textMetadata = await getLocalTextFileMetadata(localPath)
+      if (textMetadata) {
+        const html = await createTextPreviewHtml(localPath, { newProjectName })
+        res.status(200).type('text/html; charset=utf-8').send(html)
+        return
+      }
+
+      res.setHeader('Content-Disposition', 'attachment')
       res.sendFile(localPath, { dotfiles: 'allow' }, (error) => {
         if (!error) return
         if (!res.headersSent) res.status(404).json({ error: 'File not found.' })
@@ -177,10 +310,11 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     }
   })
 
-  // 7. Edit text-like local files.
+  // 8. Edit text-like local files.
   app.get('/codex-local-edit/*path', async (req, res) => {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
+    const newProjectName = typeof req.query.newProjectName === 'string' ? req.query.newProjectName : ''
     if (!localPath || !isAbsolute(localPath)) {
       res.status(400).json({ error: 'Expected absolute local file path.' })
       return
@@ -191,7 +325,11 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
         res.status(400).json({ error: 'Expected file path.' })
         return
       }
-      const html = await createTextEditorHtml(localPath)
+      if (!(await isTextEditableFile(localPath))) {
+        res.status(415).json({ error: 'Only text-like files are editable.' })
+        return
+      }
+      const html = await createTextEditorHtml(localPath, { newProjectName })
       res.status(200).type('text/html; charset=utf-8').send(html)
     } catch {
       res.status(404).json({ error: 'File not found.' })
@@ -220,12 +358,12 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
 
   const hasFrontendAssets = existsSync(spaEntryFile)
 
-  // 8. Static files from Vue build
+  // 9. Static files from Vue build
   if (hasFrontendAssets) {
     app.use(express.static(distDir))
   }
 
-  // 9. SPA fallback
+  // 10. SPA fallback
   app.use((_req, res) => {
     if (!hasFrontendAssets) {
       res

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -1,4 +1,4 @@
-import { dirname, extname, join } from 'node:path'
+import { basename, dirname, extname, join } from 'node:path'
 import { open, readFile, readdir, stat } from 'node:fs/promises'
 
 type DirectoryItem = {
@@ -24,36 +24,106 @@ type LocalDirectoryListingOptions = {
   showHidden?: boolean
 }
 
-const TEXT_EDITABLE_EXTENSIONS = new Set([
-  '.txt', '.md', '.json', '.js', '.ts', '.tsx', '.jsx', '.css', '.scss',
-  '.html', '.htm', '.xml', '.yml', '.yaml', '.log', '.csv', '.env', '.py',
-  '.sh', '.toml', '.ini', '.conf', '.sql', '.bat', '.cmd', '.ps1',
+type LocalFileLanguageConfig = {
+  label: string
+  aceMode: string
+}
+
+type LocalTextFileMetadata = {
+  language: LocalFileLanguageConfig
+  sizeBytes: number
+}
+
+const TEXT_LANGUAGE: LocalFileLanguageConfig = {
+  label: 'text',
+  aceMode: 'text',
+}
+
+const BAZEL_LANGUAGE: LocalFileLanguageConfig = {
+  label: 'bazel',
+  aceMode: 'python',
+}
+
+const FILE_LANGUAGE_RULES_BY_NAME = new Map<string, LocalFileLanguageConfig>([
+  ['build', BAZEL_LANGUAGE],
+  ['build.bazel', BAZEL_LANGUAGE],
+  ['workspace', BAZEL_LANGUAGE],
+  ['workspace.bazel', BAZEL_LANGUAGE],
+  ['module.bazel', BAZEL_LANGUAGE],
+  ['.bazelrc', BAZEL_LANGUAGE],
+  ['.env', TEXT_LANGUAGE],
+  ['.gitignore', TEXT_LANGUAGE],
+  ['.npmrc', TEXT_LANGUAGE],
 ])
 
-function languageForPath(pathValue: string): string {
-  const extension = extname(pathValue).toLowerCase()
-  switch (extension) {
-    case '.js': return 'javascript'
-    case '.ts': return 'typescript'
-    case '.jsx': return 'javascript'
-    case '.tsx': return 'typescript'
-    case '.py': return 'python'
-    case '.sh': return 'sh'
-    case '.css':
-    case '.scss': return 'css'
-    case '.html':
-    case '.htm': return 'html'
-    case '.json': return 'json'
-    case '.md': return 'markdown'
-    case '.yaml':
-    case '.yml': return 'yaml'
-    case '.xml': return 'xml'
-    case '.sql': return 'sql'
-    case '.toml': return 'ini'
-    case '.ini':
-    case '.conf': return 'ini'
-    default: return 'plaintext'
+const FILE_LANGUAGE_RULES_BY_EXTENSION = new Map<string, LocalFileLanguageConfig>([
+  ['.txt', TEXT_LANGUAGE],
+  ['.log', TEXT_LANGUAGE],
+  ['.csv', TEXT_LANGUAGE],
+  ['.md', { label: 'markdown', aceMode: 'markdown' }],
+  ['.markdown', { label: 'markdown', aceMode: 'markdown' }],
+  ['.json', { label: 'json', aceMode: 'json' }],
+  ['.jsonc', { label: 'json', aceMode: 'json' }],
+  ['.yaml', { label: 'yaml', aceMode: 'yaml' }],
+  ['.yml', { label: 'yaml', aceMode: 'yaml' }],
+  ['.lua', { label: 'lua', aceMode: 'lua' }],
+  ['.rs', { label: 'rust', aceMode: 'rust' }],
+  ['.py', { label: 'python', aceMode: 'python' }],
+  ['.c', { label: 'c', aceMode: 'c_cpp' }],
+  ['.h', { label: 'c/c++', aceMode: 'c_cpp' }],
+  ['.cpp', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.cc', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.cxx', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.hpp', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.hh', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.hxx', { label: 'c++', aceMode: 'c_cpp' }],
+  ['.toml', { label: 'toml', aceMode: 'toml' }],
+  ['.bzl', BAZEL_LANGUAGE],
+  ['.bazel', BAZEL_LANGUAGE],
+  ['.js', { label: 'javascript', aceMode: 'javascript' }],
+  ['.mjs', { label: 'javascript', aceMode: 'javascript' }],
+  ['.cjs', { label: 'javascript', aceMode: 'javascript' }],
+  ['.jsx', { label: 'jsx', aceMode: 'jsx' }],
+  ['.ts', { label: 'typescript', aceMode: 'typescript' }],
+  ['.mts', { label: 'typescript', aceMode: 'typescript' }],
+  ['.cts', { label: 'typescript', aceMode: 'typescript' }],
+  ['.tsx', { label: 'tsx', aceMode: 'tsx' }],
+  ['.vue', { label: 'vue', aceMode: 'vue' }],
+  ['.css', { label: 'css', aceMode: 'css' }],
+  ['.scss', { label: 'scss', aceMode: 'scss' }],
+  ['.html', { label: 'html', aceMode: 'html' }],
+  ['.htm', { label: 'html', aceMode: 'html' }],
+  ['.xml', { label: 'xml', aceMode: 'xml' }],
+  ['.sql', { label: 'sql', aceMode: 'sql' }],
+  ['.sh', { label: 'shell', aceMode: 'sh' }],
+  ['.bash', { label: 'shell', aceMode: 'sh' }],
+  ['.zsh', { label: 'shell', aceMode: 'sh' }],
+  ['.ini', { label: 'ini', aceMode: 'ini' }],
+  ['.conf', { label: 'ini', aceMode: 'ini' }],
+  ['.ps1', { label: 'powershell', aceMode: 'powershell' }],
+  ['.bat', TEXT_LANGUAGE],
+  ['.cmd', TEXT_LANGUAGE],
+])
+
+const MAX_INLINE_PREVIEW_BYTES = 1024 * 1024
+
+function getLanguageConfigForPath(pathValue: string): { language: LocalFileLanguageConfig; recognized: boolean } {
+  const fileName = basename(pathValue).toLowerCase()
+  if (fileName === '.env' || fileName.startsWith('.env.')) {
+    return { language: TEXT_LANGUAGE, recognized: true }
   }
+
+  const exactMatch = FILE_LANGUAGE_RULES_BY_NAME.get(fileName)
+  if (exactMatch) {
+    return { language: exactMatch, recognized: true }
+  }
+
+  const extensionMatch = FILE_LANGUAGE_RULES_BY_EXTENSION.get(extname(fileName))
+  if (extensionMatch) {
+    return { language: extensionMatch, recognized: true }
+  }
+
+  return { language: TEXT_LANGUAGE, recognized: false }
 }
 
 export function normalizeLocalPath(rawPath: string): string {
@@ -79,7 +149,7 @@ export function decodeBrowsePath(rawPath: string): string {
 }
 
 export function isTextEditablePath(pathValue: string): boolean {
-  return TEXT_EDITABLE_EXTENSIONS.has(extname(pathValue).toLowerCase())
+  return getLanguageConfigForPath(pathValue).recognized
 }
 
 function isHiddenName(value: string): boolean {
@@ -118,6 +188,29 @@ export async function isTextEditableFile(localPath: string): Promise<boolean> {
   }
 }
 
+export async function getLocalTextFileMetadata(localPath: string): Promise<LocalTextFileMetadata | null> {
+  const { language, recognized } = getLanguageConfigForPath(localPath)
+  try {
+    const fileStat = await stat(localPath)
+    if (!fileStat.isFile()) return null
+    if (recognized) {
+      return {
+        language,
+        sizeBytes: fileStat.size,
+      }
+    }
+
+    const isText = await probeFileIsText(localPath)
+    if (!isText) return null
+    return {
+      language,
+      sizeBytes: fileStat.size,
+    }
+  } catch {
+    return null
+  }
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/gu, '&amp;')
@@ -141,6 +234,14 @@ function toEditHref(pathValue: string, newProjectName = ''): string {
   const normalizedName = normalizeNewProjectName(newProjectName)
   const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
   return `/codex-local-edit${encodeURI(pathValue)}${query}`
+}
+
+function toRawFileHref(pathValue: string, options?: { download?: boolean }): string {
+  const query = new URLSearchParams({ path: pathValue })
+  if (options?.download === true) {
+    query.set('download', '1')
+  }
+  return `/codex-local-file?${query.toString()}`
 }
 
 function escapeForInlineScriptString(value: string): string {
@@ -212,6 +313,28 @@ function actionButtonsHtml(localPath: string, newProjectName: string): string {
     : ''
   const openButton = `<button class="header-open-btn open-folder-btn" type="button" aria-label="Open current folder in Codex" title="Open folder in Codex" data-path="${escapeHtml(localPath)}" data-label="" data-status="${escapeHtml(openFolderStatusText(normalizedName))}" data-error="${escapeHtml(failureStatusText(normalizedName))}">Open folder in Codex</button>`
   return `${createButton}${openButton}`
+}
+
+function renderTextPreviewToolbar(
+  localPath: string,
+  newProjectName: string,
+): string {
+  const backHref = toBrowseHref(dirname(localPath), newProjectName)
+  const rawHref = toRawFileHref(localPath)
+  const downloadHref = toRawFileHref(localPath, { download: true })
+
+  return [
+    `<a href="${escapeHtml(backHref)}">Back</a>`,
+    `<a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">Raw</a>`,
+    `<a href="${escapeHtml(downloadHref)}">Download</a>`,
+    `<a href="${escapeHtml(toEditHref(localPath, newProjectName))}">Edit</a>`,
+  ].filter(Boolean).join('')
+}
+
+function formatPreviewSize(sizeBytes: number): string {
+  if (sizeBytes >= 1024 * 1024) return `${(sizeBytes / (1024 * 1024)).toFixed(1).replace(/\.0$/u, '')} MiB`
+  if (sizeBytes >= 1024) return `${Math.round(sizeBytes / 1024)} KiB`
+  return `${sizeBytes} B`
 }
 
 export async function getLocalDirectoryListing(
@@ -358,10 +481,125 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
 </html>`
 }
 
-export async function createTextEditorHtml(localPath: string): Promise<string> {
+export async function createTextPreviewHtml(localPath: string, options?: { newProjectName?: string }): Promise<string> {
+  const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const metadata = await getLocalTextFileMetadata(localPath)
+  if (!metadata) {
+    throw new Error('Only text-like files can be previewed inline.')
+  }
+
+  const toolbar = renderTextPreviewToolbar(localPath, newProjectName)
+  const previewMeta = `${localPath} · ${metadata.language.label} · ${formatPreviewSize(metadata.sizeBytes)}`
+  const previewUnavailable = metadata.sizeBytes > MAX_INLINE_PREVIEW_BYTES
+  const previewContent = previewUnavailable
+    ? ''
+    : await readFile(localPath, 'utf8')
+  const previewPlainHtml = escapeHtml(previewContent)
+  const safePreviewLiteral = escapeForInlineScriptString(previewContent)
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(basename(localPath))}</title>
+  <style>
+    html, body { margin: 0; width: 100%; min-height: 100%; }
+    body { min-height: 100vh; font-family: ui-monospace, Menlo, Monaco, monospace; background: #09111f; color: #dbe6ff; display: flex; flex-direction: column; }
+    a { color: inherit; text-decoration: none; }
+    .toolbar { position: sticky; top: 0; z-index: 10; display: flex; flex-direction: column; gap: 10px; padding: 12px 16px; background: rgba(9, 17, 31, 0.96); backdrop-filter: blur(8px); border-bottom: 1px solid #233958; }
+    .toolbar-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .toolbar-row a { display: inline-flex; align-items: center; justify-content: center; min-height: 38px; padding: 0 12px; border: 1px solid #36557a; border-radius: 10px; background: #13233d; }
+    .toolbar-row a:hover { filter: brightness(1.08); }
+    .meta { color: #8fb8ec; font-size: 12px; overflow-wrap: anywhere; line-height: 1.5; }
+    .preview-shell { flex: 1 1 auto; min-height: 0; display: flex; padding: 18px 16px 24px; }
+    .preview-card { flex: 1 1 auto; min-height: 0; max-width: 100%; border: 1px solid #20324d; border-radius: 14px; background: #0d182b; overflow: hidden; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.24); display: flex; flex-direction: column; }
+    .preview-notice { margin: 0; padding: 12px 16px; border-bottom: 1px solid #20324d; color: #f0cf78; background: rgba(240, 207, 120, 0.08); }
+    .preview-unavailable { padding: 26px 20px; }
+    .preview-unavailable-title { margin: 0 0 8px; font-size: 15px; font-weight: 700; }
+    .preview-unavailable-text { margin: 0; color: #aac5e6; line-height: 1.6; }
+    .preview-plain {
+      flex: 1 1 auto;
+      box-sizing: border-box;
+      margin: 0;
+      padding: 18px 20px 24px;
+      min-height: 0;
+      overflow: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      tab-size: 2;
+      line-height: 1.55;
+      color: #dbe6ff;
+      background: #07101f;
+    }
+    #previewEditor { flex: 1 1 auto; width: 100%; min-height: 0; }
+    .ace_editor { background: #07101f !important; color: #dbe6ff !important; width: 100% !important; height: 100% !important; }
+    .ace_gutter { background: #07101f !important; color: #6f8eb5 !important; }
+    .ace_marker-layer .ace_active-line { background: transparent !important; }
+    .ace_marker-layer .ace_selection { background: rgba(140, 194, 255, 0.16) !important; }
+    @media (max-width: 640px) {
+      .toolbar { padding: 12px; }
+      .preview-shell { padding: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <div class="toolbar-row">${toolbar}</div>
+    <div class="meta">${escapeHtml(previewMeta)}</div>
+  </div>
+  <main class="preview-shell">
+    <section class="preview-card">
+      ${previewUnavailable
+        ? `<div class="preview-unavailable">
+  <p class="preview-unavailable-title">Inline preview disabled</p>
+  <p class="preview-unavailable-text">This file is larger than ${String(Math.floor(MAX_INLINE_PREVIEW_BYTES / 1024))} KiB. Use <strong>Raw</strong> or <strong>Download</strong> instead.</p>
+</div>`
+        : `<pre id="previewFallback" class="preview-plain">${previewPlainHtml}</pre>
+<div id="previewEditor" hidden></div>`}
+    </section>
+  </main>
+  ${previewUnavailable ? '' : `<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
+  <script>
+    const previewFallback = document.getElementById('previewFallback');
+    const previewEditor = document.getElementById('previewEditor');
+    if (window.ace && previewEditor) {
+      previewEditor.hidden = false;
+      if (previewFallback) previewFallback.hidden = true;
+      ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
+      const editor = ace.edit('previewEditor');
+      editor.setTheme('ace/theme/tomorrow_night');
+      editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
+      editor.session.setUseWorker(false);
+      editor.setValue(${safePreviewLiteral}, -1);
+      editor.setOptions({
+        readOnly: true,
+        highlightActiveLine: false,
+        highlightGutterLine: false,
+        showPrintMargin: false,
+        fontSize: '13px',
+        wrap: true,
+        behavioursEnabled: false,
+        displayIndentGuides: true,
+      });
+      editor.renderer.setShowGutter(true);
+      editor.renderer.$cursorLayer.element.style.display = 'none';
+      editor.resize();
+    }
+  </script>`}
+</body>
+</html>`
+}
+
+export async function createTextEditorHtml(localPath: string, options?: { newProjectName?: string }): Promise<string> {
+  const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const metadata = await getLocalTextFileMetadata(localPath)
+  if (!metadata) {
+    throw new Error('Only text-like files are editable.')
+  }
+
   const content = await readFile(localPath, 'utf8')
   const parentPath = dirname(localPath)
-  const language = languageForPath(localPath)
   const safeContentLiteral = escapeForInlineScriptString(content)
   return `<!doctype html>
 <html lang="en">
@@ -388,20 +626,25 @@ export async function createTextEditorHtml(localPath: string): Promise<string> {
 <body>
   <div class="toolbar">
     <div class="row">
-      <a href="${escapeHtml(toBrowseHref(parentPath))}">Back</a>
+      <a href="${escapeHtml(toBrowseHref(parentPath, newProjectName))}">Back</a>
+      <a href="${escapeHtml(toBrowseHref(localPath, newProjectName))}">Preview</a>
+      <a href="${escapeHtml(toRawFileHref(localPath))}" target="_blank" rel="noopener noreferrer">Raw</a>
+      <a href="${escapeHtml(toRawFileHref(localPath, { download: true }))}">Download</a>
       <button id="saveBtn" type="button">Save</button>
       <span id="status"></span>
     </div>
-    <div class="meta">${escapeHtml(localPath)} · ${escapeHtml(language)}</div>
+    <div class="meta">${escapeHtml(localPath)} · ${escapeHtml(metadata.language.label)}</div>
   </div>
   <div id="editor"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
   <script>
     const saveBtn = document.getElementById('saveBtn');
     const status = document.getElementById('status');
+    ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
     const editor = ace.edit('editor');
     editor.setTheme('ace/theme/tomorrow_night');
-    editor.session.setMode('ace/mode/${escapeHtml(language)}');
+    editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
+    editor.session.setUseWorker(false);
     editor.setValue(${safeContentLiteral}, -1);
     editor.setOptions({
       fontSize: '13px',

--- a/tests.md
+++ b/tests.md
@@ -239,6 +239,47 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Return appearance and runtime selection to the previous user preference.
 
+### Feature: Local path link validation and text-file browser preview
+
+#### Prerequisites
+- App is running from this repository.
+- An existing thread is open.
+- You can create temporary files on the host machine.
+
+#### Steps
+1. Create a temporary folder such as `/tmp/codexui-file-browser-test` with these files: `sample.rs`, `sample.toml`, `sample.lua`, `sample.js`, `sample.ts`, `sample.vue`, `BUILD.bazel`, `notes.txt`.
+2. In the open thread, send one message containing:
+   `/tmp/codexui-file-browser-test/sample.rs`
+   `/tmp/codexui-file-browser-test/sample.toml`
+   `/tmp/codexui-file-browser-test/BUILD.bazel`
+   `/tmp/codexui-file-browser-test/notes.txt`
+   `/tmp/codexui-file-browser-test/missing.rs`
+   `/tmp/codexui-file-browser-test/sample.rs --flag`
+   `[missing report](/tmp/codexui-file-browser-test/missing.rs)`
+3. Wait for the message to render completely.
+4. Confirm the real file paths become clickable links, but `missing.rs` and `sample.rs --flag` remain plain text.
+5. Confirm the unresolved markdown example stays plain text and still shows both `missing report` and `/tmp/codexui-file-browser-test/missing.rs`.
+6. Open each real file link and verify it opens a browser preview page instead of a download dialog.
+7. On the preview page, verify `Raw`, `Download`, and `Edit` controls exist.
+8. Click `Raw` and confirm the file opens as plain text in the browser.
+9. Click `Download` and confirm the browser downloads the file using the original basename (for example `sample.rs`, not `codex-local-file`).
+10. Click `Edit` and confirm the editor opens with matching syntax mode coverage for Rust, JavaScript, TypeScript, Vue, TOML, Lua, Bazel/Starlark fallback, and plain text.
+11. Open a text preview page on a desktop-sized viewport and verify the preview panel extends to the bottom of the browser window below the toolbar, instead of stopping at a shorter fixed-height box.
+
+#### Expected Results
+- Path-like text is only linkified after the server confirms the local path exists.
+- Nonexistent paths and command-like strings that do not map to a real file stay as plain text.
+- Unresolved markdown file references preserve the human-readable label and the original target path.
+- Text/code files open in an inline preview page with syntax coloring rather than forcing a download.
+- Preview falls back to plain text rendering if the syntax highlighter is unavailable.
+- Preview and edit pages expose the same language coverage for Rust, JavaScript, TypeScript, Vue, TOML, Lua, Bazel/Starlark fallback, and plain text files.
+- The preview panel fills the remaining viewport height below the toolbar on desktop layouts.
+- `Raw` serves the file contents directly and `Download` forces a file download.
+
+#### Rollback/Cleanup
+- Remove `/tmp/codexui-file-browser-test` after testing.
+- Delete the test thread message if it is no longer useful.
+
 ### Feature: Per-thread model selection
 
 #### Prerequisites

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { createCodexBridgeMiddleware } from "./src/server/codexAppServerBridge";
-import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from "./src/server/localBrowseUi";
+import {
+  createDirectoryListingHtml,
+  createTextEditorHtml,
+  createTextPreviewHtml,
+  decodeBrowsePath,
+  getLocalDirectoryListing,
+  getLocalTextFileMetadata,
+  isTextEditableFile,
+  normalizeLocalPath,
+} from "./src/server/localBrowseUi";
 import tailwindcss from "@tailwindcss/vite";
 import { spawnSync } from "node:child_process";
 import { createReadStream, existsSync, readFileSync } from "node:fs";
@@ -32,6 +41,40 @@ function normalizeLocalImagePath(rawPath: string): string {
     }
   }
   return trimmed;
+}
+
+function readBooleanQueryFlag(value: string | null): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+}
+
+function localFileErrorResponse(error: unknown): { status: number; body: { error: string } } {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  const statusCode = typeof error === "object" && error !== null && "statusCode" in error
+    ? Number((error as { statusCode?: unknown }).statusCode)
+    : Number.NaN;
+
+  if (code === "ENOENT" || statusCode === 404) {
+    return { status: 404, body: { error: "File not found." } };
+  }
+  if (code === "EACCES" || code === "EPERM" || statusCode === 403) {
+    return { status: 403, body: { error: "Access denied." } };
+  }
+  return { status: 500, body: { error: "Failed to read file." } };
+}
+
+function sendLocalFileJsonError(res: import("node:http").ServerResponse, error: unknown): void {
+  if (res.headersSent) return;
+  const response = localFileErrorResponse(error);
+  res.statusCode = response.status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(response.body));
+}
+
+function attachmentContentDisposition(pathValue: string): string {
+  const fileName = basename(pathValue).replace(/["\\]/gu, "_");
+  return `attachment; filename="${fileName}"`;
 }
 
 function getWorktreeName(): string {
@@ -202,11 +245,76 @@ export default defineConfig({
           stream.pipe(res);
         });
         server.middlewares.use((req, res, next) => {
+          if (!req.url || req.method !== "POST") return next();
+          const url = new URL(req.url, "http://localhost");
+          if (url.pathname !== "/codex-api/local-paths/probe") return next();
+
+          const chunks: Buffer[] = [];
+          req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+          req.on("end", async () => {
+            let paths: string[] = [];
+            try {
+              const raw = Buffer.concat(chunks).toString("utf8");
+              const parsed = raw ? JSON.parse(raw) as { paths?: unknown } : {};
+              const rawPaths = Array.isArray(parsed.paths) ? parsed.paths : [];
+              const seen = new Set<string>();
+              paths = rawPaths
+                .slice(0, 200)
+                .flatMap((item) => {
+                  if (typeof item !== "string") return [];
+                  const normalized = normalizeLocalPath(item);
+                  if (!normalized || seen.has(normalized)) return [];
+                  seen.add(normalized);
+                  return [normalized];
+                });
+            } catch {
+              res.statusCode = 400;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ error: "Expected JSON body." }));
+              return;
+            }
+
+            const entries = await Promise.all(paths.map(async (pathValue) => {
+              if (!isAbsolute(pathValue)) {
+                return {
+                  path: pathValue,
+                  exists: false,
+                  isDirectory: false,
+                };
+              }
+              try {
+                const fileStat = await stat(pathValue);
+                return {
+                  path: pathValue,
+                  exists: true,
+                  isDirectory: fileStat.isDirectory(),
+                };
+              } catch {
+                return {
+                  path: pathValue,
+                  exists: false,
+                  isDirectory: false,
+                };
+              }
+            }));
+
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ data: { entries } }));
+          });
+          req.on("error", () => {
+            res.statusCode = 500;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ error: "Failed to read request." }));
+          });
+        });
+        server.middlewares.use(async (req, res, next) => {
           if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
           const url = new URL(req.url, "http://localhost");
           if (url.pathname !== "/codex-local-file") return next();
 
           const localPath = normalizeLocalPath(url.searchParams.get("path") ?? "");
+          const wantsDownload = readBooleanQueryFlag(url.searchParams.get("download"));
           if (!localPath || !isAbsolute(localPath)) {
             res.statusCode = 400;
             res.setHeader("Content-Type", "application/json");
@@ -214,18 +322,59 @@ export default defineConfig({
             return;
           }
 
-          res.statusCode = 200;
-          res.setHeader("Cache-Control", "private, no-store");
-          res.setHeader("Content-Disposition", `inline; filename="${basename(localPath)}"`);
+          try {
+            const fileStat = await stat(localPath);
+            if (!fileStat.isFile()) {
+              res.statusCode = 400;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ error: "Expected file path." }));
+              return;
+            }
 
-          const stream = createReadStream(localPath);
-          stream.on("error", () => {
-            if (res.headersSent) return;
-            res.statusCode = 404;
-            res.setHeader("Content-Type", "application/json");
-            res.end(JSON.stringify({ error: "File not found." }));
-          });
-          stream.pipe(res);
+            const textMetadata = await getLocalTextFileMetadata(localPath);
+            res.setHeader("Cache-Control", "private, no-store");
+
+            if (wantsDownload) {
+              const stream = createReadStream(localPath);
+              stream.on("open", () => {
+                res.statusCode = 200;
+                res.setHeader("Content-Disposition", attachmentContentDisposition(localPath));
+              });
+              stream.on("error", (error) => {
+                stream.destroy();
+                sendLocalFileJsonError(res, error);
+              });
+              stream.pipe(res);
+              return;
+            }
+
+            if (textMetadata) {
+              const stream = createReadStream(localPath, { encoding: "utf8" });
+              stream.on("open", () => {
+                res.statusCode = 200;
+                res.setHeader("Content-Type", "text/plain; charset=utf-8");
+              });
+              stream.on("error", (error) => {
+                stream.destroy();
+                sendLocalFileJsonError(res, error);
+              });
+              stream.pipe(res);
+              return;
+            }
+
+            const stream = createReadStream(localPath);
+            stream.on("open", () => {
+              res.statusCode = 200;
+              res.setHeader("Content-Disposition", "inline");
+            });
+            stream.on("error", (error) => {
+              stream.destroy();
+              sendLocalFileJsonError(res, error);
+            });
+            stream.pipe(res);
+          } catch (error) {
+            sendLocalFileJsonError(res, error);
+          }
         });
         server.middlewares.use(async (req, res, next) => {
           if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) return next();
@@ -285,7 +434,17 @@ export default defineConfig({
               return;
             }
 
+            const textMetadata = await getLocalTextFileMetadata(localPath);
+            if (textMetadata) {
+              const html = await createTextPreviewHtml(localPath, { newProjectName });
+              res.statusCode = 200;
+              res.setHeader("Content-Type", "text/html; charset=utf-8");
+              res.end(html);
+              return;
+            }
+
             res.statusCode = 200;
+            res.setHeader("Content-Disposition", "attachment");
             const stream = createReadStream(localPath);
             stream.on("error", () => {
               if (res.headersSent) return;
@@ -305,6 +464,7 @@ export default defineConfig({
           const url = new URL(req.url, "http://localhost");
           if (!url.pathname.startsWith("/codex-local-edit/")) return next();
           const localPath = decodeBrowsePath(url.pathname.slice("/codex-local-edit".length));
+          const newProjectName = url.searchParams.get("newProjectName") ?? "";
           if (!localPath || !isAbsolute(localPath)) {
             res.statusCode = 400;
             res.setHeader("Content-Type", "application/json");
@@ -319,7 +479,13 @@ export default defineConfig({
               res.end(JSON.stringify({ error: "Expected file path." }));
               return;
             }
-            const html = await createTextEditorHtml(localPath);
+            if (!(await isTextEditableFile(localPath))) {
+              res.statusCode = 415;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ error: "Only text-like files are editable." }));
+              return;
+            }
+            const html = await createTextEditorHtml(localPath, { newProjectName });
             res.statusCode = 200;
             res.setHeader("Content-Type", "text/html; charset=utf-8");
             res.end(html);


### PR DESCRIPTION
This PR improves the local file browsing experience in chat messages and the built-in local file browser.

It addresses two core UX issues:

- path-like text in messages was often turned into clickable file links even when the file did not exist on the host, leading users to dead-end `File not found` pages
- text/code files often opened as downloads instead of an in-browser preview, which made quick inspection unnecessarily awkward

With this change:

- only real local paths become clickable file links
- missing paths remain plain text
- markdown file references only linkify when the target exists
- unresolved markdown references remain readable and preserve context
- text/code files open in an inline preview instead of forcing a download
- preview and edit pages support a broader set of languages
- preview has a plain-text fallback if Ace fails to load
- preview fills the available viewport height below the toolbar
- dev and prod local-browse behavior are aligned

## Problems addressed

### False-positive local file links

Previously, the chat renderer would eagerly convert many path-like strings into browse links even when they did not point to a real file on the current machine.

This produced misleading UI for cases such as:

- nonexistent paths
- command-like strings such as `some/file.rs --flag`
- markdown file references whose target path did not exist

The result was a poor interaction loop: users clicked what looked like a valid local file link and landed on a `File not found` response.

This PR changes file-link rendering to depend on server-side path existence checks.

### Source files opening as downloads

Valid text/code files were often handled as downloads rather than opening in a useful in-browser view.

That behavior is inconvenient for common workflows like:

- quickly inspecting code referenced in a conversation
- checking config files
- browsing source files before deciding whether to edit them

This PR adds a proper inline text preview page for text-like files, with actions for `Raw`, `Download`, and `Edit`.

### Weak fallback behavior

There were also a couple of failure modes that degraded poorly:

- unresolved markdown file references could lose useful context
- preview pages depended on Ace loading successfully, with no good content fallback if the CDN script failed

This PR keeps unresolved references readable and adds a plain-text fallback preview.

### Dev/prod drift

The Vite dev server and the main HTTP server did not fully match for local browsing behavior, which creates review and maintenance risk.

This PR aligns the relevant local-path probe, raw-file, browse, and edit behaviors in both environments.

## Changes

### 1. Add server-backed local path probing

Introduced a local path probe endpoint and client-side probe flow so the UI can confirm whether candidate file paths actually exist before rendering them as links.

After this change:

- existing local paths render as links
- nonexistent paths stay plain text
- command fragments that do not map to a valid path stay plain text

### 2. Preserve readable fallback text for unresolved markdown file references

Adjusted file-segment rendering so unresolved markdown file references do not collapse to incomplete or misleading text.

For unresolved references, the UI now preserves both:

- the human-readable label
- the original target path

Example:

```md
[missing report](/tmp/example/missing.rs)
```

will remain readable as plain text rather than becoming a broken local file link.

### 3. Add inline text preview pages for local files

Text-like files now open in an HTML preview page instead of forcing immediate browser download behavior.

The preview page includes:

- syntax-highlighted rendering via Ace
- `Raw` action
- `Download` action
- `Edit` action
- file metadata in the toolbar

Non-text files continue to use download-oriented behavior.

### 4. Add plain-text fallback when Ace is unavailable

If Ace fails to load, the preview page still renders the file contents in a plain `<pre>` block.

This preserves a useful read-only experience even when the CDN is blocked or unavailable.

### 5. Expand language coverage for preview/edit

Preview and edit pages now support a broader set of text/code file types, including:

- JavaScript
- TypeScript
- Vue SFCs
- Rust
- Python
- Lua
- JSON
- YAML
- Markdown
- TOML
- C / C++
- Bazel / BUILD-family files
- plain text

Additional JS/TS module variants are also covered:

- `.mjs`
- `.cjs`
- `.mts`
- `.cts`

### 6. Make preview fill remaining viewport height

The preview container no longer stops at a short fixed-height region. It now stretches to fill the remaining viewport height below the toolbar, which makes code browsing significantly more usable.

### 7. Align Vite dev middleware with main server behavior

Updated Vite dev-server route handling to match the main server for:

- `POST /codex-api/local-paths/probe`
- `/codex-local-file`
- `/codex-local-browse/*path`
- `/codex-local-edit/*path`

This avoids fixing the feature in production while leaving development behavior inconsistent.

## User-visible behavior after this PR

- Real local file paths in messages become clickable.
- Nonexistent file-like text does not become a link.
- Markdown file references only become links when the target exists.
- Missing markdown file references remain readable and preserve both label and target.
- Text/code files open in-browser with syntax highlighting.
- `Raw` serves plain text directly.
- `Download` forces file download.
- `Edit` opens the text editor for supported text-like files.
- Preview still works in plain text when Ace does not load.
- Preview uses the available screen height more effectively.

## Testing

Verified with:

```bash
./node_modules/.bin/vue-tsc --noEmit
./node_modules/.bin/vite build
./node_modules/.bin/tsup
```

Manual test coverage was also updated in `tests.md` for:

- valid vs invalid path linkification
- unresolved markdown file references
- inline preview behavior
- preview fallback behavior when syntax highlighting is unavailable
- language coverage across preview/edit
- full-height preview layout

## Why this is useful

This change makes local file references in chat much more trustworthy and much easier to use.

Before this PR:

- many path-like strings became misleading broken links
- valid source files often opened in an inconvenient way
- preview behavior was more fragile than it should be

After this PR:

- file links are based on server truth
- source files are easy to inspect inline
- failure modes degrade gracefully
- local browse behavior is consistent across dev and prod