### PR TITLE
Fix stale live assistant fragments after completed turns

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -649,6 +649,7 @@ function normalizeMessageText(value: string): string {
 }
 
 function removeRedundantLiveAgentMessages(previous: UiMessage[], incoming: UiMessage[]): UiMessage[] {
+  const incomingMessageIds = new Set(incoming.map((message) => message.id))
   const incomingAssistantTexts = new Set(
     incoming
       .filter((message) => message.role === 'assistant')
@@ -662,6 +663,7 @@ function removeRedundantLiveAgentMessages(previous: UiMessage[], incoming: UiMes
 
   const next = previous.filter((message) => {
     if (message.messageType !== 'agentMessage.live') return true
+    if (incomingMessageIds.has(message.id)) return false
     const normalized = normalizeMessageText(message.text)
     if (normalized.length === 0) return false
     return !incomingAssistantTexts.has(normalized)
@@ -1868,6 +1870,12 @@ export function useDesktopState() {
       ...liveAgentMessagesByThreadId.value,
       [threadId]: nextMessages,
     }
+  }
+
+  function clearLiveAgentMessagesForThread(threadId: string): void {
+    if (!threadId) return
+    if (!(threadId in liveAgentMessagesByThreadId.value)) return
+    liveAgentMessagesByThreadId.value = omitKey(liveAgentMessagesByThreadId.value, threadId)
   }
 
   function setLiveFileChangeMessagesForThread(threadId: string, nextMessages: UiMessage[]): void {
@@ -3422,8 +3430,12 @@ export function useDesktopState() {
       setPersistedMessagesForThread(threadId, mergedMessages)
 
       const previousLiveAgent = liveAgentMessagesByThreadId.value[threadId] ?? []
-      const nextLiveAgent = removeRedundantLiveAgentMessages(previousLiveAgent, nextMessages)
-      setLiveAgentMessagesForThread(threadId, nextLiveAgent)
+      if (inProgress) {
+        const nextLiveAgent = removeRedundantLiveAgentMessages(previousLiveAgent, nextMessages)
+        setLiveAgentMessagesForThread(threadId, nextLiveAgent)
+      } else {
+        clearLiveAgentMessagesForThread(threadId)
+      }
       removeLiveCommandsPersistedIn(threadId, nextMessages)
       removeLiveFileChangesPersistedIn(threadId, nextMessages)
 

--- a/tests.md
+++ b/tests.md
@@ -2402,3 +2402,25 @@ Test Codex CLI with Big Pickle model via OpenCode Zen provider.
 
 #### Rollback/Cleanup
 - Delete the temporary test prompts or threads if they were created only for this regression test.
+
+### Feature: Stale partial live assistant text clears after turn completion
+
+#### Prerequisites
+- App is running from this repository.
+- At least one thread can produce streaming assistant text for several seconds.
+
+#### Steps
+1. Open a thread and send a prompt that causes the assistant response to stream progressively.
+2. While the assistant text is still streaming, note a distinctive partial sentence near the bottom of the conversation.
+3. Let the turn finish normally.
+4. Confirm the final persisted assistant response remains in the conversation.
+5. Switch to a different thread, then return to the original thread.
+6. Trigger a reload path if needed by refreshing thread data or waiting for the normal thread sync.
+
+#### Expected Results
+- The partial live assistant fragment does not remain pinned at the bottom after the turn has completed.
+- Returning to the thread does not resurrect a stale partial assistant sentence beneath the persisted messages.
+- Only the final persisted assistant response remains visible.
+
+#### Rollback/Cleanup
+- Delete the temporary test prompt or thread if it was created only for this regression test.


### PR DESCRIPTION
## Summary

Fix a UI state bug where a partial live assistant message could remain pinned at the bottom of a thread after the turn had already completed.

This was separate from the earlier live-overlay cleanup. In this case, the stale row was a cached `agentMessage.live` fragment that could survive thread switches and only disappeared after a full browser reload.

## Problem

A thread could keep showing an old partial assistant sentence even after the final persisted assistant response was already available.

Typical symptoms:
- a truncated assistant fragment remained visible at the bottom of the conversation
- switching to another thread and coming back did not clear it
- reloading the browser tab did clear it

That strongly suggested stale in-memory live message state rather than bad persisted history.

## Root Cause

`liveAgentMessagesByThreadId` was only cleaned up by text-based deduplication against persisted assistant messages.

That was too weak in two cases:
- the final persisted assistant text did not exactly match the streamed partial fragment
- a thread completed in the background, so the cached live assistant row could survive until a reload rebuilt state from persisted history

## Changes

### `src/composables/useDesktopState.ts`

- strengthen `removeRedundantLiveAgentMessages(...)` to drop live agent messages when an incoming persisted message has the same message id
- add `clearLiveAgentMessagesForThread(threadId)`
- in `loadMessages(...)`:
  - keep the existing dedupe path while a thread is still `inProgress`
  - fully clear cached live assistant messages when the loaded thread is no longer `inProgress`

### `tests.md`

- add a manual regression section for stale partial live assistant text after turn completion

## Result

After a turn completes:
- stale partial assistant fragments are removed
- revisiting a thread after background completion does not resurrect the stale fragment
- only the final persisted assistant response remains visible

## Testing

- `./node_modules/.bin/vue-tsc --noEmit`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsup`

Manual regression steps were also added to `tests.md`.
