### PR TITLE
Fix stale truncated live overlay text after turn stop

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1072,8 +1072,11 @@ export function useDesktopState() {
     const threadId = selectedThreadId.value
     if (!threadId) return null
 
-    const activity = turnActivityByThreadId.value[threadId]
-    const reasoningText = (liveReasoningTextByThreadId.value[threadId] ?? '').trim()
+    const isInProgress = inProgressById.value[threadId] === true
+    const activity = isInProgress ? turnActivityByThreadId.value[threadId] : undefined
+    const reasoningText = isInProgress
+      ? (liveReasoningTextByThreadId.value[threadId] ?? '').trim()
+      : ''
     const errorText = (turnErrorByThreadId.value[threadId]?.message ?? '').trim()
 
     if (!activity && !reasoningText && !errorText) return null
@@ -1657,6 +1660,7 @@ export function useDesktopState() {
       }
     } else {
       inProgressById.value = omitKey(inProgressById.value, threadId)
+      clearCompletedTurnLiveState(threadId)
       clearInterruptPersistenceGate(threadId)
     }
     applyThreadFlags()
@@ -1947,6 +1951,9 @@ export function useDesktopState() {
     clearLivePlansForThread(threadId)
     clearLiveReasoningForThread(threadId)
     setTurnActivityForThread(threadId, null)
+    if (threadId === selectedThreadId.value) {
+      activeReasoningItemId = ''
+    }
     if (liveCommandsByThreadId.value[threadId]) {
       liveCommandsByThreadId.value = omitKey(liveCommandsByThreadId.value, threadId)
     }

--- a/tests.md
+++ b/tests.md
@@ -2378,3 +2378,27 @@ Test Codex CLI with Big Pickle model via OpenCode Zen provider.
 - To restore latest Codex CLI: `npm install -g @openai/codex@latest`
 - Remove `[model_providers.opencode-zen]` and `[profiles.pickle]` from `~/.codex/config.toml`.
 - Remove API key from environment.
+
+### Feature: Live overlay clears when a turn stops
+
+#### Prerequisites
+- App is running from this repository.
+- At least two threads exist, or one thread can be interrupted and later revisited.
+- Use a prompt that produces visible live activity near the bottom of the thread, such as reasoning text or command execution.
+
+#### Steps
+1. Open a thread and send a prompt that causes the bottom live overlay to appear with `Thinking`, `Running command`, or visible reasoning text.
+2. While the overlay is still visible, interrupt the turn from the UI.
+3. Wait for the interrupt flow to settle and the thread to leave the in-progress state.
+4. Start another prompt that produces live overlay content again.
+5. Before that second turn finishes, switch to a different thread.
+6. After the second turn has completed in the background, switch back to the original thread.
+
+#### Expected Results
+- Once the interrupted turn stops, the bottom live overlay row disappears instead of leaving faded or truncated reasoning text behind.
+- Revisiting a thread after it finishes in the background does not show stale truncated live reasoning or stale activity labels at the bottom.
+- Persisted assistant output remains visible as normal.
+- If a real turn error exists, only the error text may remain in the overlay area; stale live reasoning should not.
+
+#### Rollback/Cleanup
+- Delete the temporary test prompts or threads if they were created only for this regression test.


### PR DESCRIPTION
This PR fixes an intermittent UI bug where truncated/faded text could remain at the bottom of the conversation after a turn had already stopped.

The symptom was most visible after:
- interrupting a live turn
- switching away from a live thread and coming back after it finished in the background

## Root Cause

The leftover text was not a normal message-rendering or virtualization artifact.

It came from the dedicated bottom live overlay row that renders transient turn state such as:
- activity labels (`Thinking`, `Running command`, etc.)
- live reasoning text
- turn errors

That overlay is intentionally visually truncated/faded, so when its transient state was not cleared promptly enough, it looked like ghost/truncated text left behind at the bottom of the thread.

## What Changed

- Only show live activity/reasoning in the bottom overlay while the thread is actually marked `inProgress`.
- Clear cached live overlay state immediately when a thread leaves the in-progress state.
- Keep real turn errors visible, while preventing stale live reasoning/activity from lingering after completion.
- Add a manual regression scenario to `tests.md` covering:
  - interrupt cleanup
  - background completion after switching threads

## Why This Fix Is Safe

- It does not change persisted messages or final assistant output.
- It only affects transient live overlay state.
- Real error text is still allowed to remain visible after a failed turn.

## Testing

### Build / typecheck
- `./node_modules/.bin/vue-tsc --noEmit`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsup`

### Targeted Playwright verification
Verified with deterministic mocked notification flows for:
- interrupting a live reasoning turn while delaying the follow-up thread refresh
- switching away from a live thread, letting it complete in the background, and returning before delayed live-state reload finishes

Both scenarios confirmed that the bottom live overlay is cleared immediately and does not reappear as stale truncated text.