### PR TITLE
Follow up thread startup profiling optimizations

### DIFF
--- a/scripts/profile-browser-runtime.cjs
+++ b/scripts/profile-browser-runtime.cjs
@@ -40,6 +40,22 @@ function summarize(rows) {
   }
 }
 
+function buildWarnings(duplicateCounts, apiSummary, apiRows) {
+  const warnings = []
+  const providerModels = apiSummary.find((row) => row.key === '/codex-api/provider-models')
+  const totalApiKB = round(apiRows.reduce((sum, row) => sum + row.responseBytes, 0) / 1024)
+
+  if (duplicateCounts.threadListFirstPage > 1) warnings.push(`threadListFirstPage=${duplicateCounts.threadListFirstPage}`)
+  if (duplicateCounts.threadResume > 1) warnings.push(`threadResume=${duplicateCounts.threadResume}`)
+  if (duplicateCounts.threadRead > 0) warnings.push(`threadRead=${duplicateCounts.threadRead}`)
+  if (duplicateCounts.skillsList > 1) warnings.push(`skillsList=${duplicateCounts.skillsList}`)
+  if (duplicateCounts.rateLimitsRead > 1) warnings.push(`rateLimitsRead=${duplicateCounts.rateLimitsRead}`)
+  if (providerModels && providerModels.maxMs > 1000) warnings.push(`providerModels=${providerModels.maxMs}ms`)
+  if (totalApiKB > 750) warnings.push(`totalApiKB=${totalApiKB}`)
+
+  return { warnings, totalApiKB }
+}
+
 function requestKey(row) {
   if (row.rpc === 'thread/list') {
     return row.cursor ? 'thread/list:cursor' : 'thread/list:first-page'
@@ -185,6 +201,7 @@ async function main() {
     rateLimitsRead: apiRows.filter((row) => row.rpc === 'account/rateLimits/read').length,
     providerModels: apiRows.filter((row) => row.path === '/codex-api/provider-models').length,
   }
+  const diagnostics = buildWarnings(duplicateCounts, apiSummary, apiRows)
 
   const report = {
     targetUrl,
@@ -194,6 +211,8 @@ async function main() {
     screenshotPath,
     tracePath,
     duplicateCounts,
+    warnings: diagnostics.warnings,
+    totalApiKB: diagnostics.totalApiKB,
     bodyTextHead: bodyText.slice(0, 1000),
     performance: performanceData,
     apiSummary,
@@ -213,6 +232,8 @@ async function main() {
     title,
     totalMs,
     duplicateCounts,
+    warnings: diagnostics.warnings,
+    totalApiKB: diagnostics.totalApiKB,
     topApiSummary: apiSummary.slice(0, 12),
     slowestApiRows: report.slowestApiRows.slice(0, 10),
   }, null, 2))

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1309,13 +1309,17 @@ export async function setCustomProvider(
   return await response.json() as { ok: boolean }
 }
 
-export async function getAvailableModelIds(): Promise<string[]> {
+export async function getAvailableModelIds(options: { includeProviderModels?: boolean } = {}): Promise<string[]> {
   const payload = await callRpc<ModelListResponse>('model/list', {})
   const ids: string[] = []
   for (const row of payload.data) {
     const candidate = row.id || row.model
     if (!candidate || ids.includes(candidate)) continue
     ids.push(candidate)
+  }
+
+  if (options.includeProviderModels === false) {
+    return ids
   }
 
   try {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1089,7 +1089,6 @@ export function useDesktopState() {
   let loadThreadsPromise: Promise<void> | null = null
   const loadMessagePromiseByThreadId = new Map<string, Promise<void>>()
   let refreshSkillsPromise: Promise<void> | null = null
-  let codexRateLimitRefreshPromise: Promise<void> | null = null
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
   const pendingThreadMessageRefresh = new Set<string>()
@@ -1450,10 +1449,10 @@ export function useDesktopState() {
     return [`Mode: ${modeLabel}`, `Model: ${modelLabel}`, `Thinking: ${effortLabel}`, `Speed: ${speedLabel}`]
   }
 
-  async function refreshModelPreferences(options?: { providerChanged?: boolean }): Promise<void> {
+  async function refreshModelPreferences(options?: { providerChanged?: boolean; includeProviderModels?: boolean }): Promise<void> {
     try {
       const [modelIds, currentConfig] = await Promise.all([
-        getAvailableModelIds(),
+        getAvailableModelIds({ includeProviderModels: options?.includeProviderModels !== false }),
         getCurrentModelConfig(),
       ])
 
@@ -1520,7 +1519,9 @@ export function useDesktopState() {
 
     rateLimitRefreshPromise = (async () => {
       try {
-        accountRateLimitSnapshots.value = normalizeRateLimitSnapshotsPayload(await getAccountRateLimits())
+        const snapshot = await getAccountRateLimits()
+        setCodexRateLimit(snapshot)
+        accountRateLimitSnapshots.value = snapshot ? [snapshot] : []
       } catch {
         // Keep the last known rate-limit state if the endpoint is temporarily unavailable.
       } finally {
@@ -3526,13 +3527,11 @@ export function useDesktopState() {
     isLoadingRemainingThreadPages = true
 
     try {
-      while (threadListNextCursor) {
-        const page = await getThreadGroupsPage(threadListNextCursor, getBackgroundThreadListLimit())
-        threadListNextCursor = page.nextCursor
-        hasLoadedAllThreadPages = page.nextCursor === null
-        loadedThreadListGroups = mergeThreadGroupPages(loadedThreadListGroups, page.groups)
-        applyThreadGroups(loadedThreadListGroups, rootsState)
-      }
+      const page = await getThreadGroupsPage(threadListNextCursor, getBackgroundThreadListLimit())
+      threadListNextCursor = page.nextCursor
+      hasLoadedAllThreadPages = page.nextCursor === null
+      loadedThreadListGroups = mergeThreadGroupPages(loadedThreadListGroups, page.groups)
+      applyThreadGroups(loadedThreadListGroups, rootsState)
     } catch {
       // Keep the first page usable; a later refresh can retry remaining pages.
     } finally {
@@ -3561,7 +3560,9 @@ export function useDesktopState() {
       loadedThreadListGroups = hasLoadedThreads.value
         ? mergeThreadGroupPages(loadedThreadListGroups, groups)
         : groups
-      threadListNextCursor = page.nextCursor
+      threadListNextCursor = hasLoadedThreads.value && !hasLoadedAllThreadPages
+        ? threadListNextCursor
+        : page.nextCursor
       hasLoadedAllThreadPages = page.nextCursor === null
       await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
@@ -3576,7 +3577,7 @@ export function useDesktopState() {
 
       const currentExists = flatThreads.some((thread) => thread.id === selectedThreadId.value)
 
-      if (!currentExists) {
+      if (!currentExists && !selectedThreadId.value) {
         setSelectedThreadId(flatThreads[0]?.id ?? '')
       }
     } finally {
@@ -3612,8 +3613,7 @@ export function useDesktopState() {
       const loadedVersion = loadedVersionByThreadId.value[threadId] ?? ''
       const canReuseLoadedMessages =
         alreadyLoaded &&
-        version.length > 0 &&
-        loadedVersion === version &&
+        (version.length === 0 || loadedVersion === version) &&
         inProgressById.value[threadId] !== true
 
       if (canReuseLoadedMessages) {
@@ -3717,22 +3717,7 @@ export function useDesktopState() {
   }
 
   async function refreshCodexRateLimits(): Promise<void> {
-    if (codexRateLimitRefreshPromise) {
-      await codexRateLimitRefreshPromise
-      return
-    }
-
-    codexRateLimitRefreshPromise = (async () => {
-      try {
-        setCodexRateLimit(await getAccountRateLimits())
-      } catch {
-        // Keep the last known quota snapshot on transient failures.
-      } finally {
-        codexRateLimitRefreshPromise = null
-      }
-    })()
-
-    await codexRateLimitRefreshPromise
+    await refreshRateLimits()
   }
 
   async function refreshAll(
@@ -3745,7 +3730,10 @@ export function useDesktopState() {
     try {
       await loadThreads()
       const ancillaryRefresh = Promise.allSettled([
-        refreshModelPreferences({ providerChanged: options.providerChanged }),
+        refreshModelPreferences({
+          providerChanged: options.providerChanged,
+          includeProviderModels: options.providerChanged === true || awaitAncillaryRefreshes,
+        }),
         refreshRateLimits(),
         refreshCollaborationModes(),
         refreshSkills(),
@@ -4622,7 +4610,10 @@ export function useDesktopState() {
   async function recoverBridgeState(): Promise<void> {
     await loadPendingServerRequestsFromBridge()
     pendingThreadsRefresh = !hasLoadedThreads.value
-    if (selectedThreadId.value) {
+    if (
+      selectedThreadId.value &&
+      loadedMessagesByThreadId.value[selectedThreadId.value] !== true
+    ) {
       pendingThreadMessageRefresh.add(selectedThreadId.value)
     }
     await syncFromNotifications()

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -76,6 +76,7 @@ const NEW_THREAD_PROVIDER_MODEL_CONTEXT_PREFIX = '__new-thread-provider__::'
 const EVENT_SYNC_DEBOUNCE_MS = 220
 const RATE_LIMIT_REFRESH_DEBOUNCE_MS = 500
 const TURN_START_FOLLOW_UP_SYNC_DELAY_MS = 3000
+const RECENT_THREAD_MESSAGE_LOAD_REUSE_MS = 2000
 const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
 const GLOBAL_SERVER_REQUEST_SCOPE = '__global__'
 const MODEL_FALLBACK_ID = 'gpt-5.2-codex'
@@ -1092,6 +1093,7 @@ export function useDesktopState() {
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
   const pendingThreadMessageRefresh = new Set<string>()
+  const lastMessageLoadAtByThreadId = new Map<string, number>()
   let threadListNextCursor: string | null = null
   let isLoadingRemainingThreadPages = false
   let hasLoadedAllThreadPages = false
@@ -3611,10 +3613,17 @@ export function useDesktopState() {
       try {
       const version = currentThreadVersion(threadId)
       const loadedVersion = loadedVersionByThreadId.value[threadId] ?? ''
+      const loadedRecently =
+        Date.now() - (lastMessageLoadAtByThreadId.get(threadId) ?? 0) < RECENT_THREAD_MESSAGE_LOAD_REUSE_MS
       const canReuseLoadedMessages =
         alreadyLoaded &&
-        (version.length === 0 || loadedVersion === version) &&
-        inProgressById.value[threadId] !== true
+        (
+          loadedRecently ||
+          (
+            (version.length === 0 || loadedVersion === version) &&
+            inProgressById.value[threadId] !== true
+          )
+        )
 
       if (canReuseLoadedMessages) {
         markThreadAsRead(threadId)
@@ -3657,6 +3666,7 @@ export function useDesktopState() {
         ...loadedMessagesByThreadId.value,
         [threadId]: true,
       }
+      lastMessageLoadAtByThreadId.set(threadId, Date.now())
 
       if (version) {
         loadedVersionByThreadId.value = {
@@ -4586,7 +4596,13 @@ export function useDesktopState() {
       const loadedVersion = loadedVersionByThreadId.value[activeThreadId] ?? ''
       const hasVersionChange = currentVersion.length > 0 && currentVersion !== loadedVersion
 
-      if (isActiveDirty || isInProgress || hasVersionChange || shouldRefreshThreads) {
+      const shouldRefreshActiveThread =
+        hasVersionChange ||
+        (isInProgress && loadedMessagesByThreadId.value[activeThreadId] !== true) ||
+        (isActiveDirty && loadedMessagesByThreadId.value[activeThreadId] !== true) ||
+        (shouldRefreshThreads && loadedMessagesByThreadId.value[activeThreadId] !== true)
+
+      if (shouldRefreshActiveThread) {
         await loadMessages(activeThreadId, { silent: true })
       }
     } catch {

--- a/tests.md
+++ b/tests.md
@@ -2896,8 +2896,8 @@ Thread loading uses a smaller initial list page, hydrates later pages in the bac
 
 #### Expected Results
 - The first `thread/list` request uses a smaller initial limit instead of 100
-- Later thread pages load in the background using `nextCursor`
-- The sidebar gains older threads as background pages complete
+- One later thread page loads in the background using `nextCursor`
+- The sidebar gains older threads without draining every remaining page during initial route load
 - The direct older thread URL stays on the thread route and loads messages instead of redirecting home
 
 #### Rollback/Cleanup
@@ -3002,6 +3002,7 @@ Playwright browser runtime profiler captures route timing, Codex API network cou
 
 #### Expected Results
 - The profiler prints final URL, title, total observed time, duplicate request counts, and slowest Codex API calls
+- The profiler prints warnings for unexpected duplicate/slow paths such as extra first-page thread lists, thread reads, duplicate resumes, duplicate quota reads, slow provider model calls, or high total API payload
 - JSON report includes raw API rows, grouped summaries, Performance API data, and artifact paths
 - Screenshot is saved under `output/playwright/browser-runtime-profile-*.png`
 - Trace is saved under `output/playwright/browser-runtime-profile-*-trace.zip`


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #64 for the two commits added after that PR was merged.
- Defers provider-model probing from normal startup refreshes.
- Unifies quota refresh to avoid duplicate `account/rateLimits/read` calls.
- Limits automatic background thread pagination to one cursor page during initial route load.
- Preserves direct selected thread ids outside the first list page.
- Avoids immediate post-resume `thread/read` rereads.
- Adds profiler warnings and total API payload reporting.

## Verification
- `pnpm run build:frontend`
- `pnpm run profile:browser`
  - `threadListFirstPage: 1`
  - `threadListCursor: 1`
  - `threadResume: 0`
  - `threadRead: 0`
  - `skillsList: 1`
  - `rateLimitsRead: 1`
  - `providerModels: 0`
  - `warnings: []`
  - `totalApiKB: 197.3`
- `pnpm run profile:thread`
  - target route stayed on `#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c`
  - title: `Locate Android skill repo`
  - `threadListFirstPage: 1`
  - `threadListCursor: 1`
  - `threadResume: 1`
  - `threadRead: 0`
  - `skillsList: 1`
  - `rateLimitsRead: 1`
  - `providerModels: 0`
  - `warnings: []`
  - `totalApiKB: 236.7`

## Notes
- PR #64 was merged before these final two commits, so this PR carries only the remaining follow-up changes.
