### PR TITLE
Add thread heartbeat automations

### DIFF
--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -502,3 +502,17 @@ After each feature implementation session that uses this skill:
   - `thread/compact/start`
   - `feedback/upload`
   - `fuzzyFileSearch`
+
+## Findings: Thread Heartbeat Automations (2026-04-21)
+
+- Codex.app exposes thread heartbeat automation affordances in the sidebar:
+  - thread menu copy: `Add automation…` and `Edit automation…`
+  - attached heartbeat rows show a next-run tooltip via `sidebarTaskRow.heartbeatAutomation.nextRun`
+  - archive confirmation copy changes to `Archive chat and remove automation?`
+- Desktop heartbeat automation payloads use:
+  - `<heartbeat>`
+  - `<automation_id>`
+  - `<current_time_iso>`
+  - `<instructions>`
+- Local automation storage uses `$CODEX_HOME/automations/<id>/automation.toml`; heartbeat records include `kind = "heartbeat"` and `target_thread_id`.
+

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -20,7 +20,7 @@ import type {
   ThreadStartResponse,
   Turn,
 } from './appServerDtos'
-import { normalizeCodexApiError } from './codexErrors'
+import { extractErrorMessage, normalizeCodexApiError } from './codexErrors'
 import {
   readActiveTurnIdFromResponse,
   normalizeThreadGroupsV2,
@@ -50,6 +50,8 @@ import type {
   UiReviewWorkspaceView,
   UiRateLimitSnapshot,
   UiRateLimitWindow,
+  UiThreadAutomation,
+  UiThreadAutomationStatus,
 } from '../types/codex'
 import { normalizePathForUi } from '../pathUtils.js'
 
@@ -784,6 +786,88 @@ export async function getMethodCatalog(): Promise<string[]> {
 
 export async function getNotificationCatalog(): Promise<string[]> {
   return fetchRpcNotificationCatalog()
+}
+
+function asAutomation(record: unknown): UiThreadAutomation | null {
+  const row = asRecord(record)
+  if (!row) return null
+  const id = readString(row.id)
+  const kind = readString(row.kind)
+  const name = readString(row.name)
+  const prompt = readString(row.prompt)
+  const rrule = readString(row.rrule)
+  const status = readString(row.status)
+  if (!id || !name || !prompt || !rrule) return null
+  if (kind !== 'heartbeat' && kind !== 'cron') return null
+  if (status !== 'ACTIVE' && status !== 'PAUSED') return null
+  return {
+    id,
+    kind,
+    name,
+    prompt,
+    rrule,
+    status,
+    targetThreadId: readString(row.targetThreadId),
+    createdAtMs: readNumber(row.createdAtMs),
+    updatedAtMs: readNumber(row.updatedAtMs),
+    nextRunAtMs: readNumber(row.nextRunAtMs),
+  }
+}
+
+export async function getThreadAutomationMap(): Promise<Record<string, UiThreadAutomation>> {
+  const response = await fetch('/codex-api/thread-automations')
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to load thread automations'))
+  }
+  const data = asRecord(asRecord(payload)?.data)
+  const next: Record<string, UiThreadAutomation> = {}
+  if (!data) return next
+  for (const [threadId, value] of Object.entries(data)) {
+    const automation = asAutomation(value)
+    if (automation) next[threadId] = automation
+  }
+  return next
+}
+
+export async function getThreadAutomation(threadId: string): Promise<UiThreadAutomation | null> {
+  const response = await fetch(`/codex-api/thread-automation?threadId=${encodeURIComponent(threadId)}`)
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to load thread automation'))
+  }
+  return asAutomation(asRecord(payload)?.data)
+}
+
+export async function upsertThreadAutomation(input: {
+  threadId: string
+  name: string
+  prompt: string
+  rrule: string
+  status: UiThreadAutomationStatus
+}): Promise<UiThreadAutomation> {
+  const response = await fetch('/codex-api/thread-automation', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to save thread automation'))
+  }
+  const automation = asAutomation(asRecord(payload)?.data)
+  if (!automation) throw new Error('Thread automation response was malformed')
+  return automation
+}
+
+export async function deleteThreadAutomation(threadId: string): Promise<void> {
+  const response = await fetch(`/codex-api/thread-automation?threadId=${encodeURIComponent(threadId)}`, {
+    method: 'DELETE',
+  })
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to delete thread automation'))
+  }
 }
 
 export function subscribeCodexNotifications(onNotification: (value: RpcNotification) => void): () => void {

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -88,11 +88,36 @@ function toImageGenerationUrl(value: string): string {
   return `data:image/png;base64,${compact}`
 }
 
+function readHeartbeatField(value: string, field: string): string {
+  const match = new RegExp(`<${field}>\\s*([\\s\\S]*?)\\s*</${field}>`, 'iu').exec(value)
+  return match?.[1]?.trim() ?? ''
+}
+
+function parseHeartbeatEnvelope(value: string): { automationId: string; instructions: string } | null {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('<heartbeat>') || !trimmed.endsWith('</heartbeat>')) return null
+  const instructions = readHeartbeatField(trimmed, 'instructions')
+  if (!instructions) return null
+  return {
+    automationId: readHeartbeatField(trimmed, 'automation_id'),
+    instructions,
+  }
+}
+
 function parseUserMessageContent(
   itemId: string,
   content: UserInput[] | undefined,
-): { text: string; images: string[]; fileAttachments: UiFileAttachment[]; rawBlocks: UiMessage[] } {
-  if (!Array.isArray(content)) return { text: '', images: [], fileAttachments: [], rawBlocks: [] }
+): {
+  text: string
+  images: string[]
+  fileAttachments: UiFileAttachment[]
+  rawBlocks: UiMessage[]
+  isAutomationRun: boolean
+  automationDisplayName: string | null
+} {
+  if (!Array.isArray(content)) {
+    return { text: '', images: [], fileAttachments: [], rawBlocks: [], isAutomationRun: false, automationDisplayName: null }
+  }
 
   const textChunks: string[] = []
   const images: string[] = []
@@ -123,12 +148,15 @@ function parseUserMessageContent(
 
   const fullText = textChunks.join('\n')
   const fileAttachments = extractFileAttachments(fullText)
+  const heartbeat = parseHeartbeatEnvelope(fullText)
 
   return {
-    text: extractCodexUserRequestText(fullText),
+    text: heartbeat?.instructions ?? extractCodexUserRequestText(fullText),
     images,
     fileAttachments,
     rawBlocks,
+    isAutomationRun: heartbeat !== null,
+    automationDisplayName: heartbeat?.automationId || null,
   }
 }
 
@@ -367,11 +395,13 @@ function toUiMessages(item: ThreadItem): UiMessage[] {
     if (hasRenderableUserContent) {
       messages.push({
         id: item.id,
-        role: 'user',
+        role: parsed.isAutomationRun ? 'system' : 'user',
         text: parsed.text,
         images: parsed.images,
         fileAttachments: parsed.fileAttachments.length > 0 ? parsed.fileAttachments : undefined,
         messageType: item.type,
+        isAutomationRun: parsed.isAutomationRun,
+        automationDisplayName: parsed.automationDisplayName,
       })
     }
 
@@ -417,6 +447,7 @@ function toUiMessages(item: ThreadItem): UiMessage[] {
   if (item.type === 'reasoning') {
     return []
   }
+
 
   if (item.type === 'plan') {
     const text = typeof item.text === 'string' ? item.text : ''

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -31,6 +31,13 @@
                   <span class="thread-row-title">{{ thread.title }}</span>
                   <IconTablerGitFork v-if="thread.hasWorktree" class="thread-row-worktree-icon" title="Worktree thread" />
                   <span
+                    v-if="threadHasAutomation(thread.id)"
+                    class="thread-row-automation-chip"
+                    :title="threadAutomationTooltip(thread.id)"
+                  >
+                    Auto
+                  </span>
+                  <span
                     v-if="thread.pendingRequestState"
                     class="thread-row-request-chip"
                     :data-state="thread.pendingRequestState"
@@ -137,6 +144,13 @@
               <span class="thread-row-title-line">
                 <span class="thread-row-title">{{ thread.title }}</span>
                 <IconTablerGitFork v-if="thread.hasWorktree" class="thread-row-worktree-icon" title="Worktree thread" />
+                <span
+                  v-if="threadHasAutomation(thread.id)"
+                  class="thread-row-automation-chip"
+                  :title="threadAutomationTooltip(thread.id)"
+                >
+                  Auto
+                </span>
                 <span
                   v-if="thread.pendingRequestState"
                   class="thread-row-request-chip"
@@ -295,6 +309,13 @@
                       <span class="thread-row-title">{{ thread.title }}</span>
                       <IconTablerGitFork v-if="thread.hasWorktree" class="thread-row-worktree-icon" title="Worktree thread" />
                       <span
+                        v-if="threadHasAutomation(thread.id)"
+                        class="thread-row-automation-chip"
+                        :title="threadAutomationTooltip(thread.id)"
+                      >
+                        Auto
+                      </span>
+                      <span
                         v-if="thread.pendingRequestState"
                         class="thread-row-request-chip"
                         :data-state="thread.pendingRequestState"
@@ -350,6 +371,9 @@
         :data-open-direction="getThreadMenuDirection(openThreadMenuThread.id)"
         @click.stop
       >
+        <button class="thread-menu-item" type="button" @click="openAutomationDialog(openThreadMenuThread.id)">
+          {{ threadHasAutomation(openThreadMenuThread.id) ? 'Edit automation…' : 'Add automation…' }}
+        </button>
         <button class="thread-menu-item" type="button" @click="onBrowseThreadFiles(openThreadMenuThread.id)">
           Browse files
         </button>
@@ -393,13 +417,77 @@
     <Teleport to="body">
       <div v-if="deleteThreadDialogVisible" class="rename-thread-overlay" @click.self="closeDeleteThreadDialog">
         <div class="rename-thread-panel" role="dialog" aria-modal="true" aria-label="Delete thread">
-          <h3 class="rename-thread-title">Delete thread?</h3>
+          <h3 class="rename-thread-title">{{ deleteThreadHasAutomation ? 'Archive chat and remove automation?' : 'Delete thread?' }}</h3>
           <p class="rename-thread-subtitle">
-            This will archive the thread "{{ deleteThreadTitle }}". You can find it later in archived threads.
+            <template v-if="deleteThreadHasAutomation">
+              This will archive the thread "{{ deleteThreadTitle }}" and remove the attached heartbeat automation.
+            </template>
+            <template v-else>
+              This will archive the thread "{{ deleteThreadTitle }}". You can find it later in archived threads.
+            </template>
           </p>
           <div class="rename-thread-actions">
             <button class="rename-thread-button" type="button" @click="closeDeleteThreadDialog">Cancel</button>
-            <button class="rename-thread-button rename-thread-button-danger" type="button" @click="submitDeleteThread">Delete</button>
+            <button class="rename-thread-button rename-thread-button-danger" type="button" @click="submitDeleteThread">
+              {{ deleteThreadHasAutomation ? 'Archive and remove' : 'Delete' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div v-if="automationDialogVisible" class="rename-thread-overlay" @click.self="closeAutomationDialog">
+        <div class="rename-thread-panel automation-thread-panel" role="dialog" aria-modal="true" aria-label="Thread automation">
+          <h3 class="rename-thread-title">{{ automationDialogMode === 'edit' ? 'Edit automation' : 'Add automation' }}</h3>
+          <p class="rename-thread-subtitle">This creates a heartbeat automation attached to the selected thread.</p>
+
+          <label class="automation-thread-field">
+            <span class="automation-thread-label">Name</span>
+            <input v-model="automationDraft.name" class="rename-thread-input" type="text" placeholder="Automation name" />
+          </label>
+
+          <label class="automation-thread-field">
+            <span class="automation-thread-label">Prompt</span>
+            <textarea v-model="automationDraft.prompt" class="automation-thread-textarea" rows="6" placeholder="Describe what the automation should do"></textarea>
+          </label>
+
+          <label class="automation-thread-field">
+            <span class="automation-thread-label">Schedule (RRULE)</span>
+            <input
+              v-model="automationDraft.rrule"
+              class="rename-thread-input"
+              type="text"
+              placeholder="FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+            />
+          </label>
+
+          <label class="automation-thread-field">
+            <span class="automation-thread-label">Status</span>
+            <select v-model="automationDraft.status" class="automation-thread-select">
+              <option value="ACTIVE">Active</option>
+              <option value="PAUSED">Paused</option>
+            </select>
+          </label>
+
+          <p v-if="automationDialogError" class="rename-thread-subtitle automation-thread-error">{{ automationDialogError }}</p>
+
+          <div class="rename-thread-actions">
+            <button
+              v-if="automationDialogMode === 'edit'"
+              class="rename-thread-button rename-thread-button-danger"
+              type="button"
+              :disabled="isSavingAutomation"
+              @click="onDeleteAutomationFromDialog"
+            >
+              Remove
+            </button>
+            <button class="rename-thread-button" type="button" :disabled="isSavingAutomation" @click="closeAutomationDialog">
+              Cancel
+            </button>
+            <button class="rename-thread-button rename-thread-button-primary" type="button" :disabled="isSavingAutomation" @click="submitAutomationDialog">
+              {{ isSavingAutomation ? 'Saving…' : 'Save' }}
+            </button>
           </div>
         </div>
       </div>
@@ -410,8 +498,14 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { ComponentPublicInstance } from 'vue'
-import { getPinnedThreadState, persistPinnedThreadIds } from '../../api/codexGateway'
-import type { UiProjectGroup, UiThread } from '../../types/codex'
+import {
+  deleteThreadAutomation,
+  getPinnedThreadState,
+  getThreadAutomationMap,
+  persistPinnedThreadIds,
+  upsertThreadAutomation,
+} from '../../api/codexGateway'
+import type { UiProjectGroup, UiThread, UiThreadAutomation, UiThreadAutomationStatus } from '../../types/codex'
 import IconTablerChevronDown from '../icons/IconTablerChevronDown.vue'
 import IconTablerChevronRight from '../icons/IconTablerChevronRight.vue'
 import IconTablerDots from '../icons/IconTablerDots.vue'
@@ -495,6 +589,23 @@ const renameThreadInputRef = ref<HTMLInputElement | null>(null)
 const deleteThreadDialogVisible = ref(false)
 const deleteThreadDialogThreadId = ref('')
 const deleteThreadTitle = ref('')
+const automationByThreadId = ref<Record<string, UiThreadAutomation>>({})
+const automationDialogVisible = ref(false)
+const automationDialogThreadId = ref('')
+const automationDialogMode = ref<'create' | 'edit'>('create')
+const automationDialogError = ref('')
+const isSavingAutomation = ref(false)
+const automationDraft = ref<{
+  name: string
+  prompt: string
+  rrule: string
+  status: UiThreadAutomationStatus
+}>({
+  name: '',
+  prompt: '',
+  rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+  status: 'ACTIVE',
+})
 const groupsContainerRef = ref<HTMLElement | null>(null)
 const pendingProjectDrag = ref<PendingProjectDrag | null>(null)
 const activeProjectDrag = ref<ActiveProjectDrag | null>(null)
@@ -647,8 +758,15 @@ onMounted(async () => {
   if (normalized.length > 0) {
     pinnedThreadIds.value = normalized
   }
+  try {
+    automationByThreadId.value = await getThreadAutomationMap()
+  } catch {
+    automationByThreadId.value = {}
+  }
   hasLoadedPinnedThreadState = true
 })
+
+const deleteThreadHasAutomation = computed(() => threadHasAutomation(deleteThreadDialogThreadId.value))
 
 const threadProjectNameById = computed(() => {
   const map = new Map<string, string>()
@@ -783,6 +901,21 @@ function onSelect(threadId: string): void {
   emit('select', threadId)
 }
 
+function threadHasAutomation(threadId: string): boolean {
+  return Boolean(automationByThreadId.value[threadId])
+}
+
+function threadAutomationTooltip(threadId: string): string {
+  const automation = automationByThreadId.value[threadId]
+  if (!automation) return ''
+  const nextRunLabel = automation.status === 'PAUSED'
+    ? '-'
+    : automation.nextRunAtMs
+      ? new Date(automation.nextRunAtMs).toLocaleString()
+      : 'Not scheduled'
+  return `${automation.name} • Next run: ${nextRunLabel}`
+}
+
 function onExportThread(threadId: string): void {
   emit('export-thread', threadId)
   closeThreadMenu()
@@ -882,12 +1015,85 @@ function closeDeleteThreadDialog(): void {
   deleteThreadTitle.value = ''
 }
 
-function submitDeleteThread(): void {
+async function submitDeleteThread(): Promise<void> {
   const threadId = deleteThreadDialogThreadId.value
   if (!threadId) return
+  if (threadHasAutomation(threadId)) {
+    try {
+      await deleteThreadAutomation(threadId)
+    } catch {
+      // Keep thread archive usable even if automation cleanup fails.
+    }
+    automationByThreadId.value = Object.fromEntries(
+      Object.entries(automationByThreadId.value).filter(([id]) => id !== threadId),
+    )
+  }
   pinnedThreadIds.value = pinnedThreadIds.value.filter((id) => id !== threadId)
   emit('archive', threadId)
   closeDeleteThreadDialog()
+}
+
+function openAutomationDialog(threadId: string): void {
+  const existing = automationByThreadId.value[threadId]
+  automationDialogThreadId.value = threadId
+  automationDialogMode.value = existing ? 'edit' : 'create'
+  automationDialogError.value = ''
+  automationDraft.value = {
+    name: existing?.name ?? 'Thread automation',
+    prompt: existing?.prompt ?? '',
+    rrule: existing?.rrule ?? 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+    status: existing?.status ?? 'ACTIVE',
+  }
+  automationDialogVisible.value = true
+  closeThreadMenu()
+}
+
+function closeAutomationDialog(): void {
+  automationDialogVisible.value = false
+  automationDialogThreadId.value = ''
+  automationDialogError.value = ''
+  isSavingAutomation.value = false
+}
+
+async function submitAutomationDialog(): Promise<void> {
+  const threadId = automationDialogThreadId.value
+  if (!threadId) return
+  isSavingAutomation.value = true
+  automationDialogError.value = ''
+  try {
+    const saved = await upsertThreadAutomation({
+      threadId,
+      name: automationDraft.value.name,
+      prompt: automationDraft.value.prompt,
+      rrule: automationDraft.value.rrule,
+      status: automationDraft.value.status,
+    })
+    automationByThreadId.value = {
+      ...automationByThreadId.value,
+      [threadId]: saved,
+    }
+    closeAutomationDialog()
+  } catch (error) {
+    automationDialogError.value = error instanceof Error ? error.message : 'Failed to save automation'
+    isSavingAutomation.value = false
+  }
+}
+
+async function onDeleteAutomationFromDialog(): Promise<void> {
+  const threadId = automationDialogThreadId.value
+  if (!threadId) return
+  isSavingAutomation.value = true
+  automationDialogError.value = ''
+  try {
+    await deleteThreadAutomation(threadId)
+    automationByThreadId.value = Object.fromEntries(
+      Object.entries(automationByThreadId.value).filter(([id]) => id !== threadId),
+    )
+    closeAutomationDialog()
+  } catch (error) {
+    automationDialogError.value = error instanceof Error ? error.message : 'Failed to remove automation'
+    isSavingAutomation.value = false
+  }
 }
 
 function getProjectDisplayName(projectName: string): string {
@@ -1857,6 +2063,10 @@ onBeforeUnmount(() => {
   @apply block mx-auto rounded-lg px-2 py-0.5 text-sm font-normal text-zinc-600 transition hover:text-zinc-800 hover:bg-zinc-200;
 }
 
+.thread-row-automation-chip {
+  @apply rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800;
+}
+
 .project-header-row:hover .project-icon-folder {
   @apply opacity-0;
 }
@@ -1938,5 +2148,26 @@ onBeforeUnmount(() => {
 
 .rename-thread-button-danger {
   @apply bg-rose-600 text-white hover:bg-rose-700;
+}
+
+.automation-thread-panel {
+  @apply max-w-lg;
+}
+
+.automation-thread-field {
+  @apply mb-3 flex flex-col gap-1;
+}
+
+.automation-thread-label {
+  @apply text-xs font-medium uppercase tracking-wide text-zinc-500;
+}
+
+.automation-thread-textarea,
+.automation-thread-select {
+  @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-thread-error {
+  @apply mb-0 text-rose-600;
 }
 </style>

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -592,7 +592,9 @@ function areMessageFieldsEqual(first: UiMessage, second: UiMessage): boolean {
     areCommandExecutionsEqual(first.commandExecution, second.commandExecution) &&
     arePlanDataEqual(first.plan, second.plan) &&
     first.turnId === second.turnId &&
-    first.turnIndex === second.turnIndex
+    first.turnIndex === second.turnIndex &&
+    first.isAutomationRun === second.isAutomationRun &&
+    first.automationDisplayName === second.automationDisplayName
   )
 }
 
@@ -688,6 +690,12 @@ function removeRedundantLiveAgentMessages(previous: UiMessage[], incoming: UiMes
     return !incomingAssistantTexts.has(normalized)
   })
 
+  return next.length === previous.length ? previous : next
+}
+
+function removePersistedLiveMessages(previous: UiMessage[], incoming: UiMessage[]): UiMessage[] {
+  const incomingIds = new Set(incoming.map((message) => message.id))
+  const next = previous.filter((message) => !incomingIds.has(message.id))
   return next.length === previous.length ? previous : next
 }
 
@@ -2985,6 +2993,7 @@ export function useDesktopState() {
       text: '',
       images: [imageUrl],
       messageType: 'imageView',
+
     }
   }
 
@@ -3323,6 +3332,7 @@ export function useDesktopState() {
     const completedImageView = readCompletedImageView(notification)
     if (completedImageView) {
       upsertLiveAgentMessage(notificationThreadId, completedImageView)
+
     }
 
     const startedReasoningItemId = readReasoningStartedItemId(notification)

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1751,6 +1751,188 @@ function getCodexSessionIndexPath(): string {
   return join(getCodexHomeDir(), 'session_index.jsonl')
 }
 
+function getCodexAutomationsDir(): string {
+  return join(getCodexHomeDir(), 'automations')
+}
+
+type ThreadAutomationStatus = 'ACTIVE' | 'PAUSED'
+
+type ThreadAutomationRecord = {
+  id: string
+  kind: 'heartbeat' | 'cron'
+  name: string
+  prompt: string
+  rrule: string
+  status: ThreadAutomationStatus
+  targetThreadId: string | null
+  createdAtMs: number | null
+  updatedAtMs: number | null
+  nextRunAtMs: number | null
+}
+
+function readTomlString(value: string): string {
+  const trimmed = value.trim()
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith('\'') && trimmed.endsWith('\''))) {
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      return trimmed.slice(1, -1)
+    }
+  }
+  return trimmed
+}
+
+function serializeTomlString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function parseAutomationToml(raw: string): ThreadAutomationRecord | null {
+  const values: Record<string, string> = {}
+  for (const line of raw.split(/\r?\n/u)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue
+    const separatorIndex = trimmed.indexOf('=')
+    const key = trimmed.slice(0, separatorIndex).trim()
+    const value = trimmed.slice(separatorIndex + 1).trim()
+    if (key) values[key] = value
+  }
+
+  const id = readTomlString(values.id ?? '')
+  const kindValue = readTomlString(values.kind ?? 'heartbeat')
+  const name = readTomlString(values.name ?? '')
+  const prompt = readTomlString(values.prompt ?? '')
+  const rrule = readTomlString(values.rrule ?? '')
+  const statusValue = readTomlString(values.status ?? 'ACTIVE')
+  const targetThreadId = readTomlString(values.target_thread_id ?? '') || null
+  const createdAtMs = Number.parseInt(values.created_at ?? '', 10)
+  const updatedAtMs = Number.parseInt(values.updated_at ?? '', 10)
+
+  if (!id || !name || !prompt || !rrule) return null
+  if (kindValue !== 'heartbeat' && kindValue !== 'cron') return null
+  if (statusValue !== 'ACTIVE' && statusValue !== 'PAUSED') return null
+
+  return {
+    id,
+    kind: kindValue,
+    name,
+    prompt,
+    rrule,
+    status: statusValue,
+    targetThreadId,
+    createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : null,
+    updatedAtMs: Number.isFinite(updatedAtMs) ? updatedAtMs : null,
+    nextRunAtMs: null,
+  }
+}
+
+function serializeAutomationToml(record: ThreadAutomationRecord): string {
+  const lines = [
+    'version = 1',
+    `id = ${serializeTomlString(record.id)}`,
+    `kind = ${serializeTomlString(record.kind)}`,
+    `name = ${serializeTomlString(record.name)}`,
+    `prompt = ${serializeTomlString(record.prompt)}`,
+    `status = ${serializeTomlString(record.status)}`,
+    `rrule = ${serializeTomlString(record.rrule)}`,
+    `target_thread_id = ${serializeTomlString(record.targetThreadId ?? '')}`,
+    `created_at = ${String(record.createdAtMs ?? Date.now())}`,
+    `updated_at = ${String(record.updatedAtMs ?? Date.now())}`,
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+function slugifyAutomationId(threadId: string, name: string): string {
+  const preferred = name.trim().toLowerCase().replace(/[^a-z0-9]+/gu, '-').replace(/^-+|-+$/gu, '')
+  if (preferred) return preferred.slice(0, 48)
+  const fallback = threadId.trim().toLowerCase().replace(/[^a-z0-9]+/gu, '-').replace(/^-+|-+$/gu, '')
+  return `heartbeat-${fallback.slice(0, 24) || randomBytes(4).toString('hex')}`
+}
+
+async function readAutomationRecordFromFile(filePath: string): Promise<ThreadAutomationRecord | null> {
+  try {
+    return parseAutomationToml(await readFile(filePath, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function listThreadHeartbeatAutomations(): Promise<Record<string, ThreadAutomationRecord>> {
+  const automationRoot = getCodexAutomationsDir()
+  const next: Record<string, ThreadAutomationRecord> = {}
+  let entries
+  try {
+    entries = await readdir(automationRoot, { withFileTypes: true })
+  } catch {
+    return next
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const automation = await readAutomationRecordFromFile(join(automationRoot, entry.name, 'automation.toml'))
+    if (!automation || automation.kind !== 'heartbeat' || !automation.targetThreadId) continue
+    next[automation.targetThreadId] = automation
+  }
+
+  return next
+}
+
+async function readThreadHeartbeatAutomation(threadId: string): Promise<ThreadAutomationRecord | null> {
+  const all = await listThreadHeartbeatAutomations()
+  return all[threadId] ?? null
+}
+
+async function writeThreadHeartbeatAutomation(input: {
+  threadId: string
+  name: string
+  prompt: string
+  rrule: string
+  status: ThreadAutomationStatus
+}): Promise<ThreadAutomationRecord> {
+  const threadId = input.threadId.trim()
+  const name = input.name.trim()
+  const prompt = input.prompt.trim()
+  const rrule = input.rrule.trim()
+  if (!threadId || !name || !prompt || !rrule) {
+    throw new Error('threadId, name, prompt, and rrule are required')
+  }
+
+  const automationRoot = getCodexAutomationsDir()
+  await mkdir(automationRoot, { recursive: true })
+  const existing = await readThreadHeartbeatAutomation(threadId)
+  const id = existing?.id ?? slugifyAutomationId(threadId, name)
+  const automationDir = join(automationRoot, id)
+  const now = Date.now()
+  const record: ThreadAutomationRecord = {
+    id,
+    kind: 'heartbeat',
+    name,
+    prompt,
+    rrule,
+    status: input.status,
+    targetThreadId: threadId,
+    createdAtMs: existing?.createdAtMs ?? now,
+    updatedAtMs: now,
+    nextRunAtMs: null,
+  }
+
+  await mkdir(automationDir, { recursive: true })
+  await writeFile(join(automationDir, 'automation.toml'), serializeAutomationToml(record), 'utf8')
+  const memoryPath = join(automationDir, 'memory.md')
+  try {
+    await stat(memoryPath)
+  } catch {
+    await writeFile(memoryPath, '', 'utf8')
+  }
+  return record
+}
+
+async function deleteThreadHeartbeatAutomation(threadId: string): Promise<boolean> {
+  const automation = await readThreadHeartbeatAutomation(threadId.trim())
+  if (!automation) return false
+  await rm(join(getCodexAutomationsDir(), automation.id), { recursive: true, force: true })
+  return true
+}
+
 type ThreadTitleCache = { titles: Record<string, string>; order: string[] }
 const MAX_THREAD_TITLES = 500
 const EMPTY_THREAD_TITLE_CACHE: ThreadTitleCache = { titles: {}, order: [] }
@@ -4134,6 +4316,23 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-automations') {
+        const automationsByThreadId = await listThreadHeartbeatAutomations()
+        setJson(res, 200, { data: automationsByThreadId })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-automation') {
+        const threadId = url.searchParams.get('threadId')?.trim() ?? ''
+        if (!threadId) {
+          setJson(res, 400, { error: 'Missing threadId' })
+          return
+        }
+        const automation = await readThreadHeartbeatAutomation(threadId)
+        setJson(res, 200, { data: automation })
+        return
+      }
+
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-search') {
         const payload = asRecord(await readJsonBody(req))
         const query = typeof payload?.query === 'string' ? payload.query.trim() : ''
@@ -4174,6 +4373,33 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const threadIds = normalizePinnedThreadIds(payload?.threadIds)
         await writePinnedThreadIds(threadIds)
         setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'PUT' && url.pathname === '/codex-api/thread-automation') {
+        const payload = asRecord(await readJsonBody(req))
+        const threadId = typeof payload?.threadId === 'string' ? payload.threadId.trim() : ''
+        const name = typeof payload?.name === 'string' ? payload.name.trim() : ''
+        const prompt = typeof payload?.prompt === 'string' ? payload.prompt.trim() : ''
+        const rrule = typeof payload?.rrule === 'string' ? payload.rrule.trim() : ''
+        const status = payload?.status === 'PAUSED' ? 'PAUSED' : 'ACTIVE'
+        if (!threadId || !name || !prompt || !rrule) {
+          setJson(res, 400, { error: 'threadId, name, prompt, and rrule are required' })
+          return
+        }
+        const automation = await writeThreadHeartbeatAutomation({ threadId, name, prompt, rrule, status })
+        setJson(res, 200, { data: automation })
+        return
+      }
+
+      if (req.method === 'DELETE' && url.pathname === '/codex-api/thread-automation') {
+        const threadId = url.searchParams.get('threadId')?.trim() ?? ''
+        if (!threadId) {
+          setJson(res, 400, { error: 'Missing threadId' })
+          return
+        }
+        const removed = await deleteThreadHeartbeatAutomation(threadId)
+        setJson(res, 200, { data: { removed } })
         return
       }
 

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -76,6 +76,21 @@ export type UiThread = {
 
 export type UiPendingRequestState = 'approval' | 'response'
 
+export type UiThreadAutomationStatus = 'ACTIVE' | 'PAUSED'
+
+export type UiThreadAutomation = {
+  id: string
+  kind: 'heartbeat' | 'cron'
+  name: string
+  prompt: string
+  rrule: string
+  status: UiThreadAutomationStatus
+  targetThreadId: string | null
+  createdAtMs: number | null
+  updatedAtMs: number | null
+  nextRunAtMs: number | null
+}
+
 export type CommandExecutionData = {
   command: string
   cwd: string | null
@@ -201,6 +216,8 @@ export type UiMessage = {
   plan?: UiPlanData
   turnId?: string
   turnIndex?: number
+  isAutomationRun?: boolean
+  automationDisplayName?: string | null
 }
 
 export type UiServerRequest = {

--- a/tests.md
+++ b/tests.md
@@ -19,6 +19,30 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - <cleanup action, if any>
 
+### Feature: Thread heartbeat automations
+
+#### Prerequisites
+- App is running from this repository.
+- At least one local thread exists in the sidebar.
+- Local Codex home is writable (`$CODEX_HOME` or `~/.codex`).
+
+#### Steps
+1. Open the sidebar thread menu for a thread without an attached automation.
+2. Confirm the menu shows `Add automation…`.
+3. Click `Add automation…`.
+4. Fill name, prompt, RRULE schedule, and set status to `Paused`.
+5. Save the automation and reopen the same thread menu.
+6. Confirm the menu now shows `Edit automation…` and the thread row shows an automation chip.
+7. Open `Edit automation…`, confirm the saved values are prefilled, then remove the automation.
+
+#### Expected Results
+- Thread-scoped heartbeat automations are created under the Codex automations store and attached by `target_thread_id`.
+- The automation editor is hosted from the thread menu and uses Codex.app wording.
+- Removing the automation removes the thread row automation chip and returns the menu to `Add automation…`.
+
+#### Rollback/Cleanup
+- Remove any test automation from the thread automation dialog or delete its folder under `$CODEX_HOME/automations/<automation-id>/`.
+
 ### Feature: Telegram bot token stored in dedicated global file
 
 #### Prerequisites


### PR DESCRIPTION
## Summary
- add thread-scoped heartbeat automation CRUD backed by `$CODEX_HOME/automations/<id>/automation.toml`
- add sidebar thread automation modal and automation chips
- normalize heartbeat run envelope user messages as automation/system activity
- keep hook functionality out of this branch

## Verification
- `pnpm run build`
- Headless Playwright: thread automation add/edit/remove flow, screenshot `output/playwright/automation-sidebar-thread-menu.png`

## Notes
- Real scheduled heartbeat execution loop was not tested outside the local TOML CRUD/UI surface.
