### PR TITLE
Optimize thread loading and add browser runtime profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpm-lock.yaml
 
 package.json
 DYNAMIC_INSTRUCTIONS.md
+.omx/

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "build:cli": "tsup",
     "build": "pnpm run build:frontend && pnpm run build:cli",
     "preview": "vite preview",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "pnpm run build",
+    "profile:browser": "node scripts/profile-browser-runtime.cjs",
+    "profile:thread": "PROFILE_ROUTE='#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c' node scripts/profile-browser-runtime.cjs"
   },
   "dependencies": {
     "commander": "^13.1.0",

--- a/scripts/profile-browser-runtime.cjs
+++ b/scripts/profile-browser-runtime.cjs
@@ -7,6 +7,14 @@ const route = process.env.PROFILE_ROUTE || '/'
 const waitMs = Number.parseInt(process.env.PROFILE_WAIT_MS || '7000', 10)
 const headless = process.env.PROFILE_HEADLESS !== 'false'
 const outputDir = resolve(process.cwd(), 'output/playwright')
+const runStamp = new Date().toISOString().replace(/[:.]/g, '-')
+
+function routeSlug() {
+  const raw = route.replace(/^https?:\/\//, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '')
+  return raw || 'home'
+}
+
+const artifactPrefix = `browser-runtime-profile-${routeSlug()}-${runStamp}`
 
 function round(value) {
   return Math.round(value * 10) / 10
@@ -33,6 +41,9 @@ function summarize(rows) {
 }
 
 function requestKey(row) {
+  if (row.rpc === 'thread/list') {
+    return row.cursor ? 'thread/list:cursor' : 'thread/list:first-page'
+  }
   return row.rpc || row.path
 }
 
@@ -103,6 +114,9 @@ async function main() {
     request.__profile = {
       startedAt: performance.now(),
       rpc: parsedBody && typeof parsedBody.method === 'string' ? parsedBody.method : '',
+      cursor: parsedBody?.params && typeof parsedBody.params === 'object' && typeof parsedBody.params.cursor === 'string'
+        ? parsedBody.params.cursor
+        : '',
       requestBytes: body ? Buffer.byteLength(body, 'utf8') : 0,
     }
   })
@@ -123,6 +137,7 @@ async function main() {
       method: request.method(),
       path: new URL(response.url()).pathname,
       rpc: profile.rpc,
+      cursor: profile.cursor,
       status: response.status(),
       ms: round(performance.now() - profile.startedAt),
       requestBytes: profile.requestBytes,
@@ -131,7 +146,7 @@ async function main() {
     })
   })
 
-  const tracePath = resolve(outputDir, 'browser-runtime-profile-trace.zip')
+  const tracePath = resolve(outputDir, `${artifactPrefix}-trace.zip`)
   await context.tracing.start({ screenshots: true, snapshots: true })
 
   const startedAt = performance.now()
@@ -143,7 +158,7 @@ async function main() {
   const title = await page.title()
   const bodyText = await page.locator('body').innerText({ timeout: 5000 }).catch(() => '')
   const performanceData = await collectPerformance(page)
-  const screenshotPath = resolve(outputDir, 'browser-runtime-profile.png')
+  const screenshotPath = resolve(outputDir, `${artifactPrefix}.png`)
   await page.screenshot({ path: screenshotPath, fullPage: true })
   await context.tracing.stop({ path: tracePath })
   await browser.close()
@@ -162,6 +177,8 @@ async function main() {
 
   const duplicateCounts = {
     threadList: apiRows.filter((row) => row.rpc === 'thread/list').length,
+    threadListFirstPage: apiRows.filter((row) => row.rpc === 'thread/list' && !row.cursor).length,
+    threadListCursor: apiRows.filter((row) => row.rpc === 'thread/list' && row.cursor).length,
     threadResume: apiRows.filter((row) => row.rpc === 'thread/resume').length,
     threadRead: apiRows.filter((row) => row.rpc === 'thread/read').length,
     skillsList: apiRows.filter((row) => row.rpc === 'skills/list').length,
@@ -184,7 +201,7 @@ async function main() {
     apiRows,
   }
 
-  const reportPath = resolve(outputDir, 'browser-runtime-profile.json')
+  const reportPath = resolve(outputDir, `${artifactPrefix}.json`)
   writeFileSync(reportPath, JSON.stringify(report, null, 2))
 
   console.log(JSON.stringify({

--- a/scripts/profile-browser-runtime.cjs
+++ b/scripts/profile-browser-runtime.cjs
@@ -1,0 +1,207 @@
+const { chromium } = require('playwright')
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+
+const baseUrl = process.env.PROFILE_BASE_URL || 'http://localhost:5173'
+const route = process.env.PROFILE_ROUTE || '/'
+const waitMs = Number.parseInt(process.env.PROFILE_WAIT_MS || '7000', 10)
+const headless = process.env.PROFILE_HEADLESS !== 'false'
+const outputDir = resolve(process.cwd(), 'output/playwright')
+
+function round(value) {
+  return Math.round(value * 10) / 10
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[index]
+}
+
+function summarize(rows) {
+  const durations = rows.map((row) => row.ms).filter((value) => Number.isFinite(value))
+  const totalBytes = rows.reduce((sum, row) => sum + row.responseBytes, 0)
+  return {
+    count: rows.length,
+    minMs: round(durations.length ? Math.min(...durations) : 0),
+    avgMs: round(durations.length ? durations.reduce((sum, value) => sum + value, 0) / durations.length : 0),
+    p95Ms: round(percentile(durations, 95)),
+    maxMs: round(durations.length ? Math.max(...durations) : 0),
+    totalKB: round(totalBytes / 1024),
+  }
+}
+
+function requestKey(row) {
+  return row.rpc || row.path
+}
+
+function parseJson(value) {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+function toTargetUrl() {
+  if (/^https?:\/\//.test(route)) return route
+  if (route.startsWith('#')) return `${baseUrl}/${route}`
+  if (route.startsWith('/')) return `${baseUrl}${route}`
+  return `${baseUrl}/${route}`
+}
+
+async function collectPerformance(page) {
+  return page.evaluate(() => {
+    const navigation = performance.getEntriesByType('navigation')[0]
+    const paints = performance.getEntriesByType('paint').map((entry) => ({
+      name: entry.name,
+      startTime: entry.startTime,
+    }))
+    const resources = performance.getEntriesByType('resource')
+      .filter((entry) => entry.name.includes('/codex-api') || entry.name.includes('/assets/'))
+      .map((entry) => ({
+        name: entry.name,
+        initiatorType: entry.initiatorType,
+        duration: entry.duration,
+        transferSize: entry.transferSize,
+        decodedBodySize: entry.decodedBodySize,
+      }))
+
+    return {
+      navigation: navigation ? {
+        responseEnd: navigation.responseEnd,
+        domContentLoaded: navigation.domContentLoadedEventEnd,
+        loadEventEnd: navigation.loadEventEnd,
+      } : null,
+      paints,
+      resources,
+      memory: performance.memory ? {
+        usedJSHeapSize: performance.memory.usedJSHeapSize,
+        totalJSHeapSize: performance.memory.totalJSHeapSize,
+        jsHeapSizeLimit: performance.memory.jsHeapSizeLimit,
+      } : null,
+    }
+  })
+}
+
+async function main() {
+  mkdirSync(outputDir, { recursive: true })
+
+  const targetUrl = toTargetUrl()
+  const browser = await chromium.launch({ headless })
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } })
+  const page = await context.newPage()
+  const apiRows = []
+
+  page.on('request', (request) => {
+    const url = request.url()
+    if (!url.includes('/codex-api')) return
+
+    const body = request.postData()
+    const parsedBody = body ? parseJson(body) : null
+    request.__profile = {
+      startedAt: performance.now(),
+      rpc: parsedBody && typeof parsedBody.method === 'string' ? parsedBody.method : '',
+      requestBytes: body ? Buffer.byteLength(body, 'utf8') : 0,
+    }
+  })
+
+  page.on('response', async (response) => {
+    const request = response.request()
+    const profile = request.__profile
+    if (!profile) return
+
+    let responseBytes = 0
+    try {
+      responseBytes = (await response.body()).byteLength
+    } catch {
+      responseBytes = 0
+    }
+
+    apiRows.push({
+      method: request.method(),
+      path: new URL(response.url()).pathname,
+      rpc: profile.rpc,
+      status: response.status(),
+      ms: round(performance.now() - profile.startedAt),
+      requestBytes: profile.requestBytes,
+      responseBytes,
+      responseKB: round(responseBytes / 1024),
+    })
+  })
+
+  const tracePath = resolve(outputDir, 'browser-runtime-profile-trace.zip')
+  await context.tracing.start({ screenshots: true, snapshots: true })
+
+  const startedAt = performance.now()
+  await page.goto(targetUrl, { waitUntil: 'domcontentloaded' })
+  await page.waitForTimeout(Number.isFinite(waitMs) && waitMs >= 0 ? waitMs : 7000)
+  const totalMs = round(performance.now() - startedAt)
+
+  const finalUrl = page.url()
+  const title = await page.title()
+  const bodyText = await page.locator('body').innerText({ timeout: 5000 }).catch(() => '')
+  const performanceData = await collectPerformance(page)
+  const screenshotPath = resolve(outputDir, 'browser-runtime-profile.png')
+  await page.screenshot({ path: screenshotPath, fullPage: true })
+  await context.tracing.stop({ path: tracePath })
+  await browser.close()
+
+  const grouped = new Map()
+  for (const row of apiRows) {
+    const key = requestKey(row)
+    const rows = grouped.get(key) || []
+    rows.push(row)
+    grouped.set(key, rows)
+  }
+
+  const apiSummary = Array.from(grouped.entries())
+    .map(([key, rows]) => ({ key, ...summarize(rows) }))
+    .sort((a, b) => b.avgMs - a.avgMs)
+
+  const duplicateCounts = {
+    threadList: apiRows.filter((row) => row.rpc === 'thread/list').length,
+    threadResume: apiRows.filter((row) => row.rpc === 'thread/resume').length,
+    threadRead: apiRows.filter((row) => row.rpc === 'thread/read').length,
+    skillsList: apiRows.filter((row) => row.rpc === 'skills/list').length,
+    rateLimitsRead: apiRows.filter((row) => row.rpc === 'account/rateLimits/read').length,
+    providerModels: apiRows.filter((row) => row.path === '/codex-api/provider-models').length,
+  }
+
+  const report = {
+    targetUrl,
+    finalUrl,
+    title,
+    totalMs,
+    screenshotPath,
+    tracePath,
+    duplicateCounts,
+    bodyTextHead: bodyText.slice(0, 1000),
+    performance: performanceData,
+    apiSummary,
+    slowestApiRows: [...apiRows].sort((a, b) => b.ms - a.ms).slice(0, 20),
+    apiRows,
+  }
+
+  const reportPath = resolve(outputDir, 'browser-runtime-profile.json')
+  writeFileSync(reportPath, JSON.stringify(report, null, 2))
+
+  console.log(JSON.stringify({
+    reportPath,
+    screenshotPath,
+    tracePath,
+    targetUrl,
+    finalUrl,
+    title,
+    totalMs,
+    duplicateCounts,
+    topApiSummary: apiSummary.slice(0, 12),
+    slowestApiRows: report.slowestApiRows.slice(0, 10),
+  }, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -3002,7 +3002,6 @@ async function initialize(): Promise<void> {
     primeSelectedThread(routeThreadId.value)
   }
 
-  startPolling()
   await refreshAll({
     includeSelectedThreadMessages: route.name === 'thread',
   })
@@ -3010,6 +3009,7 @@ async function initialize(): Promise<void> {
   await applyLaunchProjectPathFromUrl()
   hasInitialized.value = true
   await syncThreadSelectionWithRoute()
+  startPolling()
 }
 
 async function syncThreadSelectionWithRoute(): Promise<void> {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3014,7 +3014,7 @@ async function initialize(): Promise<void> {
 
   startPolling()
   await refreshAll({
-    includeSelectedThreadMessages: true,
+    includeSelectedThreadMessages: route.name === 'thread',
   })
   void loadAccountsState({ silent: true })
   await applyLaunchProjectPathFromUrl()

--- a/src/App.vue
+++ b/src/App.vue
@@ -1153,16 +1153,6 @@ const routeThreadId = computed(() => {
   return typeof rawThreadId === 'string' ? rawThreadId : ''
 })
 
-const knownThreadIdSet = computed(() => {
-  const ids = new Set<string>()
-  for (const group of projectGroups.value) {
-    for (const thread of group.threads) {
-      ids.add(thread.id)
-    }
-  }
-  return ids
-})
-
 const isHomeRoute = computed(() => route.name === 'home')
 const isSkillsRoute = computed(() => route.name === 'skills')
 const contentTitle = computed(() => {
@@ -3044,11 +3034,6 @@ async function syncThreadSelectionWithRoute(): Promise<void> {
         const threadId = routeThreadId.value
         if (!threadId) continue
 
-        if (!knownThreadIdSet.value.has(threadId)) {
-          await router.replace({ name: 'home' })
-          continue
-        }
-
         if (selectedThreadId.value !== threadId) {
           await selectThread(threadId)
         } else {
@@ -3068,7 +3053,6 @@ watch(
       route.name,
       routeThreadId.value,
       isLoadingThreads.value,
-      knownThreadIdSet.value.has(routeThreadId.value),
       selectedThreadId.value,
     ] as const,
   async () => {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -914,12 +914,20 @@ export async function removeAccount(accountId: string): Promise<AccountsListResu
 
 export type ResumedThread = {
   model: string
+  messages: UiMessage[]
+  inProgress: boolean
+  activeTurnId: string
+  turnIndexByTurnId: ThreadTurnIndexById
 }
 
 export async function resumeThread(threadId: string): Promise<ResumedThread> {
   const payload = await callRpc<ThreadResumeResponse>('thread/resume', { threadId })
   return {
     model: normalizeThreadModelFromPayload(payload),
+    messages: normalizeThreadMessagesV2(payload),
+    inProgress: readThreadInProgressFromResponse(payload),
+    activeTurnId: readActiveTurnIdFromResponse(payload),
+    turnIndexByTurnId: buildTurnIndexByTurnId(payload),
   }
 }
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -468,72 +468,36 @@ function normalizeSpeedMode(value: unknown): SpeedMode {
     : 'standard'
 }
 
-async function getThreadGroupsV2(): Promise<UiProjectGroup[]> {
+const INITIAL_THREAD_LIST_LIMIT = 50
+const BACKGROUND_THREAD_LIST_LIMIT = 100
+
+export type ThreadGroupsPage = {
+  groups: UiProjectGroup[]
+  nextCursor: string | null
+}
+
+async function getThreadGroupsPageV2(cursor: string | null, limit: number): Promise<ThreadGroupsPage> {
   const payload = await callRpc<ThreadListResponse>('thread/list', {
     archived: false,
-    limit: 100,
+    limit,
     sortKey: 'updated_at',
     modelProviders: [],
+    cursor,
   })
-  return normalizeThreadGroupsV2(payload)
+  return {
+    groups: normalizeThreadGroupsV2(payload),
+    nextCursor: typeof payload.nextCursor === 'string' && payload.nextCursor.length > 0
+      ? payload.nextCursor
+      : null,
+  }
 }
 
 async function getThreadMessagesV2(threadId: string): Promise<UiMessage[]> {
-  const liveState = await fetchThreadLiveState(threadId)
-  if (liveState && !liveState.liveStateError) {
-    const fromLive = normalizeMessagesFromLiveState(liveState)
-    if (fromLive && fromLive.messages.length > 0) {
-      return fromLive.messages
-    }
-  }
-
   const payload = await callRpc<ThreadReadResponse>('thread/read', {
     threadId,
     includeTurns: true,
   })
   return normalizeThreadMessagesV2(payload)
-}
-
-type LiveStateResponse = {
-  threadId: string
-  conversationState: { turns: unknown[] } | null
-  ownerClientId: string | null
-  liveStateError: { kind: string; message: string } | null
-  isInProgress: boolean
-}
-
-async function fetchThreadLiveState(threadId: string): Promise<LiveStateResponse | null> {
-  try {
-    const response = await fetch(
-      `/codex-api/thread-live-state?threadId=${encodeURIComponent(threadId)}`,
-    )
-    if (!response.ok) return null
-    return (await response.json()) as LiveStateResponse
-  } catch {
-    return null
-  }
-}
-
-function normalizeMessagesFromLiveState(
-  liveState: LiveStateResponse,
-): { messages: UiMessage[]; inProgress: boolean; activeTurnId: string; turnIndexByTurnId: ThreadTurnIndexById } | null {
-  const state = liveState.conversationState
-  if (!state || !Array.isArray(state.turns) || state.turns.length === 0) return null
-
-  const syntheticPayload: ThreadReadResponse = {
-    thread: {
-      id: liveState.threadId,
-      turns: state.turns,
-    } as ThreadReadResponse['thread'],
-  }
-
-  const messages = normalizeThreadMessagesV2(syntheticPayload)
-  return {
-    messages,
-    inProgress: liveState.isInProgress,
-    activeTurnId: readActiveTurnIdFromResponse(syntheticPayload),
-    turnIndexByTurnId: buildTurnIndexByTurnId(syntheticPayload),
-  }
 }
 
 async function getThreadDetailV2(threadId: string): Promise<{
@@ -542,14 +506,6 @@ async function getThreadDetailV2(threadId: string): Promise<{
   activeTurnId: string
   turnIndexByTurnId: ThreadTurnIndexById
 }> {
-  const liveState = await fetchThreadLiveState(threadId)
-  if (liveState && !liveState.liveStateError) {
-    const fromLive = normalizeMessagesFromLiveState(liveState)
-    if (fromLive && fromLive.messages.length > 0) {
-      return fromLive
-    }
-  }
-
   const payload = await callRpc<ThreadReadResponse>('thread/read', {
     threadId,
     includeTurns: true,
@@ -565,10 +521,25 @@ async function getThreadDetailV2(threadId: string): Promise<{
 
 export async function getThreadGroups(): Promise<UiProjectGroup[]> {
   try {
-    return await getThreadGroupsV2()
+    return (await getThreadGroupsPageV2(null, INITIAL_THREAD_LIST_LIMIT)).groups
   } catch (error) {
     throw normalizeCodexApiError(error, 'Failed to load thread groups', 'thread/list')
   }
+}
+
+export async function getThreadGroupsPage(
+  cursor: string | null = null,
+  limit = INITIAL_THREAD_LIST_LIMIT,
+): Promise<ThreadGroupsPage> {
+  try {
+    return await getThreadGroupsPageV2(cursor, limit)
+  } catch (error) {
+    throw normalizeCodexApiError(error, 'Failed to load thread groups', 'thread/list')
+  }
+}
+
+export function getBackgroundThreadListLimit(): number {
+  return BACKGROUND_THREAD_LIST_LIMIT
 }
 
 export async function getThreadMessages(threadId: string): Promise<UiMessage[]> {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -605,20 +605,20 @@
               </section>
 
               <div
-                v-if="showCopyResponseButton(message) || showRollbackButton(message)"
+                v-if="showCopyResponseButton(message) || showEditMessageButton(message)"
                 class="message-toolbar"
                 :data-role="message.role"
               >
                 <button
-                  v-if="showRollbackButton(message)"
+                  v-if="showEditMessageButton(message)"
                   type="button"
-                  class="message-rollback-button"
-                  aria-label="Rollback to this response"
-                  title="Rollback to this response"
-                  @click="rollbackResponse(message.id)"
+                  class="message-edit-button"
+                  aria-label="Edit this message"
+                  title="Edit this message"
+                  @click="editMessage(message.id)"
                 >
-                  <IconTablerArrowBackUp class="icon-svg message-rollback-icon" />
-                  <span class="message-rollback-label">Rollback</span>
+                  <IconTablerFilePencil class="icon-svg message-edit-icon" />
+                  <span class="message-edit-label">Edit message</span>
                 </button>
                 <button
                   v-if="showForkResponseButton(message)"
@@ -835,9 +835,9 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { ThreadScrollState, UiFileChange, UiLiveOverlay, UiMessage, UiPlanStep, UiServerRequest } from '../../types/codex'
 import { useMobile } from '../../composables/useMobile'
 
-import IconTablerArrowBackUp from '../icons/IconTablerArrowBackUp.vue'
 import IconTablerArrowUp from '../icons/IconTablerArrowUp.vue'
 import IconTablerCopy from '../icons/IconTablerCopy.vue'
+import IconTablerFilePencil from '../icons/IconTablerFilePencil.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
 import IconTablerX from '../icons/IconTablerX.vue'
 
@@ -2080,37 +2080,23 @@ function forkResponse(anchorMessageId: string): void {
   })
 }
 
-const rollbackTurnIdByAnchorId = computed<Record<string, string>>(() => {
-  const groupedTurns = new Map<string, { anchorMessageId: string; turnId: string }>()
-
-  for (const message of props.messages) {
-    if (!isCopyableAssistantMessage(message) || typeof message.turnIndex !== 'number') continue
-    const turnId = typeof message.turnId === 'string' && message.turnId.length > 0 ? message.turnId : ''
-    if (!turnId) continue
-
-    const responseKey = `turn:${message.turnIndex}`
-    const existing = groupedTurns.get(responseKey)
-    if (existing) {
-      existing.anchorMessageId = message.id
-      existing.turnId = turnId
-      continue
-    }
-    groupedTurns.set(responseKey, { anchorMessageId: message.id, turnId })
-  }
-
+const editableTurnIdByMessageId = computed<Record<string, string>>(() => {
   const next: Record<string, string> = {}
-  for (const entry of groupedTurns.values()) {
-    next[entry.anchorMessageId] = entry.turnId
+  for (const message of props.messages) {
+    if (message.role !== 'user' || typeof message.turnIndex !== 'number') continue
+    const turnId = typeof message.turnId === 'string' && message.turnId.length > 0 ? message.turnId : ''
+    if (!turnId || message.text.trim().length === 0) continue
+    next[message.id] = turnId
   }
   return next
 })
 
-function showRollbackButton(message: UiMessage): boolean {
-  return typeof rollbackTurnIdByAnchorId.value[message.id] === 'string'
+function showEditMessageButton(message: UiMessage): boolean {
+  return typeof editableTurnIdByMessageId.value[message.id] === 'string'
 }
 
-function rollbackResponse(anchorMessageId: string): void {
-  const turnId = rollbackTurnIdByAnchorId.value[anchorMessageId]
+function editMessage(messageId: string): void {
+  const turnId = editableTurnIdByMessageId.value[messageId]
   if (!turnId) return
   emit('rollback', { turnId })
 }
@@ -4288,19 +4274,19 @@ onBeforeUnmount(() => {
   @apply border-emerald-200 bg-emerald-50 text-emerald-700;
 }
 
-.message-rollback-button {
+.message-edit-button {
   @apply inline-flex items-center gap-0.5 px-0.5 py-0 text-[9px] font-medium leading-none text-amber-600/70 transition hover:text-amber-700;
 }
 
 .message-fork-icon,
 .message-copy-icon,
-.message-rollback-icon {
+.message-edit-icon {
   @apply text-[10px];
 }
 
 .message-fork-label,
 .message-copy-label,
-.message-rollback-label {
+.message-edit-label {
   @apply leading-none;
 }
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3504,10 +3504,8 @@ export function useDesktopState() {
 
     try {
       const needsResume = resumedThreadById.value[threadId] !== true
-      const resumePromise = needsResume ? resumeThread(threadId) : null
-      const detailPromise = getThreadDetail(threadId)
-
-      const [resumedThread, detail] = await Promise.all([resumePromise, detailPromise])
+      const resumedThread = needsResume ? await resumeThread(threadId) : null
+      const detail = resumedThread ?? await getThreadDetail(threadId)
 
       if (resumedThread) {
         setThreadModelId(threadId, resumedThread.model)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3546,11 +3546,13 @@ export function useDesktopState() {
         loadThreadTitleCacheIfNeeded(),
       ])
       const groups = page.groups
-      loadedThreadListGroups = groups
+      loadedThreadListGroups = hasLoadedThreads.value
+        ? mergeThreadGroupPages(loadedThreadListGroups, groups)
+        : groups
       threadListNextCursor = page.nextCursor
       await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
-      applyThreadGroups(groups, rootsState)
+      applyThreadGroups(loadedThreadListGroups, rootsState)
       hasLoadedThreads.value = true
       void loadRemainingThreadPages(rootsState)
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -30,6 +30,7 @@ import {
   startThreadTurn,
   type RpcNotification,
   type SkillInfo,
+  type WorkspaceRootsState,
 } from '../api/codexGateway'
 import { normalizeFileChangeStatus, toUiFileChanges } from '../api/normalizers/v2'
 import type {
@@ -3365,12 +3366,15 @@ export function useDesktopState() {
     }, EVENT_SYNC_DEBOUNCE_MS)
   }
 
-  async function hydrateWorkspaceRootsStateIfNeeded(groups: UiProjectGroup[]): Promise<void> {
+  async function hydrateWorkspaceRootsStateIfNeeded(
+    groups: UiProjectGroup[],
+    rootsState: WorkspaceRootsState | null,
+  ): Promise<void> {
     if (hasHydratedWorkspaceRootsState) return
     hasHydratedWorkspaceRootsState = true
 
     try {
-      const rootsState = await getWorkspaceRootsState()
+      if (!rootsState) return
       const hydratedOrder: string[] = []
       for (const rootPath of rootsState.order) {
         const projectName = toProjectNameFromWorkspaceRoot(rootPath)
@@ -3417,6 +3421,14 @@ export function useDesktopState() {
     }
   }
 
+  async function loadWorkspaceRootsStateForThreadList(): Promise<WorkspaceRootsState | null> {
+    try {
+      return await getWorkspaceRootsState()
+    } catch {
+      return null
+    }
+  }
+
   async function requestThreadTitleGeneration(threadId: string, prompt: string, cwd: string | null): Promise<void> {
     if (threadTitleById.value[threadId]) return
     const trimmed = prompt.trim()
@@ -3433,17 +3445,15 @@ export function useDesktopState() {
     }
   }
 
-  async function filterGroupsByWorkspaceRoots(groups: UiProjectGroup[]): Promise<UiProjectGroup[]> {
-    try {
-      const rootsState = await getWorkspaceRootsState()
-      if (rootsState.order.length === 0) return groups
-      const allowedProjectNames = new Set(
-        rootsState.order.map((rootPath) => toProjectNameFromWorkspaceRoot(rootPath)),
-      )
-      return groups.filter((group) => allowedProjectNames.has(group.projectName))
-    } catch {
-      return groups
-    }
+  function filterGroupsByWorkspaceRoots(
+    groups: UiProjectGroup[],
+    rootsState: WorkspaceRootsState | null,
+  ): UiProjectGroup[] {
+    if (!rootsState || rootsState.order.length === 0) return groups
+    const allowedProjectNames = new Set(
+      rootsState.order.map((rootPath) => toProjectNameFromWorkspaceRoot(rootPath)),
+    )
+    return groups.filter((group) => allowedProjectNames.has(group.projectName))
   }
 
   async function loadThreads() {
@@ -3452,10 +3462,14 @@ export function useDesktopState() {
     }
 
     try {
-      const [groups] = await Promise.all([getThreadGroups(), loadThreadTitleCacheIfNeeded()])
-      await hydrateWorkspaceRootsStateIfNeeded(groups)
+      const [groups, rootsState] = await Promise.all([
+        getThreadGroups(),
+        loadWorkspaceRootsStateForThreadList(),
+        loadThreadTitleCacheIfNeeded(),
+      ])
+      await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
-      const visibleGroups = await filterGroupsByWorkspaceRoots(groups)
+      const visibleGroups = filterGroupsByWorkspaceRoots(groups, rootsState)
 
       const nextProjectOrder = mergeProjectOrder(projectOrder.value, visibleGroups)
       if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1095,6 +1095,7 @@ export function useDesktopState() {
   const pendingThreadMessageRefresh = new Set<string>()
   let threadListNextCursor: string | null = null
   let isLoadingRemainingThreadPages = false
+  let hasLoadedAllThreadPages = false
   let loadedThreadListGroups: UiProjectGroup[] = []
   let hasHydratedWorkspaceRootsState = false
   let activeReasoningItemId = ''
@@ -3528,6 +3529,7 @@ export function useDesktopState() {
       while (threadListNextCursor) {
         const page = await getThreadGroupsPage(threadListNextCursor, getBackgroundThreadListLimit())
         threadListNextCursor = page.nextCursor
+        hasLoadedAllThreadPages = page.nextCursor === null
         loadedThreadListGroups = mergeThreadGroupPages(loadedThreadListGroups, page.groups)
         applyThreadGroups(loadedThreadListGroups, rootsState)
       }
@@ -3560,11 +3562,14 @@ export function useDesktopState() {
         ? mergeThreadGroupPages(loadedThreadListGroups, groups)
         : groups
       threadListNextCursor = page.nextCursor
+      hasLoadedAllThreadPages = page.nextCursor === null
       await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
       applyThreadGroups(loadedThreadListGroups, rootsState)
       hasLoadedThreads.value = true
-      void loadRemainingThreadPages(rootsState)
+      if (!hasLoadedAllThreadPages) {
+        void loadRemainingThreadPages(rootsState)
+      }
 
       const flatThreads = flattenThreads(projectGroups.value)
       pruneThreadScopedState(flatThreads)
@@ -4616,7 +4621,7 @@ export function useDesktopState() {
 
   async function recoverBridgeState(): Promise<void> {
     await loadPendingServerRequestsFromBridge()
-    pendingThreadsRefresh = true
+    pendingThreadsRefresh = !hasLoadedThreads.value
     if (selectedThreadId.value) {
       pendingThreadMessageRefresh.add(selectedThreadId.value)
     }

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1086,6 +1086,10 @@ export function useDesktopState() {
   let eventSyncTimer: number | null = null
   let rateLimitRefreshTimer: number | null = null
   const delayedTurnSyncTimerByThreadId = new Map<string, number>()
+  let loadThreadsPromise: Promise<void> | null = null
+  const loadMessagePromiseByThreadId = new Map<string, Promise<void>>()
+  let refreshSkillsPromise: Promise<void> | null = null
+  let codexRateLimitRefreshPromise: Promise<void> | null = null
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
   const pendingThreadMessageRefresh = new Set<string>()
@@ -3535,6 +3539,12 @@ export function useDesktopState() {
   }
 
   async function loadThreads() {
+    if (loadThreadsPromise) {
+      await loadThreadsPromise
+      return
+    }
+
+    loadThreadsPromise = (async () => {
     if (!hasLoadedThreads.value) {
       isLoadingThreads.value = true
     }
@@ -3567,10 +3577,21 @@ export function useDesktopState() {
     } finally {
       isLoadingThreads.value = false
     }
+    })().finally(() => {
+      loadThreadsPromise = null
+    })
+
+    await loadThreadsPromise
   }
 
   async function loadMessages(threadId: string, options: { silent?: boolean } = {}) {
     if (!threadId) {
+      return
+    }
+
+    const existingLoad = loadMessagePromiseByThreadId.get(threadId)
+    if (existingLoad) {
+      await existingLoad
       return
     }
 
@@ -3580,7 +3601,8 @@ export function useDesktopState() {
       isLoadingMessages.value = true
     }
 
-    try {
+    const loadPromise = (async () => {
+      try {
       const version = currentThreadVersion(threadId)
       const loadedVersion = loadedVersionByThreadId.value[threadId] ?? ''
       const canReuseLoadedMessages =
@@ -3650,11 +3672,17 @@ export function useDesktopState() {
         clearCompletedTurnLiveState(threadId)
       }
       markThreadAsRead(threadId)
-    } finally {
+      } finally {
       if (shouldShowLoading) {
         isLoadingMessages.value = false
       }
-    }
+      }
+    })().finally(() => {
+      loadMessagePromiseByThreadId.delete(threadId)
+    })
+
+    loadMessagePromiseByThreadId.set(threadId, loadPromise)
+    await loadPromise
   }
 
   async function ensureThreadMessagesLoaded(threadId: string, options: { silent?: boolean } = {}): Promise<void> {
@@ -3664,20 +3692,42 @@ export function useDesktopState() {
   }
 
   async function refreshSkills(): Promise<void> {
-    try {
-      const selectedCwd = selectedThread.value?.cwd?.trim() ?? ''
-      installedSkills.value = await getSkillsList(selectedCwd ? [selectedCwd] : undefined)
-    } catch {
-      // keep previous skills on failure
+    if (refreshSkillsPromise) {
+      await refreshSkillsPromise
+      return
     }
+
+    refreshSkillsPromise = (async () => {
+      try {
+        const selectedCwd = selectedThread.value?.cwd?.trim() ?? ''
+        installedSkills.value = await getSkillsList(selectedCwd ? [selectedCwd] : undefined)
+      } catch {
+        // keep previous skills on failure
+      } finally {
+        refreshSkillsPromise = null
+      }
+    })()
+
+    await refreshSkillsPromise
   }
 
   async function refreshCodexRateLimits(): Promise<void> {
-    try {
-      setCodexRateLimit(await getAccountRateLimits())
-    } catch {
-      // Keep the last known quota snapshot on transient failures.
+    if (codexRateLimitRefreshPromise) {
+      await codexRateLimitRefreshPromise
+      return
     }
+
+    codexRateLimitRefreshPromise = (async () => {
+      try {
+        setCodexRateLimit(await getAccountRateLimits())
+      } catch {
+        // Keep the last known quota snapshot on transient failures.
+      } finally {
+        codexRateLimitRefreshPromise = null
+      }
+    })()
+
+    await codexRateLimitRefreshPromise
   }
 
   async function refreshAll(

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -11,12 +11,13 @@ import {
   getPendingServerRequests,
   getSkillsList,
   getThreadDetail,
+  getBackgroundThreadListLimit,
   interruptThreadTurn,
   pickCodexRateLimitSnapshot,
   replyToServerRequest,
   revertThreadFileChanges,
   rollbackThread,
-  getThreadGroups,
+  getThreadGroupsPage,
   getWorkspaceRootsState,
   setCodexSpeedMode,
   setWorkspaceRootsState,
@@ -1088,6 +1089,9 @@ export function useDesktopState() {
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
   const pendingThreadMessageRefresh = new Set<string>()
+  let threadListNextCursor: string | null = null
+  let isLoadingRemainingThreadPages = false
+  let loadedThreadListGroups: UiProjectGroup[] = []
   let hasHydratedWorkspaceRootsState = false
   let activeReasoningItemId = ''
   let shouldAutoScrollOnNextAgentEvent = false
@@ -3456,41 +3460,99 @@ export function useDesktopState() {
     return groups.filter((group) => allowedProjectNames.has(group.projectName))
   }
 
+  function applyThreadGroups(groups: UiProjectGroup[], rootsState: WorkspaceRootsState | null): void {
+    const visibleGroups = filterGroupsByWorkspaceRoots(groups, rootsState)
+
+    const nextProjectOrder = mergeProjectOrder(projectOrder.value, visibleGroups)
+    if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
+      projectOrder.value = nextProjectOrder
+      saveProjectOrder(projectOrder.value)
+    }
+
+    const orderedGroups = orderGroupsByProjectOrder(visibleGroups, projectOrder.value)
+    markServerListedThreads(new Set(flattenThreads(orderedGroups).map((thread) => thread.id)))
+    const mergedWithInProgress = mergeIncomingWithLocalInProgressThreads(
+      sourceGroups.value,
+      orderedGroups,
+      inProgressById.value,
+    )
+    sourceGroups.value = mergeThreadGroups(sourceGroups.value, mergedWithInProgress)
+    inProgressById.value = pruneThreadStateMap(
+      inProgressById.value,
+      new Set(flattenThreads(sourceGroups.value).map((thread) => thread.id)),
+    )
+    applyThreadFlags()
+  }
+
+  function mergeThreadGroupPages(previous: UiProjectGroup[], incoming: UiProjectGroup[]): UiProjectGroup[] {
+    if (previous.length === 0) return incoming
+    if (incoming.length === 0) return previous
+
+    const threadById = new Map<string, UiThread>()
+    for (const thread of flattenThreads(previous)) {
+      threadById.set(thread.id, thread)
+    }
+    for (const thread of flattenThreads(incoming)) {
+      threadById.set(thread.id, thread)
+    }
+    const groupsByProject = new Map<string, UiThread[]>()
+    for (const thread of threadById.values()) {
+      const existing = groupsByProject.get(thread.projectName)
+      if (existing) existing.push(thread)
+      else groupsByProject.set(thread.projectName, [thread])
+    }
+
+    return Array.from(groupsByProject.entries())
+      .map(([projectName, threads]) => ({
+        projectName,
+        threads: threads.sort(
+          (first, second) => new Date(second.updatedAtIso).getTime() - new Date(first.updatedAtIso).getTime(),
+        ),
+      }))
+      .sort((first, second) => {
+        const firstUpdated = new Date(first.threads[0]?.updatedAtIso ?? 0).getTime()
+        const secondUpdated = new Date(second.threads[0]?.updatedAtIso ?? 0).getTime()
+        return secondUpdated - firstUpdated
+      })
+  }
+
+  async function loadRemainingThreadPages(rootsState: WorkspaceRootsState | null): Promise<void> {
+    if (isLoadingRemainingThreadPages || !threadListNextCursor) return
+    isLoadingRemainingThreadPages = true
+
+    try {
+      while (threadListNextCursor) {
+        const page = await getThreadGroupsPage(threadListNextCursor, getBackgroundThreadListLimit())
+        threadListNextCursor = page.nextCursor
+        loadedThreadListGroups = mergeThreadGroupPages(loadedThreadListGroups, page.groups)
+        applyThreadGroups(loadedThreadListGroups, rootsState)
+      }
+    } catch {
+      // Keep the first page usable; a later refresh can retry remaining pages.
+    } finally {
+      isLoadingRemainingThreadPages = false
+    }
+  }
+
   async function loadThreads() {
     if (!hasLoadedThreads.value) {
       isLoadingThreads.value = true
     }
 
     try {
-      const [groups, rootsState] = await Promise.all([
-        getThreadGroups(),
+      const [page, rootsState] = await Promise.all([
+        getThreadGroupsPage(),
         loadWorkspaceRootsStateForThreadList(),
         loadThreadTitleCacheIfNeeded(),
       ])
+      const groups = page.groups
+      loadedThreadListGroups = groups
+      threadListNextCursor = page.nextCursor
       await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
-      const visibleGroups = filterGroupsByWorkspaceRoots(groups, rootsState)
-
-      const nextProjectOrder = mergeProjectOrder(projectOrder.value, visibleGroups)
-      if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
-        projectOrder.value = nextProjectOrder
-        saveProjectOrder(projectOrder.value)
-      }
-
-      const orderedGroups = orderGroupsByProjectOrder(visibleGroups, projectOrder.value)
-      markServerListedThreads(new Set(flattenThreads(orderedGroups).map((thread) => thread.id)))
-      const mergedWithInProgress = mergeIncomingWithLocalInProgressThreads(
-        sourceGroups.value,
-        orderedGroups,
-        inProgressById.value,
-      )
-      sourceGroups.value = mergeThreadGroups(sourceGroups.value, mergedWithInProgress)
-      inProgressById.value = pruneThreadStateMap(
-        inProgressById.value,
-        new Set(flattenThreads(sourceGroups.value).map((thread) => thread.id)),
-      )
-      applyThreadFlags()
+      applyThreadGroups(groups, rootsState)
       hasLoadedThreads.value = true
+      void loadRemainingThreadPages(rootsState)
 
       const flatThreads = flattenThreads(projectGroups.value)
       pruneThreadScopedState(flatThreads)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3579,6 +3579,19 @@ export function useDesktopState() {
     }
 
     try {
+      const version = currentThreadVersion(threadId)
+      const loadedVersion = loadedVersionByThreadId.value[threadId] ?? ''
+      const canReuseLoadedMessages =
+        alreadyLoaded &&
+        version.length > 0 &&
+        loadedVersion === version &&
+        inProgressById.value[threadId] !== true
+
+      if (canReuseLoadedMessages) {
+        markThreadAsRead(threadId)
+        return
+      }
+
       const needsResume = resumedThreadById.value[threadId] !== true
       const resumedThread = needsResume ? await resumeThread(threadId) : null
       const detail = resumedThread ?? await getThreadDetail(threadId)
@@ -3616,7 +3629,6 @@ export function useDesktopState() {
         [threadId]: true,
       }
 
-      const version = currentThreadVersion(threadId)
       if (version) {
         loadedVersionByThreadId.value = {
           ...loadedVersionByThreadId.value,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3042,7 +3042,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       if (!shouldLog) return
       didLog = true
       const rpcPart = rpcMethod ? `, rpcMethod=${rpcMethod}` : ''
-      console.info(`[codex-api-perf] ${requestMethod} ${requestPath} -> ${res.statusCode} (${durationMs}ms, bodyMB=${bodyMbValue.toFixed(4)}${rpcPart})`)
+      console.info(`[codex-api-perf] ${requestMethod} ${requestPath} -> ${res.statusCode} (${durationMs}ms, bodyMB=${bodyMbValue.toFixed(1)}${rpcPart})`)
     }
     res.once('finish', logApiRequestDuration)
     res.once('close', logApiRequestDuration)

--- a/tests.md
+++ b/tests.md
@@ -2770,3 +2770,54 @@ New TestChat threads use the provider-scoped model selected in the new-thread co
 
 #### Rollback/Cleanup
 - Switch provider/model settings back to preferred defaults if needed
+
+---
+
+### User message edit action replaces rollback button
+
+#### Feature/Change Name
+The old rollback button is replaced with an `Edit message` action under each eligible user message, while keeping the existing behavior that appends the original text into the composer and rolls the thread back from that turn.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. An existing thread with at least one completed user/assistant turn
+
+#### Steps
+1. Open a thread with multiple completed turns
+2. Hover a completed user message
+3. Confirm `Edit message` appears under that user message
+4. Confirm assistant responses no longer show the old `Rollback` button
+5. Click `Edit message` on an earlier user message with recognizable text
+6. Observe the composer draft after the click
+7. Confirm the thread rolls back from the selected turn
+
+#### Expected Results
+- The action under eligible user messages is labeled `Edit message`
+- Assistant responses no longer render the old rollback action
+- Clicking `Edit message` appends the original user text into the composer
+- The existing rollback behavior still truncates the selected turn and later turns
+
+#### Rollback/Cleanup
+- Re-send the edited message if you want to recreate the conversation path
+
+---
+
+### API perf log bodyMB uses one decimal place
+
+#### Feature/Change Name
+`[codex-api-perf]` log entries format `bodyMB` with one decimal place instead of four.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. A request large enough to trigger `[codex-api-perf]` logging
+
+#### Steps
+1. Trigger a `/codex-api/` request that exceeds the perf logging threshold
+2. Inspect the server log line that includes `bodyMB=...`
+
+#### Expected Results
+- `bodyMB` is formatted with one decimal place, such as `bodyMB=3.4`
+- The log does not print extra precision such as `bodyMB=3.4489`
+
+#### Rollback/Cleanup
+- None

--- a/tests.md
+++ b/tests.md
@@ -2821,3 +2821,30 @@ The old rollback button is replaced with an `Edit message` action under each eli
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Cold thread load avoids duplicate history fetch
+
+#### Feature/Change Name
+Cold thread message loading reuses the `thread/resume` response instead of also issuing `thread/read`.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Browser dev tools Network panel open, filtered to Codex RPC or `/codex-api`
+3. An existing thread that has not been opened in the current browser session
+
+#### Steps
+1. Refresh the app
+2. Open the existing thread
+3. Inspect the network/RPC calls made during the initial thread load
+4. Open the same thread again or switch away and back
+
+#### Expected Results
+- The first cold open performs `thread/resume` for that thread and renders its messages
+- The first cold open does not also perform a redundant `thread/read` for the same thread load
+- Returning to an already resumed thread can use `thread/read` when a refresh is needed
+- Messages, in-progress state, active turn tracking, and model selection still populate correctly
+
+#### Rollback/Cleanup
+- None

--- a/tests.md
+++ b/tests.md
@@ -2997,14 +2997,14 @@ Playwright browser runtime profiler captures route timing, Codex API network cou
 1. Run `pnpm run profile:browser`
 2. Run `PROFILE_ROUTE='#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c' pnpm run profile:browser`
 3. Inspect console output for duplicate counts and slowest API rows
-4. Open `output/playwright/browser-runtime-profile.json`
-5. Open `output/playwright/browser-runtime-profile-trace.zip` with `npx playwright show-trace`
+4. Open the generated `output/playwright/browser-runtime-profile-*.json`
+5. Open the generated `output/playwright/browser-runtime-profile-*-trace.zip` with `npx playwright show-trace`
 
 #### Expected Results
 - The profiler prints final URL, title, total observed time, duplicate request counts, and slowest Codex API calls
 - JSON report includes raw API rows, grouped summaries, Performance API data, and artifact paths
-- Screenshot is saved at `output/playwright/browser-runtime-profile.png`
-- Trace is saved at `output/playwright/browser-runtime-profile-trace.zip`
+- Screenshot is saved under `output/playwright/browser-runtime-profile-*.png`
+- Trace is saved under `output/playwright/browser-runtime-profile-*-trace.zip`
 
 #### Rollback/Cleanup
 - Delete generated files under `output/playwright/` if local artifacts are no longer needed

--- a/tests.md
+++ b/tests.md
@@ -2953,3 +2953,30 @@ Loaded thread messages are reused when the thread list version has not changed a
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Thread selection keeps sidebar list stable during refresh
+
+#### Feature/Change Name
+Selecting a thread does not briefly hide older/sidebar threads while thread list refresh and background pagination run.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. More than one page of threads available in the sidebar
+3. Background pagination has loaded older threads
+
+#### Steps
+1. Open the app and wait until older thread pages appear in the sidebar
+2. Select a different thread
+3. Watch the sidebar while the selected thread loads and any thread list refresh occurs
+4. Repeat selection between recent and older threads
+
+#### Expected Results
+- The sidebar does not collapse to only the first page of recent threads
+- Previously loaded older threads remain visible during refresh
+- The selected thread stays highlighted and messages load normally
+- Background pagination can still add newly loaded older threads without hiding existing ones
+
+#### Rollback/Cleanup
+- None

--- a/tests.md
+++ b/tests.md
@@ -2980,3 +2980,31 @@ Selecting a thread does not briefly hide older/sidebar threads while thread list
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Browser runtime profiling with Playwright
+
+#### Feature/Change Name
+Playwright browser runtime profiler captures route timing, Codex API network counts, screenshots, and trace files.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://localhost:5173`
+2. Dependencies installed (`pnpm install`)
+3. Target route available, such as `#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c`
+
+#### Steps
+1. Run `pnpm run profile:browser`
+2. Run `PROFILE_ROUTE='#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c' pnpm run profile:browser`
+3. Inspect console output for duplicate counts and slowest API rows
+4. Open `output/playwright/browser-runtime-profile.json`
+5. Open `output/playwright/browser-runtime-profile-trace.zip` with `npx playwright show-trace`
+
+#### Expected Results
+- The profiler prints final URL, title, total observed time, duplicate request counts, and slowest Codex API calls
+- JSON report includes raw API rows, grouped summaries, Performance API data, and artifact paths
+- Screenshot is saved at `output/playwright/browser-runtime-profile.png`
+- Trace is saved at `output/playwright/browser-runtime-profile-trace.zip`
+
+#### Rollback/Cleanup
+- Delete generated files under `output/playwright/` if local artifacts are no longer needed

--- a/tests.md
+++ b/tests.md
@@ -2848,3 +2848,30 @@ Cold thread message loading reuses the `thread/resume` response instead of also 
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### First app start avoids unnecessary selected-thread message load
+
+#### Feature/Change Name
+Initial home-route startup skips loading the previously selected thread's messages and loads workspace-root state only once for the first thread list.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Browser dev tools Network panel open
+3. A saved selected thread exists from a previous app session
+
+#### Steps
+1. Open the app at the home route (`/`)
+2. Inspect startup network/RPC calls
+3. Open the app directly at `/thread/<threadId>` for an existing thread
+4. Inspect startup network/RPC calls again
+
+#### Expected Results
+- Home-route startup loads the thread list but does not load messages for the previous selected thread
+- Direct thread-route startup still loads that thread's messages
+- First thread-list loading performs a single workspace roots state request for ordering and filtering
+- Thread groups still respect saved workspace root ordering/filtering after startup
+
+#### Rollback/Cleanup
+- None

--- a/tests.md
+++ b/tests.md
@@ -2926,3 +2926,30 @@ Normal thread detail loading calls `thread/read` directly instead of first calli
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Thread message cache skips unchanged refetches
+
+#### Feature/Change Name
+Loaded thread messages are reused when the thread list version has not changed and the thread is not in progress.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Browser dev tools Network panel open
+3. An existing completed thread
+
+#### Steps
+1. Open the completed thread and wait for messages to render
+2. Switch to another thread or home
+3. Return to the same completed thread without new turn or thread update events
+4. Inspect network/RPC calls during the return
+
+#### Expected Results
+- The first open loads messages normally
+- Returning to the unchanged completed thread reuses cached messages
+- No additional `thread/read` or `thread/resume` call is made for that unchanged return
+- If the thread version changes or the thread is in progress, messages still refresh from the server
+
+#### Rollback/Cleanup
+- None

--- a/tests.md
+++ b/tests.md
@@ -2875,3 +2875,54 @@ Initial home-route startup skips loading the previously selected thread's messag
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Thread list startup pagination and direct older-thread links
+
+#### Feature/Change Name
+Thread loading uses a smaller initial list page, hydrates later pages in the background, and direct thread URLs are not rejected just because the thread is outside the first page.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Browser dev tools Network panel open
+3. More than 50 existing threads, including a valid older thread outside the first updated page
+
+#### Steps
+1. Open the app home route
+2. Inspect the first `thread/list` RPC request
+3. Keep the app open and watch subsequent `thread/list` RPC requests
+4. Open `/thread/<older-thread-id>` directly for a valid thread outside the first page
+
+#### Expected Results
+- The first `thread/list` request uses a smaller initial limit instead of 100
+- Later thread pages load in the background using `nextCursor`
+- The sidebar gains older threads as background pages complete
+- The direct older thread URL stays on the thread route and loads messages instead of redirecting home
+
+#### Rollback/Cleanup
+- None
+
+---
+
+### Thread detail load avoids duplicate live-state history fetch
+
+#### Feature/Change Name
+Normal thread detail loading calls `thread/read` directly instead of first calling `/codex-api/thread-live-state`, whose server path also reads full thread history.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Browser dev tools Network panel open
+3. An existing thread with a large history
+
+#### Steps
+1. Open the existing thread
+2. Inspect network/RPC calls during the message load
+
+#### Expected Results
+- The message load performs `thread/read` or `thread/resume` for the thread
+- It does not first call `/codex-api/thread-live-state` for the same normal message load
+- Messages and active/in-progress state still render correctly
+
+#### Rollback/Cleanup
+- None


### PR DESCRIPTION
## Summary
- Optimizes thread loading by reducing cold thread load work, paging thread lists, preserving direct older-thread links, and avoiding duplicate live-state/history fetches.
- Stabilizes sidebar refresh behavior so selecting a thread does not briefly hide already-loaded thread pages.
- Adds a reusable Playwright browser runtime profiler with network counts, payload sizes, screenshots, Performance API data, trace artifacts, and warning thresholds.
- Coalesces startup/thread refresh work to reduce duplicate thread/message/skills/quota requests.
- Defers provider-model probing from normal startup, limits automatic cursor pagination to one page, and avoids immediate post-resume rereads.

## Verification
- `pnpm run build:frontend`
- `pnpm run profile:thread`
  - target: `http://localhost:5173/#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c`
  - final URL stayed on target thread
  - title: `Locate Android skill repo`
  - `threadListFirstPage: 1`
  - `threadListCursor: 1`
  - `threadResume: 1`
  - `threadRead: 0`
  - `skillsList: 1`
  - `rateLimitsRead: 1`
  - `providerModels: 0`
  - `warnings: []`
  - `totalApiKB: 236.7`
- `pnpm run profile:browser`
  - final URL: `http://localhost:5173/#/`
  - `threadListFirstPage: 1`
  - `threadListCursor: 1`
  - `threadResume: 0`
  - `threadRead: 0`
  - `skillsList: 1`
  - `rateLimitsRead: 1`
  - `providerModels: 0`
  - `warnings: []`
  - `totalApiKB: 197.3`

## Notes
- Generated Playwright artifacts are ignored under `output/playwright/` and are not included in the PR.
- Background pagination intentionally loads one cursor page after the first page so older threads begin hydrating without draining all pages during initial route load.
