### PR TITLE
Add line-targeted local file browsing and theme-aware standalone browse/editor pages

### DIFF
--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -301,12 +301,12 @@
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                         <template v-else-if="segment.kind === 'file'">
                           <a
-                            v-if="confirmedBrowseUrl(segment.path)"
+                            v-if="browseUrlForInlineFile(segment)"
                             class="message-file-link"
-                            :href="confirmedBrowseUrl(segment.path)"
+                            :href="browseUrlForInlineFile(segment)"
                             target="_blank"
                             rel="noopener noreferrer"
-                            :title="segment.path"
+                            :title="fileLinkTitle(segment)"
                           >
                             {{ segment.displayPath }}
                           </a>
@@ -338,12 +338,12 @@
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                         <template v-else-if="segment.kind === 'file'">
                           <a
-                            v-if="confirmedBrowseUrl(segment.path)"
+                            v-if="browseUrlForInlineFile(segment)"
                             class="message-file-link"
-                            :href="confirmedBrowseUrl(segment.path)"
+                            :href="browseUrlForInlineFile(segment)"
                             target="_blank"
                             rel="noopener noreferrer"
-                            :title="segment.path"
+                            :title="fileLinkTitle(segment)"
                           >
                             {{ segment.displayPath }}
                           </a>
@@ -370,12 +370,12 @@
                         <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                         <template v-else-if="segment.kind === 'file'">
                           <a
-                            v-if="confirmedBrowseUrl(segment.path)"
+                            v-if="browseUrlForInlineFile(segment)"
                             class="message-file-link"
-                            :href="confirmedBrowseUrl(segment.path)"
+                            :href="browseUrlForInlineFile(segment)"
                             target="_blank"
                             rel="noopener noreferrer"
-                            :title="segment.path"
+                            :title="fileLinkTitle(segment)"
                           >
                             {{ segment.displayPath }}
                           </a>
@@ -410,12 +410,12 @@
                             <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                             <template v-else-if="segment.kind === 'file'">
                               <a
-                                v-if="confirmedBrowseUrl(segment.path)"
+                                v-if="browseUrlForInlineFile(segment)"
                                 class="message-file-link"
-                                :href="confirmedBrowseUrl(segment.path)"
+                                :href="browseUrlForInlineFile(segment)"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                :title="segment.path"
+                                :title="fileLinkTitle(segment)"
                               >
                                 {{ segment.displayPath }}
                               </a>
@@ -462,12 +462,12 @@
                                 <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                                 <template v-else-if="segment.kind === 'file'">
                                   <a
-                                    v-if="confirmedBrowseUrl(segment.path)"
+                                    v-if="browseUrlForInlineFile(segment)"
                                     class="message-file-link"
-                                    :href="confirmedBrowseUrl(segment.path)"
+                                    :href="browseUrlForInlineFile(segment)"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    :title="segment.path"
+                                    :title="fileLinkTitle(segment)"
                                   >
                                     {{ segment.displayPath }}
                                   </a>
@@ -503,12 +503,12 @@
                                 <s v-else-if="segment.kind === 'strikethrough'" class="message-strikethrough-text">{{ segment.value }}</s>
                                 <template v-else-if="segment.kind === 'file'">
                                   <a
-                                    v-if="confirmedBrowseUrl(segment.path)"
+                                    v-if="browseUrlForInlineFile(segment)"
                                     class="message-file-link"
-                                    :href="confirmedBrowseUrl(segment.path)"
+                                    :href="browseUrlForInlineFile(segment)"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    :title="segment.path"
+                                    :title="fileLinkTitle(segment)"
                                   >
                                     {{ segment.displayPath }}
                                   </a>
@@ -1239,7 +1239,8 @@ type InlineSegment =
   | { kind: 'strikethrough'; value: string }
   | { kind: 'code'; value: string }
   | { kind: 'url'; value: string; href: string }
-  | { kind: 'file'; value: string; path: string; displayPath: string; fallbackText: string; downloadName: string }
+  | { kind: 'file'; value: string; path: string; line: number | null; column: number | null; displayPath: string; fallbackText: string; downloadName: string }
+type FileInlineSegment = Extract<InlineSegment, { kind: 'file' }>
 type TaskListItem = {
   text: string
   checked: boolean
@@ -1435,29 +1436,37 @@ function resolveRelativePath(pathValue: string, cwd: string): string {
   return normalizePathDots(`${base.replace(/\/+$/u, '')}/${normalizedPath}`)
 }
 
-function parseFileReference(value: string): { path: string; line: number | null } | null {
+function normalizePositiveInteger(value: string | undefined): number | null {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function parseFileReference(value: string): { path: string; line: number | null; column: number | null } | null {
   if (!value) return null
 
   let pathValue = value.trim()
   const wrapped = trimLinkWrappers(pathValue)
   pathValue = wrapped.core.trim()
   let line: number | null = null
+  let column: number | null = null
 
-  const hashLineMatch = pathValue.match(/^(.*)#L(\d+)(?:C\d+)?$/u)
+  const hashLineMatch = pathValue.match(/^(.*)#L(\d+)(?:C(\d+))?$/u)
   if (hashLineMatch) {
     pathValue = hashLineMatch[1]
-    line = Number(hashLineMatch[2])
+    line = normalizePositiveInteger(hashLineMatch[2])
+    column = normalizePositiveInteger(hashLineMatch[3])
   } else {
-    const colonLineMatch = pathValue.match(/^(.*):(\d+)(?::\d+)?$/u)
+    const colonLineMatch = pathValue.match(/^(.*?):(\d+)(?::(\d+))?$/u)
     if (colonLineMatch) {
       pathValue = colonLineMatch[1]
-      line = Number(colonLineMatch[2])
+      line = normalizePositiveInteger(colonLineMatch[2])
+      column = normalizePositiveInteger(colonLineMatch[3])
     }
   }
 
   pathValue = normalizeFileUrlToPath(pathValue)
   if (!isFilePath(pathValue)) return null
-  return { path: pathValue, line }
+  return { path: pathValue, line, column }
 }
 
 function trimLinkWrappers(value: string): { core: string; leading: string; trailing: string } {
@@ -2173,6 +2182,8 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
           kind: 'file',
           value: token,
           path: ref.path,
+          line: ref.line,
+          column: ref.column,
           displayPath: token,
           fallbackText: token,
           downloadName: getBasename(ref.path),
@@ -2377,6 +2388,8 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
           kind: 'file',
           value: target,
           path: ref.path,
+          line: ref.line,
+          column: ref.column,
           displayPath,
           fallbackText: fileLinkFallbackText(displayPath, target),
           downloadName: getBasename(ref.path),
@@ -2468,6 +2481,8 @@ function parseInlineSegments(text: string): InlineSegment[] {
               kind: 'file',
               value: markdownLink.target,
               path: markdownFileReference.path,
+              line: markdownFileReference.line,
+              column: markdownFileReference.column,
               displayPath,
               fallbackText: fileLinkFallbackText(displayPath, markdownLink.target),
               downloadName: getBasename(markdownFileReference.path),
@@ -2486,12 +2501,14 @@ function parseInlineSegments(text: string): InlineSegment[] {
         const fileReference = parseFileReference(token)
         if (fileReference) {
           const displayPath = fileReference.line
-            ? `${fileReference.path}:${String(fileReference.line)}`
+            ? `${fileReference.path}:${String(fileReference.line)}${fileReference.column ? `:${String(fileReference.column)}` : ''}`
             : fileReference.path
           segments.push({
             kind: 'file',
             value: token,
             path: fileReference.path,
+            line: fileReference.line,
+            column: fileReference.column,
             displayPath,
             fallbackText: displayPath,
             downloadName: getBasename(fileReference.path),
@@ -2529,6 +2546,18 @@ function resolveAbsoluteLocalPath(pathValue: string): string {
   return ''
 }
 
+function resolveAbsoluteLocalPathLiteral(pathValue: string): string {
+  const normalized = pathValue.trim()
+  if (!normalized) return ''
+
+  const resolved = normalizePathDots(normalizePathSeparators(resolveRelativePath(normalizeFileUrlToPath(normalized), props.cwd)))
+  if (!resolved) return ''
+  if (resolved.startsWith('/') || /^[A-Za-z]:\//u.test(resolved)) {
+    return resolved
+  }
+  return ''
+}
+
 function toRenderableImageUrl(value: string): string {
   const normalized = value.trim()
   if (!normalized) return ''
@@ -2555,20 +2584,47 @@ function toRenderableImageUrl(value: string): string {
   return normalized
 }
 
-function toBrowseUrl(pathValue: string): string {
-  const resolved = resolveAbsoluteLocalPath(pathValue)
-  if (resolved) {
-    const normalizedResolved = resolved.startsWith('/') ? resolved : `/${resolved}`
-    return `/codex-local-browse${encodeURI(normalizedResolved)}`
-  }
-  return '#'
+function buildBrowseUrl(resolvedPath: string, line: number | null = null, column: number | null = null): string {
+  const normalizedResolved = resolvedPath.startsWith('/') ? resolvedPath : `/${resolvedPath}`
+  const query = new URLSearchParams()
+  if (line) query.set('line', String(line))
+  if (column) query.set('column', String(column))
+  const encodedQuery = query.toString()
+  return `/codex-local-browse${encodeURI(normalizedResolved)}${encodedQuery ? `?${encodedQuery}` : ''}`
 }
 
-function confirmedBrowseUrl(pathValue: string): string {
+function toBrowseUrl(pathValue: string): string {
+  const resolved = resolveAbsoluteLocalPathLiteral(pathValue)
+  return resolved ? buildBrowseUrl(resolved) : '#'
+}
+
+function confirmedBrowseUrl(
+  pathValue: string,
+  line: number | null = null,
+  column: number | null = null,
+  rawValue: string = pathValue,
+): string {
+  const literalResolved = resolveAbsoluteLocalPathLiteral(rawValue)
   const resolved = resolveAbsoluteLocalPath(pathValue)
+
+  if (
+    literalResolved
+    && literalResolved !== resolved
+    && localPathProbeResults.value[literalResolved] === true
+  ) {
+    return buildBrowseUrl(literalResolved)
+  }
+
   if (!resolved || localPathProbeResults.value[resolved] !== true) return ''
-  const normalizedResolved = resolved.startsWith('/') ? resolved : `/${resolved}`
-  return `/codex-local-browse${encodeURI(normalizedResolved)}`
+  return buildBrowseUrl(resolved, line, column)
+}
+
+function browseUrlForInlineFile(segment: FileInlineSegment): string {
+  return confirmedBrowseUrl(segment.path, segment.line, segment.column, segment.value)
+}
+
+function fileLinkTitle(segment: FileInlineSegment): string {
+  return segment.value.trim() || segment.path
 }
 
 const fileLinkContextMenuStyle = computed(() => ({
@@ -3273,8 +3329,10 @@ function parseMessageBlocks(text: string): MessageBlock[] {
 function collectInlineLocalPathCandidates(text: string, output: Set<string>): void {
   for (const segment of parseInlineSegments(text)) {
     if (segment.kind !== 'file') continue
+    const literalResolved = resolveAbsoluteLocalPathLiteral(segment.value)
     const resolved = resolveAbsoluteLocalPath(segment.path)
-    if (resolved) output.add(resolved)
+    if (literalResolved) output.add(literalResolved)
+    if (resolved && resolved !== literalResolved) output.add(resolved)
   }
 }
 
@@ -3444,11 +3502,11 @@ function renderInlineSegmentsAsHtml(text: string): string {
         return `<s class="message-strikethrough-text">${escapeHtml(segment.value)}</s>`
       }
       if (segment.kind === 'file') {
-        const browseUrl = confirmedBrowseUrl(segment.path)
+        const browseUrl = browseUrlForInlineFile(segment)
         if (!browseUrl) {
           return escapeHtml(segment.fallbackText)
         }
-        return `<a class="message-file-link" href="${escapeHtml(browseUrl)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(segment.path)}">${escapeHtml(segment.displayPath)}</a>`
+        return `<a class="message-file-link" href="${escapeHtml(browseUrl)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(fileLinkTitle(segment))}">${escapeHtml(segment.displayPath)}</a>`
       }
       if (segment.kind === 'url') {
         return `<a class="message-file-link" href="${escapeHtml(segment.href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(segment.href)}">${escapeHtml(segment.value)}</a>`

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -86,6 +86,12 @@ function readBooleanQueryFlag(value: unknown): boolean {
   return typeof value === 'string' && ['1', 'true', 'yes', 'on'].includes(value.toLowerCase())
 }
 
+function readPositiveIntegerQueryParam(value: unknown): number | null {
+  if (typeof value !== 'string') return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
 function localFileErrorResponse(error: unknown): { status: number, body: { error: string } } {
   const code = typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code?: unknown }).code ?? '')
@@ -279,6 +285,8 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
     const newProjectName = typeof req.query.newProjectName === 'string' ? req.query.newProjectName : ''
+    const line = readPositiveIntegerQueryParam(req.query.line)
+    const column = line ? readPositiveIntegerQueryParam(req.query.column) : null
     if (!localPath || !isAbsolute(localPath)) {
       res.status(400).json({ error: 'Expected absolute local file path.' })
       return
@@ -295,7 +303,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
 
       const textMetadata = await getLocalTextFileMetadata(localPath)
       if (textMetadata) {
-        const html = await createTextPreviewHtml(localPath, { newProjectName })
+        const html = await createTextPreviewHtml(localPath, { newProjectName, line, column })
         res.status(200).type('text/html; charset=utf-8').send(html)
         return
       }
@@ -315,6 +323,8 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
     const rawPath = readWildcardPathParam(req.params.path)
     const localPath = decodeBrowsePath(`/${rawPath}`)
     const newProjectName = typeof req.query.newProjectName === 'string' ? req.query.newProjectName : ''
+    const line = readPositiveIntegerQueryParam(req.query.line)
+    const column = line ? readPositiveIntegerQueryParam(req.query.column) : null
     if (!localPath || !isAbsolute(localPath)) {
       res.status(400).json({ error: 'Expected absolute local file path.' })
       return
@@ -329,7 +339,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
         res.status(415).json({ error: 'Only text-like files are editable.' })
         return
       }
-      const html = await createTextEditorHtml(localPath, { newProjectName })
+      const html = await createTextEditorHtml(localPath, { newProjectName, line, column })
       res.status(200).type('text/html; charset=utf-8').send(html)
     } catch {
       res.status(404).json({ error: 'File not found.' })

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -112,6 +112,8 @@ const FILE_LANGUAGE_RULES_BY_EXTENSION = new Map<string, LocalFileLanguageConfig
 ])
 
 const MAX_INLINE_PREVIEW_BYTES = 1024 * 1024
+const DARK_MODE_STORAGE_KEY = 'codex-web-local.dark-mode.v1'
+const ACE_CDN_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2'
 
 function getLanguageConfigForPath(pathValue: string): { language: LocalFileLanguageConfig; recognized: boolean } {
   const fileName = basename(pathValue).toLowerCase()
@@ -273,6 +275,102 @@ function escapeForInlineScriptString(value: string): string {
     .replace(/\u2029/gu, '\\u2029')
 }
 
+function renderStandaloneThemeBootstrapScript(): string {
+  return [
+    '(function() {',
+    `  const storageKey = ${JSON.stringify(DARK_MODE_STORAGE_KEY)};`,
+    '  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");',
+    '  function readStoredPreference() {',
+    '    try {',
+    '      const value = window.localStorage.getItem(storageKey);',
+    '      return value === "light" || value === "dark" ? value : "system";',
+    '    } catch {',
+    '      return "system";',
+    '    }',
+    '  }',
+    '  function resolveTheme(preference) {',
+    '    if (preference === "light" || preference === "dark") return preference;',
+    '    return mediaQuery.matches ? "dark" : "light";',
+    '  }',
+    '  function applyTheme() {',
+    '    const preference = readStoredPreference();',
+    '    const resolvedTheme = resolveTheme(preference);',
+    '    document.documentElement.dataset.theme = resolvedTheme;',
+    '    document.documentElement.style.colorScheme = resolvedTheme;',
+    '    window.__codexLocalBrowseTheme = { preference, resolvedTheme };',
+    '    window.dispatchEvent(new CustomEvent("codex-local-browse-themechange", { detail: window.__codexLocalBrowseTheme }));',
+    '  }',
+    '  applyTheme();',
+    '  window.__codexApplyLocalBrowseTheme = applyTheme;',
+    '  window.addEventListener("storage", function(event) {',
+    '    if (event.key !== storageKey) return;',
+    '    applyTheme();',
+    '  });',
+    '  mediaQuery.addEventListener("change", function() {',
+    '    if (readStoredPreference() !== "system") return;',
+    '    applyTheme();',
+    '  });',
+    '})();',
+  ].join('\n')
+}
+
+function renderStandaloneThemeCss(): string {
+  return `
+    :root {
+      color-scheme: light;
+      --lb-bg: #f3f6fb;
+      --lb-surface: #ffffff;
+      --lb-surface-muted: #eef3fb;
+      --lb-surface-strong: #e7edf8;
+      --lb-toolbar-bg: rgba(243, 246, 251, 0.96);
+      --lb-border: #cfd9ea;
+      --lb-border-strong: #b6c4db;
+      --lb-text: #172033;
+      --lb-text-muted: #52607a;
+      --lb-link: #2457b8;
+      --lb-button-text: #172033;
+      --lb-accent-bg: #dfeafe;
+      --lb-accent-border: #9db8ef;
+      --lb-primary-bg: linear-gradient(135deg, #2f67d8 0%, #4b88ff 100%);
+      --lb-primary-border: #2f67d8;
+      --lb-primary-text: #f8fbff;
+      --lb-selection: rgba(77, 124, 255, 0.18);
+      --lb-selection-strong: rgba(77, 124, 255, 0.24);
+      --lb-target-line: rgba(77, 124, 255, 0.14);
+      --lb-target-stripe: #4d7cff;
+      --lb-warning-text: #8a5a00;
+      --lb-warning-bg: rgba(194, 136, 18, 0.12);
+      --lb-shadow: 0 16px 40px rgba(31, 49, 82, 0.12);
+    }
+    :root[data-theme='dark'] {
+      color-scheme: dark;
+      --lb-bg: #09111f;
+      --lb-surface: #0d182b;
+      --lb-surface-muted: #101f3a;
+      --lb-surface-strong: #13233d;
+      --lb-toolbar-bg: rgba(9, 17, 31, 0.96);
+      --lb-border: #20324d;
+      --lb-border-strong: #36557a;
+      --lb-text: #dbe6ff;
+      --lb-text-muted: #8fb8ec;
+      --lb-link: #8cc2ff;
+      --lb-button-text: #dbe6ff;
+      --lb-accent-bg: #162643;
+      --lb-accent-border: #36557a;
+      --lb-primary-bg: linear-gradient(135deg, #2e6ee6 0%, #3d8cff 100%);
+      --lb-primary-border: #4f8de0;
+      --lb-primary-text: #eef6ff;
+      --lb-selection: rgba(140, 194, 255, 0.16);
+      --lb-selection-strong: rgba(140, 194, 255, 0.3);
+      --lb-target-line: rgba(140, 194, 255, 0.16);
+      --lb-target-stripe: #8cc2ff;
+      --lb-warning-text: #f0cf78;
+      --lb-warning-bg: rgba(240, 207, 120, 0.08);
+      --lb-shadow: 0 20px 40px rgba(0, 0, 0, 0.24);
+    }
+  `
+}
+
 async function getDirectoryItems(localPath: string): Promise<DirectoryItem[]> {
   const entries = await readdir(localPath, { withFileTypes: true })
   const withMeta = await Promise.all(entries.map(async (entry) => {
@@ -397,6 +495,12 @@ function renderAceLineTargetScript(): string {
     '  editorInstance.selection.moveCursorToPosition({ row: zeroBasedRow, column: zeroBasedColumn });',
     '  editorInstance.selection.selectLine();',
     '}',
+    'function currentAceThemeName() {',
+    '  return document.documentElement.dataset.theme === "light" ? "tomorrow" : "tomorrow_night";',
+    '}',
+    'function applyAceTheme(editorInstance) {',
+    '  editorInstance.setTheme("ace/theme/" + currentAceThemeName());',
+    '}',
   ].join('\n')
 }
 
@@ -454,35 +558,37 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Index of ${escapeHtml(localPath)}</title>
+  <script>${renderStandaloneThemeBootstrapScript()}</script>
   <style>
-    body { font-family: ui-monospace, Menlo, Monaco, monospace; margin: 16px; background: #0b1020; color: #dbe6ff; }
-    a { color: #8cc2ff; text-decoration: none; }
+    ${renderStandaloneThemeCss()}
+    body { font-family: ui-monospace, Menlo, Monaco, monospace; margin: 16px; background: var(--lb-bg); color: var(--lb-text); }
+    a { color: var(--lb-link); text-decoration: none; }
     a:hover { text-decoration: underline; }
     ul { list-style: none; padding: 0; margin: 12px 0 0; display: flex; flex-direction: column; gap: 8px; }
     .file-row { display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: 10px; }
-    .file-link { display: block; padding: 10px 12px; border: 1px solid #28405f; border-radius: 10px; background: #0f1b33; overflow-wrap: anywhere; }
+    .file-link { display: block; padding: 10px 12px; border: 1px solid var(--lb-border); border-radius: 10px; background: var(--lb-surface); color: var(--lb-text); overflow-wrap: anywhere; box-shadow: var(--lb-shadow); }
     .header-actions { display: flex; align-items: center; gap: 10px; margin-top: 10px; flex-wrap: wrap; }
-    .header-parent-link { color: #9ec8ff; font-size: 14px; padding: 8px 10px; border: 1px solid #2a4569; border-radius: 10px; background: #101f3a; }
+    .header-parent-link { color: var(--lb-link); font-size: 14px; padding: 8px 10px; border: 1px solid var(--lb-border); border-radius: 10px; background: var(--lb-surface-muted); }
     .header-parent-link:hover { text-decoration: none; filter: brightness(1.08); }
     .header-open-btn {
       height: 42px;
       padding: 0 14px;
-      border: 1px solid #4f8de0;
+      border: 1px solid var(--lb-primary-border);
       border-radius: 10px;
-      background: linear-gradient(135deg, #2e6ee6 0%, #3d8cff 100%);
-      color: #eef6ff;
+      background: var(--lb-primary-bg);
+      color: var(--lb-primary-text);
       font-weight: 700;
       letter-spacing: 0.01em;
       cursor: pointer;
-      box-shadow: 0 6px 18px rgba(33, 90, 199, 0.35);
+      box-shadow: var(--lb-shadow);
     }
     .header-open-btn:hover { filter: brightness(1.08); }
     .header-open-btn:disabled { opacity: 0.6; cursor: default; }
-    .picker-summary { margin: 10px 0 0; color: #b8d5ff; max-width: 60rem; line-height: 1.45; }
+    .picker-summary { margin: 10px 0 0; color: var(--lb-text-muted); max-width: 60rem; line-height: 1.45; }
     .row-actions { display: inline-flex; align-items: center; gap: 8px; min-width: 42px; justify-content: flex-end; }
-    .icon-btn { display: inline-flex; align-items: center; justify-content: center; width: 42px; height: 42px; border: 1px solid #36557a; border-radius: 10px; background: #162643; color: #dbe6ff; text-decoration: none; cursor: pointer; }
+    .icon-btn { display: inline-flex; align-items: center; justify-content: center; width: 42px; height: 42px; border: 1px solid var(--lb-accent-border); border-radius: 10px; background: var(--lb-accent-bg); color: var(--lb-button-text); text-decoration: none; cursor: pointer; }
     .icon-btn:hover { filter: brightness(1.08); text-decoration: none; }
-    .status { margin: 10px 0 0; color: #8cc2ff; min-height: 1.25em; }
+    .status { margin: 10px 0 0; color: var(--lb-text-muted); min-height: 1.25em; }
     h1 { font-size: 18px; margin: 0; word-break: break-all; }
     @media (max-width: 640px) {
       body { margin: 12px; }
@@ -571,21 +677,23 @@ export async function createTextPreviewHtml(localPath: string, options?: LocalBr
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(basename(localPath))}</title>
+  <script>${renderStandaloneThemeBootstrapScript()}</script>
   <style>
+    ${renderStandaloneThemeCss()}
     html, body { margin: 0; width: 100%; min-height: 100%; }
-    body { min-height: 100vh; font-family: ui-monospace, Menlo, Monaco, monospace; background: #09111f; color: #dbe6ff; display: flex; flex-direction: column; }
+    body { min-height: 100vh; font-family: ui-monospace, Menlo, Monaco, monospace; background: var(--lb-bg); color: var(--lb-text); display: flex; flex-direction: column; }
     a { color: inherit; text-decoration: none; }
-    .toolbar { position: sticky; top: 0; z-index: 10; display: flex; flex-direction: column; gap: 10px; padding: 12px 16px; background: rgba(9, 17, 31, 0.96); backdrop-filter: blur(8px); border-bottom: 1px solid #233958; }
+    .toolbar { position: sticky; top: 0; z-index: 10; display: flex; flex-direction: column; gap: 10px; padding: 12px 16px; background: var(--lb-toolbar-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--lb-border); }
     .toolbar-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-    .toolbar-row a { display: inline-flex; align-items: center; justify-content: center; min-height: 38px; padding: 0 12px; border: 1px solid #36557a; border-radius: 10px; background: #13233d; }
+    .toolbar-row a { display: inline-flex; align-items: center; justify-content: center; min-height: 38px; padding: 0 12px; border: 1px solid var(--lb-accent-border); border-radius: 10px; background: var(--lb-accent-bg); color: var(--lb-button-text); }
     .toolbar-row a:hover { filter: brightness(1.08); }
-    .meta { color: #8fb8ec; font-size: 12px; overflow-wrap: anywhere; line-height: 1.5; }
+    .meta { color: var(--lb-text-muted); font-size: 12px; overflow-wrap: anywhere; line-height: 1.5; }
     .preview-shell { flex: 1 1 auto; min-height: 0; display: flex; padding: 18px 16px 24px; }
-    .preview-card { flex: 1 1 auto; min-height: 0; max-width: 100%; border: 1px solid #20324d; border-radius: 14px; background: #0d182b; overflow: hidden; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.24); display: flex; flex-direction: column; }
-    .preview-notice { margin: 0; padding: 12px 16px; border-bottom: 1px solid #20324d; color: #f0cf78; background: rgba(240, 207, 120, 0.08); }
+    .preview-card { flex: 1 1 auto; min-height: 0; max-width: 100%; border: 1px solid var(--lb-border); border-radius: 14px; background: var(--lb-surface); overflow: hidden; box-shadow: var(--lb-shadow); display: flex; flex-direction: column; }
+    .preview-notice { margin: 0; padding: 12px 16px; border-bottom: 1px solid var(--lb-border); color: var(--lb-warning-text); background: var(--lb-warning-bg); }
     .preview-unavailable { padding: 26px 20px; }
     .preview-unavailable-title { margin: 0 0 8px; font-size: 15px; font-weight: 700; }
-    .preview-unavailable-text { margin: 0; color: #aac5e6; line-height: 1.6; }
+    .preview-unavailable-text { margin: 0; color: var(--lb-text-muted); line-height: 1.6; }
     .preview-plain {
       flex: 1 1 auto;
       box-sizing: border-box;
@@ -597,22 +705,21 @@ export async function createTextPreviewHtml(localPath: string, options?: LocalBr
       overflow-wrap: anywhere;
       tab-size: 2;
       line-height: 1.55;
-      color: #dbe6ff;
-      background: #07101f;
+      color: var(--lb-text);
+      background: var(--lb-surface);
     }
     .preview-target-line {
       display: inline-block;
       min-width: 100%;
       margin: 0 -20px;
       padding: 0 20px;
-      background: rgba(140, 194, 255, 0.16);
-      box-shadow: inset 3px 0 0 #8cc2ff;
+      background: var(--lb-target-line);
+      box-shadow: inset 3px 0 0 var(--lb-target-stripe);
     }
     #previewEditor { flex: 1 1 auto; width: 100%; min-height: 0; }
-    .ace_editor { background: #07101f !important; color: #dbe6ff !important; width: 100% !important; height: 100% !important; }
-    .ace_gutter { background: #07101f !important; color: #6f8eb5 !important; }
+    .ace_editor { width: 100% !important; height: 100% !important; }
     .ace_marker-layer .ace_active-line { background: transparent !important; }
-    .ace_marker-layer .ace_selection { background: rgba(140, 194, 255, 0.16) !important; }
+    .ace_marker-layer .ace_selection { background: var(--lb-selection) !important; }
     @media (max-width: 640px) {
       .toolbar { padding: 12px; }
       .preview-shell { padding: 12px; }
@@ -635,7 +742,7 @@ export async function createTextPreviewHtml(localPath: string, options?: LocalBr
 <div id="previewEditor" hidden></div>`}
     </section>
   </main>
-	  ${previewUnavailable ? '' : `<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
+	  ${previewUnavailable ? '' : `<script src="${ACE_CDN_BASE}/ace.min.js"></script>
 	  <script>
 	    const targetLineNumber = ${line ?? 'null'};
 	    const targetColumnNumber = ${column ?? 'null'};
@@ -647,14 +754,14 @@ export async function createTextPreviewHtml(localPath: string, options?: LocalBr
 	      previewTargetLine.scrollIntoView({ block: 'center' });
 	    }
 	    if (window.ace && previewEditor) {
-      previewEditor.hidden = false;
-      if (previewFallback) previewFallback.hidden = true;
-      ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
-      const editor = ace.edit('previewEditor');
-      editor.setTheme('ace/theme/tomorrow_night');
-      editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
-      editor.session.setUseWorker(false);
-      editor.setValue(${safePreviewLiteral}, -1);
+	      previewEditor.hidden = false;
+	      if (previewFallback) previewFallback.hidden = true;
+	      ace.config.set('basePath', '${ACE_CDN_BASE}/');
+	      const editor = ace.edit('previewEditor');
+	      applyAceTheme(editor);
+	      editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
+	      editor.session.setUseWorker(false);
+	      editor.setValue(${safePreviewLiteral}, -1);
       editor.setOptions({
         readOnly: true,
         highlightActiveLine: !!targetLineNumber,
@@ -670,6 +777,9 @@ export async function createTextPreviewHtml(localPath: string, options?: LocalBr
 	      if (targetLineNumber) {
 	        selectTargetLine(editor, targetLineNumber, targetColumnNumber);
 	      }
+	      window.addEventListener('codex-local-browse-themechange', function() {
+	        applyAceTheme(editor);
+	      });
 	      editor.resize();
 	    }
 	  </script>`}
@@ -695,20 +805,21 @@ export async function createTextEditorHtml(localPath: string, options?: LocalBro
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Edit ${escapeHtml(localPath)}</title>
+  <script>${renderStandaloneThemeBootstrapScript()}</script>
   <style>
+    ${renderStandaloneThemeCss()}
     html, body { width: 100%; height: 100%; margin: 0; }
-    body { font-family: ui-monospace, Menlo, Monaco, monospace; background: #0b1020; color: #dbe6ff; display: flex; flex-direction: column; overflow: hidden; }
-    .toolbar { position: sticky; top: 0; z-index: 10; display: flex; flex-direction: column; gap: 8px; padding: 10px 12px; background: #0b1020; border-bottom: 1px solid #243a5a; }
+    body { font-family: ui-monospace, Menlo, Monaco, monospace; background: var(--lb-bg); color: var(--lb-text); display: flex; flex-direction: column; overflow: hidden; }
+    .toolbar { position: sticky; top: 0; z-index: 10; display: flex; flex-direction: column; gap: 8px; padding: 10px 12px; background: var(--lb-bg); border-bottom: 1px solid var(--lb-border); }
     .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-    button, a { background: #1b2a4a; color: #dbe6ff; border: 1px solid #345; padding: 6px 10px; border-radius: 6px; text-decoration: none; cursor: pointer; }
+    button, a { background: var(--lb-accent-bg); color: var(--lb-button-text); border: 1px solid var(--lb-accent-border); padding: 6px 10px; border-radius: 6px; text-decoration: none; cursor: pointer; }
     button:hover, a:hover { filter: brightness(1.08); }
     #editor { flex: 1 1 auto; min-height: 0; width: 100%; border: none; overflow: hidden; }
-    #status { margin-left: 8px; color: #8cc2ff; }
-    .ace_editor { background: #07101f !important; color: #dbe6ff !important; width: 100% !important; height: 100% !important; }
-    .ace_gutter { background: #07101f !important; color: #6f8eb5 !important; }
-    .ace_marker-layer .ace_active-line { background: #10213c !important; }
-    .ace_marker-layer .ace_selection { background: rgba(140, 194, 255, 0.3) !important; }
-    .meta { opacity: 0.9; font-size: 12px; overflow-wrap: anywhere; }
+    #status { margin-left: 8px; color: var(--lb-text-muted); }
+    .ace_editor { width: 100% !important; height: 100% !important; }
+    .ace_marker-layer .ace_active-line { background: var(--lb-target-line) !important; }
+    .ace_marker-layer .ace_selection { background: var(--lb-selection-strong) !important; }
+    .meta { opacity: 0.9; font-size: 12px; overflow-wrap: anywhere; color: var(--lb-text-muted); }
   </style>
 </head>
 <body>
@@ -724,19 +835,19 @@ export async function createTextEditorHtml(localPath: string, options?: LocalBro
     <div class="meta">${escapeHtml([localPath, metadata.language.label, formatLineTargetLabel(line, column)].filter(Boolean).join(' · '))}</div>
   </div>
   <div id="editor"></div>
-	  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
+	  <script src="${ACE_CDN_BASE}/ace.min.js"></script>
 	  <script>
 	    const targetLineNumber = ${line ?? 'null'};
 	    const targetColumnNumber = ${column ?? 'null'};
 	    const saveBtn = document.getElementById('saveBtn');
 	    const status = document.getElementById('status');
 	    ${renderAceLineTargetScript()}
-	    ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
+	    ace.config.set('basePath', '${ACE_CDN_BASE}/');
 	    const editor = ace.edit('editor');
-    editor.setTheme('ace/theme/tomorrow_night');
-    editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
-    editor.session.setUseWorker(false);
-    editor.setValue(${safeContentLiteral}, -1);
+	    applyAceTheme(editor);
+	    editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
+	    editor.session.setUseWorker(false);
+	    editor.setValue(${safeContentLiteral}, -1);
     editor.setOptions({
       fontSize: '13px',
       wrap: true,
@@ -748,6 +859,9 @@ export async function createTextEditorHtml(localPath: string, options?: LocalBro
 	    if (targetLineNumber) {
 	      selectTargetLine(editor, targetLineNumber, targetColumnNumber);
 	    }
+	    window.addEventListener('codex-local-browse-themechange', function() {
+	      applyAceTheme(editor);
+	    });
 	    editor.resize();
 
     saveBtn.addEventListener('click', async () => {

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -34,6 +34,12 @@ type LocalTextFileMetadata = {
   sizeBytes: number
 }
 
+type LocalBrowseLocationOptions = {
+  newProjectName?: string
+  line?: number | null
+  column?: number | null
+}
+
 const TEXT_LANGUAGE: LocalFileLanguageConfig = {
   label: 'text',
   aceMode: 'text',
@@ -224,16 +230,30 @@ function normalizeNewProjectName(value: string): string {
   return value.trim().replace(/[\\/]+/gu, '').trim()
 }
 
-function toBrowseHref(pathValue: string, newProjectName = ''): string {
-  const normalizedName = normalizeNewProjectName(newProjectName)
-  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-browse${encodeURI(pathValue)}${query}`
+function normalizeLineTarget(value: number | null | undefined): number | null {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : null
 }
 
-function toEditHref(pathValue: string, newProjectName = ''): string {
-  const normalizedName = normalizeNewProjectName(newProjectName)
-  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-edit${encodeURI(pathValue)}${query}`
+function buildLocationQuery(options?: LocalBrowseLocationOptions): string {
+  const query = new URLSearchParams()
+  const normalizedName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const line = normalizeLineTarget(options?.line)
+  const column = line ? normalizeLineTarget(options?.column) : null
+
+  if (normalizedName) query.set('newProjectName', normalizedName)
+  if (line) query.set('line', String(line))
+  if (column) query.set('column', String(column))
+
+  const encoded = query.toString()
+  return encoded ? `?${encoded}` : ''
+}
+
+function toBrowseHref(pathValue: string, options?: LocalBrowseLocationOptions): string {
+  return `/codex-local-browse${encodeURI(pathValue)}${buildLocationQuery(options)}`
+}
+
+function toEditHref(pathValue: string, options?: LocalBrowseLocationOptions): string {
+  return `/codex-local-edit${encodeURI(pathValue)}${buildLocationQuery(options)}`
 }
 
 function toRawFileHref(pathValue: string, options?: { download?: boolean }): string {
@@ -317,24 +337,67 @@ function actionButtonsHtml(localPath: string, newProjectName: string): string {
 
 function renderTextPreviewToolbar(
   localPath: string,
-  newProjectName: string,
+  options?: LocalBrowseLocationOptions,
 ): string {
-  const backHref = toBrowseHref(dirname(localPath), newProjectName)
+  const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const line = normalizeLineTarget(options?.line)
+  const column = line ? normalizeLineTarget(options?.column) : null
+  const backHref = toBrowseHref(dirname(localPath), { newProjectName })
   const rawHref = toRawFileHref(localPath)
   const downloadHref = toRawFileHref(localPath, { download: true })
+  const lineLocation = line ? { newProjectName, line, column } : { newProjectName }
 
   return [
     `<a href="${escapeHtml(backHref)}">Back</a>`,
     `<a href="${escapeHtml(rawHref)}" target="_blank" rel="noopener noreferrer">Raw</a>`,
     `<a href="${escapeHtml(downloadHref)}">Download</a>`,
-    `<a href="${escapeHtml(toEditHref(localPath, newProjectName))}">Edit</a>`,
+    `<a href="${escapeHtml(toEditHref(localPath, lineLocation))}">Edit</a>`,
   ].filter(Boolean).join('')
+}
+
+function formatLineTargetLabel(line: number | null, column: number | null): string {
+  if (!line) return ''
+  if (column) return `line ${String(line)}:${String(column)}`
+  return `line ${String(line)}`
+}
+
+function renderPlainPreviewContent(content: string, targetLine: number | null): string {
+  if (!targetLine || targetLine < 1) return escapeHtml(content)
+
+  const trailingNewline = content.endsWith('\n')
+  const lines = content.split('\n')
+  if (trailingNewline) lines.pop()
+  if (targetLine > lines.length) return escapeHtml(content)
+
+  return lines
+    .map((line, index) => {
+      const escapedLine = escapeHtml(line || ' ')
+      if (index + 1 === targetLine) {
+        return `<span id="previewTargetLine" class="preview-target-line">${escapedLine}</span>`
+      }
+      return escapedLine
+    })
+    .join('\n') + (trailingNewline ? '\n' : '')
 }
 
 function formatPreviewSize(sizeBytes: number): string {
   if (sizeBytes >= 1024 * 1024) return `${(sizeBytes / (1024 * 1024)).toFixed(1).replace(/\.0$/u, '')} MiB`
   if (sizeBytes >= 1024) return `${Math.round(sizeBytes / 1024)} KiB`
   return `${sizeBytes} B`
+}
+
+function renderAceLineTargetScript(): string {
+  return [
+    'function selectTargetLine(editorInstance, lineNumber, columnNumber) {',
+    '  if (!lineNumber) return;',
+    '  const zeroBasedRow = lineNumber - 1;',
+    '  const zeroBasedColumn = Math.max(0, (columnNumber ?? 1) - 1);',
+    '  editorInstance.gotoLine(lineNumber, zeroBasedColumn, true);',
+    '  editorInstance.scrollToLine(lineNumber, true, true, function() {});',
+    '  editorInstance.selection.moveCursorToPosition({ row: zeroBasedRow, column: zeroBasedColumn });',
+    '  editorInstance.selection.selectLine();',
+    '}',
+  ].join('\n')
 }
 
 export async function getLocalDirectoryListing(
@@ -371,14 +434,14 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
     .map((item) => {
       const suffix = item.isDirectory ? '/' : ''
       const editAction = item.editable
-        ? ` <a class="icon-btn" aria-label="Edit ${escapeHtml(item.name)}" href="${escapeHtml(toEditHref(item.path, newProjectName))}" title="Edit">✏️</a>`
+        ? ` <a class="icon-btn" aria-label="Edit ${escapeHtml(item.name)}" href="${escapeHtml(toEditHref(item.path, { newProjectName }))}" title="Edit">✏️</a>`
         : ''
-      return `<li class="file-row"><a class="file-link" href="${escapeHtml(toBrowseHref(item.path, newProjectName))}">${escapeHtml(item.name)}${suffix}</a><span class="row-actions">${editAction}</span></li>`
+      return `<li class="file-row"><a class="file-link" href="${escapeHtml(toBrowseHref(item.path, { newProjectName }))}">${escapeHtml(item.name)}${suffix}</a><span class="row-actions">${editAction}</span></li>`
     })
     .join('\n')
 
   const parentLink = localPath !== parentPath
-    ? `<a class="header-parent-link" href="${escapeHtml(toBrowseHref(parentPath, newProjectName))}">..</a>`
+    ? `<a class="header-parent-link" href="${escapeHtml(toBrowseHref(parentPath, { newProjectName }))}">..</a>`
     : ''
   const pickerSummary = newProjectName
     ? `<p class="picker-summary">Browse to the parent folder where you want to create <strong>${escapeHtml(newProjectName)}</strong>, or open the current folder directly.</p>`
@@ -481,20 +544,25 @@ export async function createDirectoryListingHtml(localPath: string, options?: { 
 </html>`
 }
 
-export async function createTextPreviewHtml(localPath: string, options?: { newProjectName?: string }): Promise<string> {
+export async function createTextPreviewHtml(localPath: string, options?: LocalBrowseLocationOptions): Promise<string> {
   const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const line = normalizeLineTarget(options?.line)
+  const column = line ? normalizeLineTarget(options?.column) : null
   const metadata = await getLocalTextFileMetadata(localPath)
   if (!metadata) {
     throw new Error('Only text-like files can be previewed inline.')
   }
 
-  const toolbar = renderTextPreviewToolbar(localPath, newProjectName)
-  const previewMeta = `${localPath} · ${metadata.language.label} · ${formatPreviewSize(metadata.sizeBytes)}`
+  const toolbar = renderTextPreviewToolbar(localPath, { newProjectName, line, column })
+  const lineTargetLabel = formatLineTargetLabel(line, column)
+  const previewMeta = [localPath, metadata.language.label, formatPreviewSize(metadata.sizeBytes), lineTargetLabel]
+    .filter(Boolean)
+    .join(' · ')
   const previewUnavailable = metadata.sizeBytes > MAX_INLINE_PREVIEW_BYTES
   const previewContent = previewUnavailable
     ? ''
     : await readFile(localPath, 'utf8')
-  const previewPlainHtml = escapeHtml(previewContent)
+  const previewPlainHtml = renderPlainPreviewContent(previewContent, line)
   const safePreviewLiteral = escapeForInlineScriptString(previewContent)
 
   return `<!doctype html>
@@ -532,6 +600,14 @@ export async function createTextPreviewHtml(localPath: string, options?: { newPr
       color: #dbe6ff;
       background: #07101f;
     }
+    .preview-target-line {
+      display: inline-block;
+      min-width: 100%;
+      margin: 0 -20px;
+      padding: 0 20px;
+      background: rgba(140, 194, 255, 0.16);
+      box-shadow: inset 3px 0 0 #8cc2ff;
+    }
     #previewEditor { flex: 1 1 auto; width: 100%; min-height: 0; }
     .ace_editor { background: #07101f !important; color: #dbe6ff !important; width: 100% !important; height: 100% !important; }
     .ace_gutter { background: #07101f !important; color: #6f8eb5 !important; }
@@ -559,11 +635,18 @@ export async function createTextPreviewHtml(localPath: string, options?: { newPr
 <div id="previewEditor" hidden></div>`}
     </section>
   </main>
-  ${previewUnavailable ? '' : `<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
-  <script>
-    const previewFallback = document.getElementById('previewFallback');
-    const previewEditor = document.getElementById('previewEditor');
-    if (window.ace && previewEditor) {
+	  ${previewUnavailable ? '' : `<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
+	  <script>
+	    const targetLineNumber = ${line ?? 'null'};
+	    const targetColumnNumber = ${column ?? 'null'};
+	    const previewFallback = document.getElementById('previewFallback');
+	    const previewTargetLine = document.getElementById('previewTargetLine');
+	    const previewEditor = document.getElementById('previewEditor');
+	    ${renderAceLineTargetScript()}
+	    if (previewTargetLine) {
+	      previewTargetLine.scrollIntoView({ block: 'center' });
+	    }
+	    if (window.ace && previewEditor) {
       previewEditor.hidden = false;
       if (previewFallback) previewFallback.hidden = true;
       ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
@@ -574,25 +657,30 @@ export async function createTextPreviewHtml(localPath: string, options?: { newPr
       editor.setValue(${safePreviewLiteral}, -1);
       editor.setOptions({
         readOnly: true,
-        highlightActiveLine: false,
+        highlightActiveLine: !!targetLineNumber,
         highlightGutterLine: false,
         showPrintMargin: false,
         fontSize: '13px',
         wrap: true,
         behavioursEnabled: false,
         displayIndentGuides: true,
-      });
-      editor.renderer.setShowGutter(true);
-      editor.renderer.$cursorLayer.element.style.display = 'none';
-      editor.resize();
-    }
-  </script>`}
+	      });
+	      editor.renderer.setShowGutter(true);
+	      editor.renderer.$cursorLayer.element.style.display = 'none';
+	      if (targetLineNumber) {
+	        selectTargetLine(editor, targetLineNumber, targetColumnNumber);
+	      }
+	      editor.resize();
+	    }
+	  </script>`}
 </body>
 </html>`
 }
 
-export async function createTextEditorHtml(localPath: string, options?: { newProjectName?: string }): Promise<string> {
+export async function createTextEditorHtml(localPath: string, options?: LocalBrowseLocationOptions): Promise<string> {
   const newProjectName = normalizeNewProjectName(options?.newProjectName ?? '')
+  const line = normalizeLineTarget(options?.line)
+  const column = line ? normalizeLineTarget(options?.column) : null
   const metadata = await getLocalTextFileMetadata(localPath)
   if (!metadata) {
     throw new Error('Only text-like files are editable.')
@@ -626,22 +714,25 @@ export async function createTextEditorHtml(localPath: string, options?: { newPro
 <body>
   <div class="toolbar">
     <div class="row">
-      <a href="${escapeHtml(toBrowseHref(parentPath, newProjectName))}">Back</a>
-      <a href="${escapeHtml(toBrowseHref(localPath, newProjectName))}">Preview</a>
+      <a href="${escapeHtml(toBrowseHref(parentPath, { newProjectName }))}">Back</a>
+      <a href="${escapeHtml(toBrowseHref(localPath, { newProjectName, line, column }))}">Preview</a>
       <a href="${escapeHtml(toRawFileHref(localPath))}" target="_blank" rel="noopener noreferrer">Raw</a>
       <a href="${escapeHtml(toRawFileHref(localPath, { download: true }))}">Download</a>
       <button id="saveBtn" type="button">Save</button>
       <span id="status"></span>
     </div>
-    <div class="meta">${escapeHtml(localPath)} · ${escapeHtml(metadata.language.label)}</div>
+    <div class="meta">${escapeHtml([localPath, metadata.language.label, formatLineTargetLabel(line, column)].filter(Boolean).join(' · '))}</div>
   </div>
   <div id="editor"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
-  <script>
-    const saveBtn = document.getElementById('saveBtn');
-    const status = document.getElementById('status');
-    ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
-    const editor = ace.edit('editor');
+	  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/ace.min.js"></script>
+	  <script>
+	    const targetLineNumber = ${line ?? 'null'};
+	    const targetColumnNumber = ${column ?? 'null'};
+	    const saveBtn = document.getElementById('saveBtn');
+	    const status = document.getElementById('status');
+	    ${renderAceLineTargetScript()}
+	    ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.2/');
+	    const editor = ace.edit('editor');
     editor.setTheme('ace/theme/tomorrow_night');
     editor.session.setMode('ace/mode/${escapeHtml(metadata.language.aceMode)}');
     editor.session.setUseWorker(false);
@@ -652,9 +743,12 @@ export async function createTextEditorHtml(localPath: string, options?: { newPro
       showPrintMargin: false,
       useSoftTabs: true,
       tabSize: 2,
-      behavioursEnabled: true,
-    });
-    editor.resize();
+	      behavioursEnabled: true,
+	    });
+	    if (targetLineNumber) {
+	      selectTargetLine(editor, targetLineNumber, targetColumnNumber);
+	    }
+	    editor.resize();
 
     saveBtn.addEventListener('click', async () => {
       status.textContent = 'Saving...';

--- a/tests.md
+++ b/tests.md
@@ -270,6 +270,9 @@ This file tracks manual regression and feature verification steps.
 13. Click `Edit` from that targeted preview and verify the editor opens at the same line/column target with the full target line selected.
 14. On hosts that allow `:` or `#` in filenames, create a literal file such as `/tmp/codexui-file-browser-test/literal:12:3.txt`, send that exact path in the thread, and confirm it opens the literal file instead of stripping the suffix into line-target metadata.
 15. Open a text preview page on a desktop-sized viewport and verify the preview panel extends to the bottom of the browser window below the toolbar, instead of stopping at a shorter fixed-height box.
+16. In the main app, switch Appearance to `Light`, then open a local directory listing, a preview page, and an editor page in new tabs/windows and confirm all three use a light theme with readable syntax colors.
+17. Switch Appearance to `Dark` and repeat the same three local browsing views, confirming they switch to dark mode and keep readable syntax colors.
+18. Set Appearance to `System`, change the OS/browser preferred color scheme if available, then reload one of the standalone local browsing pages and confirm it follows the resolved system theme.
 
 #### Expected Results
 - Path-like text is only linkified after the server confirms the local path exists.
@@ -279,6 +282,8 @@ This file tracks manual regression and feature verification steps.
 - File references with `:line[:column]` or `#Lline[Ccolumn]` open preview/editor at the requested location.
 - Targeted line opens with a full-line Ace selection, not only cursor placement.
 - On hosts that allow those characters in filenames, exact existing paths still win over interpreted line-target syntax.
+- Standalone local directory, preview, and editor pages follow the same `Light`/`Dark`/`System` appearance preference as the main app.
+- Ace syntax highlighting remains readable in both light and dark themes.
 - Preview falls back to plain text rendering if the syntax highlighter is unavailable.
 - Preview and edit pages expose the same language coverage for Rust, JavaScript, TypeScript, Vue, TOML, Lua, Bazel/Starlark fallback, and plain text files.
 - The preview panel fills the remaining viewport height below the toolbar on desktop layouts.

--- a/tests.md
+++ b/tests.md
@@ -247,12 +247,13 @@ This file tracks manual regression and feature verification steps.
 - You can create temporary files on the host machine.
 
 #### Steps
-1. Create a temporary folder such as `/tmp/codexui-file-browser-test` with these files: `sample.rs`, `sample.toml`, `sample.lua`, `sample.js`, `sample.ts`, `sample.vue`, `BUILD.bazel`, `notes.txt`.
+1. Create a temporary folder such as `/tmp/codexui-file-browser-test` with these files: `sample.rs`, `sample.toml`, `sample.lua`, `sample.js`, `sample.ts`, `sample.vue`, `BUILD.bazel`, `notes.txt`, and a multi-line file such as `jump.ts` with at least 20 lines.
 2. In the open thread, send one message containing:
    `/tmp/codexui-file-browser-test/sample.rs`
    `/tmp/codexui-file-browser-test/sample.toml`
    `/tmp/codexui-file-browser-test/BUILD.bazel`
    `/tmp/codexui-file-browser-test/notes.txt`
+   `/tmp/codexui-file-browser-test/jump.ts:12:3`
    `/tmp/codexui-file-browser-test/missing.rs`
    `/tmp/codexui-file-browser-test/sample.rs --flag`
    `[missing report](/tmp/codexui-file-browser-test/missing.rs)`
@@ -264,13 +265,20 @@ This file tracks manual regression and feature verification steps.
 8. Click `Raw` and confirm the file opens as plain text in the browser.
 9. Click `Download` and confirm the browser downloads the file using the original basename (for example `sample.rs`, not `codex-local-file`).
 10. Click `Edit` and confirm the editor opens with matching syntax mode coverage for Rust, JavaScript, TypeScript, Vue, TOML, Lua, Bazel/Starlark fallback, and plain text.
-11. Open a text preview page on a desktop-sized viewport and verify the preview panel extends to the bottom of the browser window below the toolbar, instead of stopping at a shorter fixed-height box.
+11. Open the `jump.ts:12:3` link and verify the generated preview URL includes `line=12` and `column=3`.
+12. In preview, verify the view opens centered around line 12 and that line is selected the same way Ace selects a line when you click its gutter line number.
+13. Click `Edit` from that targeted preview and verify the editor opens at the same line/column target with the full target line selected.
+14. On hosts that allow `:` or `#` in filenames, create a literal file such as `/tmp/codexui-file-browser-test/literal:12:3.txt`, send that exact path in the thread, and confirm it opens the literal file instead of stripping the suffix into line-target metadata.
+15. Open a text preview page on a desktop-sized viewport and verify the preview panel extends to the bottom of the browser window below the toolbar, instead of stopping at a shorter fixed-height box.
 
 #### Expected Results
 - Path-like text is only linkified after the server confirms the local path exists.
 - Nonexistent paths and command-like strings that do not map to a real file stay as plain text.
 - Unresolved markdown file references preserve the human-readable label and the original target path.
 - Text/code files open in an inline preview page with syntax coloring rather than forcing a download.
+- File references with `:line[:column]` or `#Lline[Ccolumn]` open preview/editor at the requested location.
+- Targeted line opens with a full-line Ace selection, not only cursor placement.
+- On hosts that allow those characters in filenames, exact existing paths still win over interpreted line-target syntax.
 - Preview falls back to plain text rendering if the syntax highlighter is unavailable.
 - Preview and edit pages expose the same language coverage for Rust, JavaScript, TypeScript, Vue, TOML, Lua, Bazel/Starlark fallback, and plain text files.
 - The preview panel fills the remaining viewport height below the toolbar on desktop layouts.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,11 @@ function readBooleanQueryFlag(value: string | null): boolean {
   return ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
 }
 
+function readPositiveIntegerQueryParam(value: string | null): number | null {
+  const parsed = Number(value ?? "");
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 function localFileErrorResponse(error: unknown): { status: number; body: { error: string } } {
   const code = typeof error === "object" && error !== null && "code" in error
     ? String((error as { code?: unknown }).code ?? "")
@@ -416,6 +421,8 @@ export default defineConfig({
 
           const localPath = decodeBrowsePath(url.pathname.slice("/codex-local-browse".length));
           const newProjectName = url.searchParams.get("newProjectName") ?? "";
+          const line = readPositiveIntegerQueryParam(url.searchParams.get("line"));
+          const column = line ? readPositiveIntegerQueryParam(url.searchParams.get("column")) : null;
           if (!localPath || !isAbsolute(localPath)) {
             res.statusCode = 400;
             res.setHeader("Content-Type", "application/json");
@@ -436,7 +443,7 @@ export default defineConfig({
 
             const textMetadata = await getLocalTextFileMetadata(localPath);
             if (textMetadata) {
-              const html = await createTextPreviewHtml(localPath, { newProjectName });
+              const html = await createTextPreviewHtml(localPath, { newProjectName, line, column });
               res.statusCode = 200;
               res.setHeader("Content-Type", "text/html; charset=utf-8");
               res.end(html);
@@ -465,6 +472,8 @@ export default defineConfig({
           if (!url.pathname.startsWith("/codex-local-edit/")) return next();
           const localPath = decodeBrowsePath(url.pathname.slice("/codex-local-edit".length));
           const newProjectName = url.searchParams.get("newProjectName") ?? "";
+          const line = readPositiveIntegerQueryParam(url.searchParams.get("line"));
+          const column = line ? readPositiveIntegerQueryParam(url.searchParams.get("column")) : null;
           if (!localPath || !isAbsolute(localPath)) {
             res.statusCode = 400;
             res.setHeader("Content-Type", "application/json");
@@ -485,7 +494,7 @@ export default defineConfig({
               res.end(JSON.stringify({ error: "Only text-like files are editable." }));
               return;
             }
-            const html = await createTextEditorHtml(localPath, { newProjectName });
+            const html = await createTextEditorHtml(localPath, { newProjectName, line, column });
             res.statusCode = 200;
             res.setHeader("Content-Type", "text/html; charset=utf-8");
             res.end(html);


### PR DESCRIPTION
This PR improves standalone local file browsing in two ways:

1. Local file links can now target a specific line/column.
2. Standalone local directory/preview/editor pages now follow the app appearance setting instead of forcing a dark theme.

## What changed

### Line-targeted local file browsing

Local file references now support both common line-target formats:

- `path:line[:column]`
- `path#Lline[Ccolumn]`

Examples:

- `/tmp/example.ts:12`
- `/tmp/example.ts:12:3`
- `/tmp/example.ts#L12`
- `/tmp/example.ts#L12C3`

This target information is preserved through the standalone local browsing flow:

- chat-rendered local file links include `line` / `column` in the browse URL
- preview pages display the target in metadata
- preview -> edit navigation preserves the same target
- preview/editor open at the requested location
- the requested line is selected in Ace, matching gutter line-number selection behavior

There is also a correctness fix for ambiguous names: if the exact literal path exists, it wins over interpreting a trailing `:line[:column]` or `#L...` suffix as a line target.

### Theme-aware standalone local browsing

Standalone local browsing pages previously used a fixed dark look and always forced a dark Ace theme, which could make syntax highlighting harder to read.

These pages now follow the same app appearance preference as the main UI:

- `Light`
- `Dark`
- `System`

This applies to:

- directory listing pages
- file preview pages
- file editor pages

Implementation details:

- standalone pages read the same appearance preference key already used by the app
- `System` mode resolves via `prefers-color-scheme`
- page chrome now uses light/dark CSS variables instead of a hard-coded dark palette
- Ace switches between light and dark themes to match the resolved appearance
- runtime theme changes are handled for standalone pages as well

## Files changed

- `src/components/content/ThreadConversation.vue`
- `src/server/localBrowseUi.ts`
- `src/server/httpServer.ts`
- `vite.config.ts`
- `tests.md`

## Manual testing

Updated `tests.md` coverage includes:

- `:line[:column]` and `#Lline[Ccolumn]` targets
- preview/editor opening at the requested location
- full-line selection for targeted lines
- exact literal filename precedence over parsed target suffixes
- standalone local browse pages following `Light` / `Dark` / `System`
- readable Ace syntax highlighting in both light and dark themes

## Verification

Passed locally:

```bash
./node_modules/.bin/vue-tsc --noEmit
./node_modules/.bin/vite build
./node_modules/.bin/tsup