### PR TITLE
Unify provider proxy handling for completions and responses

### DIFF
--- a/ProxySpec.md
+++ b/ProxySpec.md
@@ -218,12 +218,37 @@ Rules:
 - Network/proxy failures return `502` with `Proxy error: <message>`.
 - The proxy must not replace provider errors with unrelated auth-refresh errors.
 
-## Known Limits
+## Caveats
 
-- Non-function tools are not converted into Chat Completions tools.
-- Streaming tool-call deltas from Chat Completions are not fully reconstructed; tool-capable turns should rely on non-streaming or provider behavior that returns complete tool calls.
-- Provider-specific built-in tools need explicit wrapper support.
-- If a provider only supports a non-OpenAI-compatible schema, it needs a new wrapper or adapter.
+The proxy is a compatibility adapter, not a guarantee that every provider behaves identically to OpenAI Responses API.
+
+- No custom prompts are injected by the proxy. Behavior changes come from request/response translation only.
+- Completions mode still presents a local Responses API surface to Codex. This is intentional because Codex tool execution depends on Responses-shaped tool-loop semantics.
+- OpenRouter Responses mode sanitizes unsupported tool entries. This avoids schema rejection, but it also means unsupported provider tools are not available unless explicitly allowed by the OpenRouter wrapper.
+- Non-function tools are not converted into Chat Completions tools. Standard Chat Completions only supports function tools in the shape this proxy emits.
+- Streaming tool-call deltas from Chat Completions are not fully reconstructed. Tool-capable turns should rely on non-streaming responses or providers that return complete tool calls.
+- Provider-specific built-in tools need explicit wrapper support. Adding a provider does not automatically make its custom tool types work.
+- Custom endpoints are assumed to be OpenAI-compatible. If a custom provider has a non-OpenAI schema, it needs a dedicated wrapper or adapter.
+- The proxy cannot make a weak model use tools correctly. It can preserve the protocol path, but tool-call quality still depends on the selected model.
+- Large context, provider rate limits, provider payload limits, and provider-side safety/filtering errors are still upstream constraints.
+- Chat Completions translation is intentionally conservative. Unknown Responses fields are not all mirrored into Chat payloads because sending provider-unsupported fields can break otherwise valid requests.
+- Error forwarding depends on upstream response shape. JSON provider errors are preserved best; HTML/plain-text failures are wrapped into a JSON error for Codex.
+- Local proxy placeholder bearer tokens are not security boundaries. They prevent Codex from needing direct provider keys, but the app server still holds and forwards the real key.
+
+## TODO
+
+- Add automated unit tests for Responses-to-Chat message conversion, including `function_call`, `function_call_output`, and `developer` role mapping.
+- Add automated unit tests for Chat-to-Responses conversion, including assistant text, tool calls, usage mapping, and empty choices.
+- Add integration tests with mocked upstream providers for OpenRouter, OpenCode Zen, and custom endpoint modes.
+- Add a regression test for the OpenRouter invalid tool discriminator failure.
+- Add a regression test that asks for `codex --version` in Completions mode and verifies a bash/tool call is emitted and completed.
+- Add explicit handling for Chat Completions streaming tool-call deltas if providers used in practice stream tool calls instead of returning complete tool calls.
+- Add structured proxy diagnostics in development mode that show selected upstream protocol, sanitized tool count, and upstream status without logging secrets.
+- Add provider capability metadata so the UI can warn when a selected mode/provider combination has known limitations.
+- Add a small compatibility matrix to the settings UI or docs for tested models/providers.
+- Add stricter validation for custom endpoint base URLs before saving settings.
+- Add opt-in debug capture for raw upstream request/response metadata with API keys and payload content redacted.
+- Revisit OpenCode Zen `responsesPayloadFormat: "chat"` after upstream behavior stabilizes or official docs clarify the expected payload.
 
 ## Manual Verification
 

--- a/ProxySpec.md
+++ b/ProxySpec.md
@@ -1,0 +1,247 @@
+# Provider Proxy Spec
+
+This document describes the local provider proxy used by Codex Web Local for OpenRouter, OpenCode Zen, and custom OpenAI-compatible endpoints.
+
+## Goal
+
+Codex CLI expects to talk to a Responses API-compatible provider. Many third-party providers either only support Chat Completions or support Responses with provider-specific tool restrictions. The local proxy keeps Codex speaking Responses API while adapting requests and responses to the selected upstream provider.
+
+Success criteria:
+
+- Codex always receives Responses-shaped responses from the local app server.
+- Providers can be used in either Responses mode or Completions mode when supported.
+- Tool calls, tool results, and bash execution continue to work in Completions mode.
+- Upstream provider errors are returned as-is whenever possible.
+- Provider-specific payload fixes are isolated in provider-specific wrappers.
+
+## Local Routes
+
+The app server exposes one Responses-compatible route per provider:
+
+| Provider | Local route | Upstream Responses | Upstream Chat Completions |
+| --- | --- | --- | --- |
+| OpenRouter | `/codex-api/openrouter-proxy/v1/responses` | `https://openrouter.ai/api/v1/responses` | `https://openrouter.ai/api/v1/chat/completions` |
+| OpenCode Zen | `/codex-api/zen-proxy/v1/responses` | `https://opencode.ai/zen/v1/responses` | `https://opencode.ai/zen/v1/chat/completions` |
+| Custom endpoint | `/codex-api/custom-proxy/v1/responses` | `<baseUrl>/responses` | `<baseUrl>/chat/completions` |
+
+Even when the user selects Completions mode, Codex is configured to call the local `/responses` route. The proxy performs the final upstream protocol conversion.
+
+## Runtime Configuration
+
+When the app server port is known, provider config is passed to Codex CLI with `-c` arguments instead of modifying `~/.codex/config.toml`.
+
+OpenRouter:
+
+```toml
+model_provider = "openrouter-free"
+model_providers.openrouter-free.base_url = "http://127.0.0.1:<port>/codex-api/openrouter-proxy/v1"
+model_providers.openrouter-free.wire_api = "responses"
+model_providers.openrouter-free.experimental_bearer_token = "openrouter-proxy-token"
+```
+
+OpenCode Zen:
+
+```toml
+model_provider = "opencode-zen"
+model_providers.opencode-zen.base_url = "http://127.0.0.1:<port>/codex-api/zen-proxy/v1"
+model_providers.opencode-zen.wire_api = "responses"
+model_providers.opencode-zen.experimental_bearer_token = "zen-proxy-token"
+```
+
+Custom endpoint:
+
+```toml
+model_provider = "custom-endpoint"
+model_providers.custom-endpoint.base_url = "http://127.0.0.1:<port>/codex-api/custom-proxy/v1"
+model_providers.custom-endpoint.wire_api = "responses"
+model_providers.custom-endpoint.experimental_bearer_token = "custom-proxy-token"
+```
+
+The token in Codex config is only a local proxy placeholder. The real provider key is read by the app server from `~/.codex/webui-free-mode.json`.
+
+## Mode Selection
+
+The persisted provider state contains `wireApi`:
+
+```ts
+type WireApi = 'responses' | 'chat'
+```
+
+The UI labels these as:
+
+- `Responses`: forward to upstream Responses API.
+- `Completions`: convert to upstream Chat Completions API.
+
+For local proxy routes, Codex still uses `wire_api="responses"` in both modes. `wireApi` controls only what the proxy sends upstream.
+
+## Unified Proxy Flow
+
+All provider wrappers call `handleUnifiedResponsesProxyRequest`.
+
+High-level flow:
+
+1. Read the incoming Responses request from Codex.
+2. Load the real provider bearer token and selected `wireApi`.
+3. Decide upstream protocol:
+   - Responses mode: send Responses payload upstream.
+   - Completions mode: convert to Chat Completions payload.
+   - Provider fallback: optionally force Responses when tools require it.
+4. Send request to upstream provider.
+5. If upstream used Chat Completions, convert the response back to Responses format.
+6. Return status, body, and errors to Codex.
+
+## Responses To Chat Translation
+
+When using Chat Completions upstream, the proxy maps:
+
+| Responses field/item | Chat Completions field/item |
+| --- | --- |
+| `input: string` | one `user` message |
+| `instructions` | one leading `system` message |
+| `input[].type = "message"` | message with mapped role |
+| `role = "developer"` | `system` role |
+| `function_call` | assistant message with `tool_calls` |
+| `function_call_output` | `tool` message with `tool_call_id` |
+| `computer_call_output` | `tool` message with `tool_call_id` |
+| `max_output_tokens` | `max_tokens` |
+| `temperature` | `temperature` |
+| `top_p` | `top_p` |
+| `tools[].type = "function"` | `tools[].type = "function"` with nested `function` object |
+| `tool_choice` function | Chat function `tool_choice` |
+
+Unsupported non-function tools are omitted from Chat Completions payloads because standard Chat Completions only accepts function tools.
+
+## Chat To Responses Translation
+
+When upstream returns a Chat Completions response, the proxy maps:
+
+| Chat Completions item | Responses item |
+| --- | --- |
+| `choices[].message.content` | `output[].type = "message"` with `output_text` |
+| `choices[].message.tool_calls[]` | `output[].type = "function_call"` |
+| `tool_calls[].id` | `call_id` |
+| `tool_calls[].function.name` | `name` |
+| `tool_calls[].function.arguments` | `arguments` |
+| `usage.prompt_tokens` | `usage.input_tokens` |
+| `usage.completion_tokens` | `usage.output_tokens` |
+| `usage.total_tokens` | `usage.total_tokens` |
+
+This is the critical part that lets Codex continue its tool loop after a Chat Completions provider asks for a bash/tool call.
+
+## Streaming Behavior
+
+If Chat Completions streaming is active and no tool loop is involved, the proxy converts streaming chat deltas into Responses-style server-sent events:
+
+- `response.created`
+- `response.output_item.added`
+- `response.content_part.added`
+- `response.output_text.delta`
+- `response.output_text.done`
+- `response.content_part.done`
+- `response.output_item.done`
+- `response.completed`
+
+If the upstream Chat Completions response is non-streaming but Codex requested streaming, the proxy sends a synthetic Responses SSE completion from the final converted response.
+
+## Provider Wrappers
+
+Provider wrappers only define provider-specific endpoints and behavior.
+
+### OpenRouter
+
+OpenRouter wrapper:
+
+- Responses endpoint: `https://openrouter.ai/api/v1/responses`
+- Chat endpoint: `https://openrouter.ai/api/v1/chat/completions`
+- Allows fallback to Responses when tools or tool outputs are present.
+- Sanitizes Responses tool entries before forwarding to OpenRouter.
+
+Allowed OpenRouter Responses tool types:
+
+- `function`
+- `openrouter:datetime`
+- `openrouter:image_generation`
+- `openrouter:experimental__search_models`
+- `openrouter:web_search`
+
+If no valid tools remain after sanitization, the proxy removes both `tools` and `tool_choice`.
+
+This prevents OpenRouter from rejecting Codex-local tool descriptors with errors like:
+
+```text
+Invalid Responses API request
+tools[N]: No matching discriminator
+```
+
+### OpenCode Zen
+
+OpenCode Zen wrapper:
+
+- Responses endpoint: `https://opencode.ai/zen/v1/responses`
+- Chat endpoint: `https://opencode.ai/zen/v1/chat/completions`
+- Uses `responsesPayloadFormat: "chat"` for Responses endpoint compatibility.
+- Does not fallback to Responses for tool traffic in Completions mode.
+
+### Custom Endpoint
+
+Custom endpoint wrapper:
+
+- Responses endpoint: `<baseUrl>/responses`
+- Chat endpoint: `<baseUrl>/chat/completions`
+- Does not filter provider-advertised models.
+- Does not apply provider-specific tool sanitization.
+- Returns upstream errors without rewriting them when possible.
+
+## Why Direct Chat Mode Was Not Enough
+
+Directly setting Codex to `wire_api="chat"` is not reliable for this app because Codex and the app server expect Responses-shaped tool-loop semantics. A plain Chat Completions provider can return valid text, but Codex may not receive the function-call output shape it needs to continue with bash/tool execution.
+
+The local proxy solves this by:
+
+- Presenting Responses API to Codex.
+- Translating Chat Completions tool calls back into Responses `function_call` items.
+- Translating tool results from Responses input back into Chat `tool` messages on the next request.
+
+## Why OpenRouter Failed Before
+
+The failing `hi` case happened because Codex sent a Responses request containing tool entries that OpenRouter does not accept in its Responses schema. OpenRouter validated the full `tools` array and rejected the request before the model could answer.
+
+The proxy fix avoids that failure by sanitizing OpenRouter Responses tools and by routing Completions mode through the unified adapter.
+
+## Error Handling
+
+Rules:
+
+- Missing local provider key returns a local `401` with the provider-specific missing-key message.
+- Upstream JSON errors are forwarded with their original status when possible.
+- Non-JSON upstream failures are returned as JSON with the raw response prefix as the message.
+- Network/proxy failures return `502` with `Proxy error: <message>`.
+- The proxy must not replace provider errors with unrelated auth-refresh errors.
+
+## Known Limits
+
+- Non-function tools are not converted into Chat Completions tools.
+- Streaming tool-call deltas from Chat Completions are not fully reconstructed; tool-capable turns should rely on non-streaming or provider behavior that returns complete tool calls.
+- Provider-specific built-in tools need explicit wrapper support.
+- If a provider only supports a non-OpenAI-compatible schema, it needs a new wrapper or adapter.
+
+## Manual Verification
+
+Recommended smoke tests:
+
+1. OpenRouter Responses mode, send `hi`.
+2. OpenRouter Completions mode, ask `what codex cli version is?`; verify bash runs.
+3. OpenCode Zen Completions mode, ask `what codex cli version is?`; verify bash runs.
+4. Custom endpoint Completions mode against `http://127.0.0.1:8666/v1`, ask `what codex cli version is?`; verify bash runs.
+5. Custom endpoint model list should keep provider-advertised models, including `auto-*` aliases.
+6. Provider errors should display the actual upstream message.
+
+## Code Map
+
+- Unified adapter: `src/server/unifiedResponsesProxy.ts`
+- OpenRouter wrapper: `src/server/openRouterProxy.ts`
+- OpenCode Zen wrapper: `src/server/zenProxy.ts`
+- Custom endpoint wrapper: `src/server/customEndpointProxy.ts`
+- Provider CLI config: `src/server/freeMode.ts`
+- App server proxy routes: `src/server/codexAppServerBridge.ts`
+- UI API mode toggles: `src/App.vue`

--- a/src/App.vue
+++ b/src/App.vue
@@ -689,7 +689,7 @@
                   :cwd="composerCwd"
                   :collaboration-modes="availableCollaborationModes"
                   :selected-collaboration-mode="selectedCollaborationMode"
-                  :models="availableModelIds" :selected-model="selectedModelId"
+                  :models="availableModelIds" :selected-model="composerSelectedModelId"
                   :selected-reasoning-effort="selectedReasoningEffort"
                   :selected-speed-mode="selectedSpeedMode"
                   :is-updating-speed-mode="isUpdatingSpeedMode"
@@ -750,7 +750,7 @@
                     :collaboration-modes="availableCollaborationModes"
                     :selected-collaboration-mode="selectedCollaborationMode"
                     :models="availableModelIds"
-                    :selected-model="selectedModelId"
+                    :selected-model="composerSelectedModelId"
                     :selected-reasoning-effort="selectedReasoningEffort"
                     :selected-speed-mode="selectedSpeedMode"
                     :is-updating-speed-mode="isUpdatingSpeedMode"
@@ -1014,7 +1014,8 @@ const {
   removeQueuedMessage,
   steerQueuedMessage,
   setSelectedCollaborationMode,
-  setSelectedModelId,
+  readModelIdForThread,
+  setSelectedModelIdForThread,
 
   setSelectedReasoningEffort,
   updateSelectedSpeedMode,
@@ -1196,6 +1197,7 @@ const latestUserTurnId = computed(() => {
 })
 const liveOverlay = computed(() => selectedLiveOverlay.value)
 const composerThreadContextId = computed(() => (isHomeRoute.value ? '__new-thread__' : selectedThreadId.value))
+const composerSelectedModelId = computed(() => readModelIdForThread(composerThreadContextId.value))
 const selectedThreadPendingRequest = computed<UiServerRequest | null>(() => {
   const rows = selectedThreadServerRequests.value
   return rows.length > 0 ? rows[rows.length - 1] : null
@@ -2542,7 +2544,7 @@ function collapsePathSegments(rawSegments: readonly string[]): string[] {
 }
 
 function onSelectModel(modelId: string): void {
-  setSelectedModelId(modelId)
+  setSelectedModelIdForThread(composerThreadContextId.value, modelId)
 }
 
 function onSelectReasoningEffort(effort: ReasoningEffort | ''): void {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3891,7 +3891,7 @@ export function useDesktopState() {
 
     const nextText = text.trim()
     const targetCwd = cwd.trim()
-    const selectedModel = selectedModelId.value.trim()
+    const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
     if (!nextText && imageUrls.length === 0 && fileAttachments.length === 0) return ''
 
     isSendingMessage.value = true
@@ -3929,7 +3929,7 @@ export function useDesktopState() {
         {
           label: 'Thinking',
           details: buildPendingTurnDetails(
-            selectedModelId.value,
+            readModelIdForThread(threadId),
             selectedReasoningEffort.value,
             selectedCollaborationMode.value,
           ),

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1159,6 +1159,14 @@ export function useDesktopState() {
   })
 
   function readModelIdForThread(threadId: string): string {
+    const contextId = toThreadContextId(threadId)
+    if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
+      const providerContextId = toProviderModelContextId(activeProviderId.value)
+      const providerModelId = providerContextId
+        ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
+        : ''
+      if (providerModelId) return providerModelId
+    }
     return readSelectedModel(selectedModelIdByContext.value, threadId).trim()
   }
 
@@ -1189,9 +1197,9 @@ export function useDesktopState() {
     shouldAutoScrollOnNextAgentEvent = false
   }
 
-  function setSelectedModelId(modelId: string): void {
+  function setSelectedModelIdForThread(threadId: string, modelId: string): void {
     const normalizedModelId = modelId.trim()
-    const contextId = toThreadContextId(selectedThreadId.value)
+    const contextId = toThreadContextId(threadId)
     if (normalizedModelId) {
       const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
       nextModelMap[contextId] = normalizedModelId
@@ -1199,8 +1207,12 @@ export function useDesktopState() {
     } else {
       selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, contextId)
     }
-    selectedModelId.value = readModelIdForThread(selectedThreadId.value)
-    ensureAvailableModelIds(selectedModelId.value)
+    if (threadId.trim() === selectedThreadId.value) {
+      selectedModelId.value = readModelIdForThread(selectedThreadId.value)
+      ensureAvailableModelIds(selectedModelId.value)
+    } else {
+      ensureAvailableModelIds(normalizedModelId)
+    }
     if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
       const providerContextId = toProviderModelContextId(activeProviderId.value)
       if (providerContextId) {
@@ -1214,6 +1226,10 @@ export function useDesktopState() {
       }
     }
     saveSelectedModelMap(selectedModelIdByContext.value)
+  }
+
+  function setSelectedModelId(modelId: string): void {
+    setSelectedModelIdForThread(selectedThreadId.value, modelId)
   }
 
   function setThreadModelId(threadId: string, modelId: string): void {
@@ -4636,6 +4652,8 @@ export function useDesktopState() {
     removeQueuedMessage,
     steerQueuedMessage,
     setSelectedCollaborationMode,
+    readModelIdForThread,
+    setSelectedModelIdForThread,
     setSelectedModelId,
 
     setSelectedReasoningEffort,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -28,6 +28,7 @@ import {
 } from './freeMode.js'
 import { handleOpenRouterProxyRequest } from './openRouterProxy.js'
 import { handleZenProxyRequest } from './zenProxy.js'
+import { handleCustomEndpointProxyRequest } from './customEndpointProxy.js'
 import { getSpawnInvocation } from '../utils/commandInvocation.js'
 import {
   resolveCodexCommand,
@@ -3060,6 +3061,21 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           wireApi = state.wireApi === 'chat' ? 'chat' : 'responses'
         } catch { /* use empty */ }
         handleOpenRouterProxyRequest(req, res, bearerToken, wireApi)
+        return
+      }
+
+      if (url.pathname === '/codex-api/custom-proxy/v1/responses' && req.method === 'POST') {
+        const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
+        let bearerToken = ''
+        let wireApi: 'responses' | 'chat' = 'responses'
+        let baseUrl = ''
+        try {
+          const state = JSON.parse(readFileSync(statePath, 'utf8')) as FreeModeState
+          bearerToken = state.apiKey ?? ''
+          wireApi = state.wireApi === 'chat' ? 'chat' : 'responses'
+          baseUrl = state.customBaseUrl ?? ''
+        } catch { /* use empty */ }
+        handleCustomEndpointProxyRequest(req, res, { baseUrl, bearerToken, wireApi })
         return
       }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -551,7 +551,7 @@ async function fetchCustomEndpointDefaultModel(baseUrl: string, apiKey: string):
     if (!response.ok) return ''
     const payload = await response.json() as unknown
     const modelIds = normalizeProviderModelsData(payload)
-    return modelIds.find((modelId) => !/^auto[-_]/iu.test(modelId)) ?? modelIds[0] ?? ''
+    return modelIds[0] ?? ''
   } catch {
     return ''
   }
@@ -3619,7 +3619,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
                 const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
                 if (resp.ok) {
                   const json = await resp.json() as unknown
-                  const ids = normalizeProviderModelsData(json).filter((id) => !/^auto[-_]/iu.test(id))
+                  const ids = normalizeProviderModelsData(json)
                   const currentModel = fmState.model?.trim() ?? ''
                   const orderedIds = currentModel && ids.includes(currentModel)
                     ? [currentModel, ...ids.filter((id) => id !== currentModel)]

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -540,6 +540,23 @@ function normalizeProviderModelsData(payload: unknown): string[] {
   return ids
 }
 
+async function fetchCustomEndpointDefaultModel(baseUrl: string, apiKey: string): Promise<string> {
+  const normalizedBaseUrl = baseUrl.trim()
+  if (!normalizedBaseUrl) return ''
+
+  try {
+    const modelsUrl = buildProviderModelsUrl(normalizedBaseUrl, null)
+    const headers: Record<string, string> = apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+    const response = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(PROVIDER_MODELS_FETCH_TIMEOUT_MS) })
+    if (!response.ok) return ''
+    const payload = await response.json() as unknown
+    const modelIds = normalizeProviderModelsData(payload)
+    return modelIds.find((modelId) => !/^auto[-_]/iu.test(modelId)) ?? modelIds[0] ?? ''
+  } catch {
+    return ''
+  }
+}
+
 async function readProviderBackedModelIds(appServer: AppServerProcess): Promise<ProviderModelsResponse> {
   const configPayload = asRecord(await appServer.rpc('config/read', {}))
   const config = asRecord(configPayload?.config)
@@ -3253,7 +3270,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             }
             const resolvedModel = providerType === 'openrouter'
               ? (current.model || FREE_MODE_DEFAULT_MODEL)
-              : ''
+              : providerType === 'custom'
+                ? await fetchCustomEndpointDefaultModel(baseUrl, resolvedKey)
+                : ''
             const state: FreeModeState = {
               enabled: true,
               apiKey: resolvedKey,
@@ -3599,9 +3618,13 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
                 }
                 const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
                 if (resp.ok) {
-                  const json = await resp.json() as { data?: Array<{ id: string }> }
-                  const ids = (json.data ?? []).map(m => m.id).filter(Boolean)
-                  setJson(res, 200, { data: ids, exclusive: true, source: 'custom' })
+                  const json = await resp.json() as unknown
+                  const ids = normalizeProviderModelsData(json).filter((id) => !/^auto[-_]/iu.test(id))
+                  const currentModel = fmState.model?.trim() ?? ''
+                  const orderedIds = currentModel && ids.includes(currentModel)
+                    ? [currentModel, ...ids.filter((id) => id !== currentModel)]
+                    : ids
+                  setJson(res, 200, { data: orderedIds, exclusive: true, source: 'custom' })
                   return
                 }
               } catch {

--- a/src/server/customEndpointProxy.ts
+++ b/src/server/customEndpointProxy.ts
@@ -1,0 +1,25 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { handleUnifiedResponsesProxyRequest } from './unifiedResponsesProxy.js'
+
+function joinEndpoint(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/u, '')}${path}`
+}
+
+export function handleCustomEndpointProxyRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: {
+    baseUrl: string
+    bearerToken: string
+    wireApi: 'responses' | 'chat'
+  },
+): void {
+  handleUnifiedResponsesProxyRequest(req, res, {
+    bearerToken: options.bearerToken,
+    wireApi: options.wireApi,
+    responsesEndpoint: joinEndpoint(options.baseUrl, '/responses'),
+    chatCompletionsEndpoint: joinEndpoint(options.baseUrl, '/chat/completions'),
+    missingKeyMessage: 'Missing custom endpoint API key',
+    allowToolFallbackToResponses: false,
+  })
+}

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -187,13 +187,19 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
   }
 
   if (state.provider === 'custom' && state.customBaseUrl) {
-    const wireApi = state.wireApi || 'responses'
+    const baseUrl = serverPort
+      ? `http://127.0.0.1:${serverPort}/codex-api/custom-proxy/v1`
+      : state.customBaseUrl
+    const wireApi = serverPort ? 'responses' : (state.wireApi || 'responses')
+    const authArgs: string[] = serverPort
+      ? ['-c', `model_providers.${CUSTOM_PROVIDER_ID}.experimental_bearer_token="custom-proxy-token"`]
+      : ['-c', `model_providers.${CUSTOM_PROVIDER_ID}.env_key="CUSTOM_ENDPOINT_API_KEY"`]
     return [
       '-c', `model_provider="${CUSTOM_PROVIDER_ID}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.name="Custom Endpoint"`,
-      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.base_url="${state.customBaseUrl}"`,
+      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.base_url="${baseUrl}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.wire_api="${wireApi}"`,
-      '-c', `model_providers.${CUSTOM_PROVIDER_ID}.env_key="CUSTOM_ENDPOINT_API_KEY"`,
+      ...authArgs,
     ]
   }
 

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -194,7 +194,11 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
     const authArgs: string[] = serverPort
       ? ['-c', `model_providers.${CUSTOM_PROVIDER_ID}.experimental_bearer_token="custom-proxy-token"`]
       : ['-c', `model_providers.${CUSTOM_PROVIDER_ID}.env_key="CUSTOM_ENDPOINT_API_KEY"`]
+    const modelArgs: string[] = state.model?.trim()
+      ? ['-c', `model="${state.model.trim()}"`]
+      : []
     return [
+      ...modelArgs,
       '-c', `model_provider="${CUSTOM_PROVIDER_ID}"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.name="Custom Endpoint"`,
       '-c', `model_providers.${CUSTOM_PROVIDER_ID}.base_url="${baseUrl}"`,

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -58,6 +58,7 @@ export type UnifiedProxyOptions = {
   chatCompletionsEndpoint: string
   missingKeyMessage: string
   allowToolFallbackToResponses: boolean
+  responsesPayloadFormat?: 'raw' | 'chat'
   sanitizeResponsesRequest?: (payload: Record<string, unknown>) => Record<string, unknown>
 }
 
@@ -397,17 +398,18 @@ export function handleUnifiedResponsesProxyRequest(
       const hasToolOutputs = hasToolOutputsInInput(parsedBody.input)
       const useResponsesFallback = options.allowToolFallbackToResponses && (hasTools || hasToolOutputs)
       const useChatCompletions = options.wireApi === 'chat' && !useResponsesFallback
+      const useChatPayload = useChatCompletions || options.responsesPayloadFormat === 'chat'
       const isStreaming = parsedBody.stream === true
       const effectiveStreaming = useChatCompletions && isStreaming && !(hasTools || hasToolOutputs)
 
       let payload = ''
       let upstreamUrl: URL
 
-      if (useChatCompletions) {
+      if (useChatPayload) {
         const chatReq: ChatCompletionsRequest = {
           model: parsedBody.model,
           messages: responsesInputToMessages(parsedBody.input, parsedBody.instructions),
-          stream: effectiveStreaming,
+          stream: useChatCompletions ? effectiveStreaming : isStreaming,
         }
         if (parsedBody.temperature != null) chatReq.temperature = parsedBody.temperature
         if (parsedBody.top_p != null) chatReq.top_p = parsedBody.top_p
@@ -417,7 +419,7 @@ export function handleUnifiedResponsesProxyRequest(
         if (chatTools) chatReq.tools = chatTools
         if (chatToolChoice) chatReq.tool_choice = chatToolChoice
         payload = JSON.stringify(chatReq)
-        upstreamUrl = new URL(options.chatCompletionsEndpoint)
+        upstreamUrl = new URL(useChatCompletions ? options.chatCompletionsEndpoint : options.responsesEndpoint)
       } else {
         const requestBody =
           parsedBody && typeof parsedBody === 'object' && !Array.isArray(parsedBody)

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { request as httpRequest } from 'node:http'
 import { request as httpsRequest } from 'node:https'
 
 type ResponsesApiInput = {
@@ -398,9 +399,10 @@ export function handleUnifiedResponsesProxyRequest(
         upstreamUrl = new URL(options.responsesEndpoint)
       }
 
-      const proxyReq = httpsRequest({
+      const requestFn = upstreamUrl.protocol === 'http:' ? httpRequest : httpsRequest
+      const proxyReq = requestFn({
         hostname: upstreamUrl.hostname,
-        port: upstreamUrl.port || 443,
+        port: upstreamUrl.port || (upstreamUrl.protocol === 'http:' ? 80 : 443),
         path: upstreamUrl.pathname,
         method: 'POST',
         headers: {

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -79,6 +79,34 @@ function safeStringifyUnknown(value: unknown): string {
   }
 }
 
+function appendAssistantText(messages: ChatMessage[], text: string): void {
+  const trimmedText = text.trim()
+  if (!trimmedText) return
+
+  const lastMessage = messages[messages.length - 1]
+  if (lastMessage?.role === 'assistant' && Array.isArray(lastMessage.tool_calls)) {
+    lastMessage.content = lastMessage.content
+      ? `${lastMessage.content}\n${trimmedText}`
+      : trimmedText
+    return
+  }
+
+  messages.push({ role: 'assistant', content: trimmedText })
+}
+
+function appendAssistantToolCall(
+  messages: ChatMessage[],
+  toolCall: NonNullable<ChatMessage['tool_calls']>[number],
+): void {
+  const lastMessage = messages[messages.length - 1]
+  if (lastMessage?.role === 'assistant' && !lastMessage.tool_call_id) {
+    lastMessage.tool_calls = [...(lastMessage.tool_calls ?? []), toolCall]
+    return
+  }
+
+  messages.push({ role: 'assistant', tool_calls: [toolCall] })
+}
+
 function responsesInputToMessages(input: string | ResponsesApiInput[], instructions?: string): ChatMessage[] {
   const messages: ChatMessage[] = []
   if (instructions) {
@@ -103,7 +131,11 @@ function responsesInputToMessages(input: string | ResponsesApiInput[], instructi
               .join('\n')
           : (typeof item.text === 'string' ? item.text : '')
       const role = item.role === 'developer' ? 'system' : item.role
-      messages.push({ role, content: text })
+      if (role === 'assistant') {
+        appendAssistantText(messages, text)
+      } else {
+        messages.push({ role, content: text })
+      }
       continue
     }
 
@@ -117,16 +149,13 @@ function responsesInputToMessages(input: string | ResponsesApiInput[], instructi
     }
 
     if (item.type === 'function_call' && item.call_id && item.name) {
-      messages.push({
-        role: 'assistant',
-        tool_calls: [{
-          id: item.call_id,
-          type: 'function',
-          function: {
-            name: item.name,
-            arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
-          },
-        }],
+      appendAssistantToolCall(messages, {
+        id: item.call_id,
+        type: 'function',
+        function: {
+          name: item.name,
+          arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
+        },
       })
     }
   }

--- a/src/server/zenProxy.ts
+++ b/src/server/zenProxy.ts
@@ -17,5 +17,6 @@ export function handleZenProxyRequest(
     chatCompletionsEndpoint: ZEN_CHAT_COMPLETIONS_ENDPOINT,
     missingKeyMessage: 'Missing OpenCode Zen API key',
     allowToolFallbackToResponses: false,
+    responsesPayloadFormat: 'chat',
   })
 }

--- a/tests.md
+++ b/tests.md
@@ -2653,6 +2653,36 @@ Both OpenRouter and OpenCode Zen routes use a unified Responses proxy layer that
 #### Rollback/Cleanup
 - Switch provider/API format back to preferred defaults
 
+### OpenCode Zen Responses Payload Normalization
+
+#### Feature/Change Name
+OpenCode Zen `Responses` mode converts Codex Responses `input` payloads to Zen-compatible `messages` payloads.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. OpenCode Zen API key configured
+
+#### Steps
+1. Open Settings
+2. Set Provider to `OpenCode Zen`
+3. Set API format to `Responses`
+4. Save
+5. Select model `trinity-large-preview-free`
+6. Send `hi`
+7. Switch API format to `Completions`
+8. Save
+9. Select model `trinity-large-preview-free`
+10. Send `hi`
+
+#### Expected Results
+- `Responses` mode posts to `/zen/v1/responses` with a `messages` payload derived from Codex Responses `input`
+- `trinity-large-preview-free` returns a successful assistant greeting in `Responses` mode
+- `Completions` mode still posts through `/zen/v1/chat/completions` and returns a successful assistant greeting
+- Models unsupported by Zen for a chosen format, such as `minimax-m2.5-free` in `Responses` mode, surface the upstream error without being hidden
+
+#### Rollback/Cleanup
+- Switch provider/API format back to preferred defaults
+
 ---
 
 ### Raw auth/provider error messages

--- a/tests.md
+++ b/tests.md
@@ -2742,3 +2742,31 @@ Custom endpoint `Completions` mode uses a local Responses-compatible proxy so cu
 
 #### Rollback/Cleanup
 - Switch provider/API format back to preferred defaults
+
+---
+
+### TestChat GLM-5 new-thread model selection
+
+#### Feature/Change Name
+New TestChat threads use the provider-scoped model selected in the new-thread composer.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Custom endpoint provider configured for `http://127.0.0.1:8666/v1`
+3. Custom endpoint API format set to `Completions`
+4. The local endpoint advertises model `glm-5`
+
+#### Steps
+1. Open the app home page
+2. Select project `TestChat`
+3. Select model `glm-5` in the new-thread composer
+4. Send `create todo list app`
+5. Inspect the created session metadata or UI model selector for the new thread
+
+#### Expected Results
+- The new thread starts with model `glm-5`, not the previous model from another provider or context
+- The running turn uses the custom endpoint completions proxy
+- The UI keeps `glm-5` selected after the thread is created
+
+#### Rollback/Cleanup
+- Switch provider/model settings back to preferred defaults if needed

--- a/tests.md
+++ b/tests.md
@@ -2699,6 +2699,9 @@ Custom endpoint `Completions` mode uses a local Responses-compatible proxy so cu
 
 #### Expected Results
 - The Codex app-server starts with `wire_api="responses"` against `/codex-api/custom-proxy/v1`
+- The custom provider save records a usable default model from `/models` when available
+- The Codex app-server receives the custom default model via runtime config
+- Unusable `auto-*` aliases are not offered ahead of concrete custom models
 - The local proxy forwards the request to `/v1/chat/completions`
 - The UI renders an assistant greeting such as `Hey! How can I help you today?`
 

--- a/tests.md
+++ b/tests.md
@@ -2655,22 +2655,52 @@ Both OpenRouter and OpenCode Zen routes use a unified Responses proxy layer that
 
 ---
 
-### Auth conflict error normalization (refresh token reuse)
+### Raw auth/provider error messages
 
 #### Feature/Change Name
-Normalize upstream refresh-token reuse/auth-refresh failure messages into a clear actionable error for Codex app-server session conflicts.
+Surface upstream auth/provider errors without rewriting them in the client normalizer.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
-2. Two or more Codex app-server/dev sessions active with the same Codex auth profile
+2. A provider/backend request that can return an error
 
 #### Steps
-1. Trigger a request that causes an upstream auth refresh conflict (for example, run turns from overlapping sessions)
+1. Trigger a provider/backend error, such as an auth refresh failure or invalid custom-provider response
 2. Observe the surfaced error text in the UI/failed RPC path
 
 #### Expected Results
-- Error text is normalized to a clear session-conflict message, not the raw backend phrase
-- Message includes remediation: close duplicate sessions, sign out/in again, and retry
+- Error text matches the original upstream/backend error message
+- No replacement copy like `Authentication session conflict detected...` is injected
 
 #### Rollback/Cleanup
-- Stop duplicate app-server processes if started for repro
+- Restore provider/session settings to the preferred state
+
+---
+
+### Custom endpoint Completions via local Responses proxy
+
+#### Feature/Change Name
+Custom endpoint `Completions` mode uses a local Responses-compatible proxy so current Codex CLI versions do not reject `wire_api="chat"`.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Local OpenAI-compatible endpoint running at `http://127.0.0.1:8666/v1`
+3. API key `pwd`
+
+#### Steps
+1. Open Settings
+2. Set Provider to `Custom endpoint`
+3. Enter Custom endpoint URL `http://127.0.0.1:8666/v1`
+4. Enter API key `pwd`
+5. Set API format to `Completions`
+6. Save
+7. Select model `claude-sonnet-4.5`
+8. Send `hi`
+
+#### Expected Results
+- The Codex app-server starts with `wire_api="responses"` against `/codex-api/custom-proxy/v1`
+- The local proxy forwards the request to `/v1/chat/completions`
+- The UI renders an assistant greeting such as `Hey! How can I help you today?`
+
+#### Rollback/Cleanup
+- Switch provider/API format back to preferred defaults

--- a/tests.md
+++ b/tests.md
@@ -2696,14 +2696,19 @@ Custom endpoint `Completions` mode uses a local Responses-compatible proxy so cu
 6. Save
 7. Select model `claude-sonnet-4.5`
 8. Send `hi`
+9. Select model `glm-5`
+10. Send `hi`
+11. In the same thread, ask `what is latest codex cli version?`
 
 #### Expected Results
 - The Codex app-server starts with `wire_api="responses"` against `/codex-api/custom-proxy/v1`
 - The custom provider save records a usable default model from `/models` when available
 - The Codex app-server receives the custom default model via runtime config
-- Unusable `auto-*` aliases are not offered ahead of concrete custom models
+- The model list preserves endpoint-advertised models, including `auto-*` aliases
 - The local proxy forwards the request to `/v1/chat/completions`
 - The UI renders an assistant greeting such as `Hey! How can I help you today?`
+- `glm-5` returns a successful assistant response
+- Follow-up tool-output turns do not fail with Kiro Gateway's generic `payload size exceeded ~615KB` error when the payload is small
 
 #### Rollback/Cleanup
 - Switch provider/API format back to preferred defaults


### PR DESCRIPTION
## Summary
- route OpenRouter, OpenCode Zen, and custom endpoints through a unified local Responses-compatible proxy
- preserve tool-capable behavior in completions mode and scope selected models per provider
- document proxy behavior, caveats, and TODOs in ProxySpec.md

## Testing
- tested OpenRouter responses mode with simple prompts
- tested completions mode bash/tool flow with `codex --version`
- tested custom endpoint completions proxy path
- tested OpenCode Zen completions path and normalized responses handling
