### PR TITLE
Preserve queued-message mode per item

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3805,12 +3805,14 @@ export function useDesktopState() {
     mode: 'steer' | 'queue' = 'steer',
     fileAttachments: FileAttachment[] = [],
     queueInsertIndex?: number,
+    collaborationModeOverride?: CollaborationModeKind,
   ): Promise<void> {
     if (isUpdatingSpeedMode.value) return
 
     const threadId = selectedThreadId.value
     const nextText = text.trim()
     if (!threadId || (!nextText && imageUrls.length === 0 && fileAttachments.length === 0)) return
+    const collaborationMode = collaborationModeOverride ?? selectedCollaborationMode.value
 
     if (await maybeReplyToPendingUserInputRequest(threadId, nextText, imageUrls, skills, fileAttachments)) {
       return
@@ -3831,7 +3833,7 @@ export function useDesktopState() {
         imageUrls,
         skills,
         fileAttachments,
-        collaborationMode: selectedCollaborationMode.value,
+        collaborationMode,
       })
       queuedMessagesByThreadId.value = {
         ...queuedMessagesByThreadId.value,
@@ -3842,7 +3844,14 @@ export function useDesktopState() {
 
     if (isInProgress) {
       shouldAutoScrollOnNextAgentEvent = true
-      void startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments).catch((unknownError) => {
+      void startTurnForThread(
+        threadId,
+        nextText,
+        imageUrls,
+        skills,
+        fileAttachments,
+        collaborationMode,
+      ).catch((unknownError) => {
         const errorMessage = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
         setTurnErrorForThread(threadId, errorMessage)
         error.value = errorMessage
@@ -3860,7 +3869,7 @@ export function useDesktopState() {
         details: buildPendingTurnDetails(
           readModelIdForThread(threadId),
           selectedReasoningEffort.value,
-          selectedCollaborationMode.value,
+          collaborationMode,
         ),
       },
     )
@@ -3868,7 +3877,14 @@ export function useDesktopState() {
     setThreadInProgress(threadId, true)
 
     try {
-      await startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments)
+      await startTurnForThread(
+        threadId,
+        nextText,
+        imageUrls,
+        skills,
+        fileAttachments,
+        collaborationMode,
+      )
     } catch (unknownError) {
       shouldAutoScrollOnNextAgentEvent = false
       setThreadInProgress(threadId, false)
@@ -3976,9 +3992,10 @@ export function useDesktopState() {
     imageUrls: string[] = [],
     skills: Array<{ name: string; path: string }> = [],
     fileAttachments: FileAttachment[] = [],
+    collaborationModeOverride?: CollaborationModeKind,
   ): Promise<void> {
     const reasoningEffort = selectedReasoningEffort.value
-    const collaborationMode = selectedCollaborationMode.value
+    const collaborationMode = collaborationModeOverride ?? selectedCollaborationMode.value
     const normalizedText = nextText.trim()
     const normalizedImageUrls = [...imageUrls]
     if (
@@ -4101,8 +4118,14 @@ export function useDesktopState() {
     setTurnErrorForThread(threadId, null)
     setThreadInProgress(threadId, true)
     try {
-      setSelectedCollaborationMode(next.collaborationMode)
-      await startTurnForThread(threadId, next.text, next.imageUrls, next.skills, next.fileAttachments)
+      await startTurnForThread(
+        threadId,
+        next.text,
+        next.imageUrls,
+        next.skills,
+        next.fileAttachments,
+        next.collaborationMode,
+      )
     } catch {
       setThreadInProgress(threadId, false)
       setTurnActivityForThread(threadId, null)
@@ -4597,8 +4620,15 @@ export function useDesktopState() {
     const msg = queue.find((m) => m.id === messageId)
     if (!msg) return
     removeQueuedMessage(messageId)
-    setSelectedCollaborationMode(msg.collaborationMode)
-    void sendMessageToSelectedThread(msg.text, msg.imageUrls, msg.skills, 'steer', msg.fileAttachments)
+    void sendMessageToSelectedThread(
+      msg.text,
+      msg.imageUrls,
+      msg.skills,
+      'steer',
+      msg.fileAttachments,
+      undefined,
+      msg.collaborationMode,
+    )
   }
 
   function primeSelectedThread(threadId: string): void {

--- a/tests.md
+++ b/tests.md
@@ -1508,6 +1508,32 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Stop running dev servers and unset temporary env overrides.
 
+### Feature: Queued messages keep mode at queue time without changing current composer mode
+
+#### Prerequisites
+- Start the app from this repository (`pnpm run dev`).
+- Open any existing thread.
+- Ensure Plan mode toggle is visible in the composer attach menu.
+
+#### Steps
+1. Enable Plan mode in the composer.
+2. Send a prompt that keeps the turn running long enough to queue follow-ups.
+3. While the turn is in progress, queue one message (`A`) with Plan mode still enabled.
+4. Toggle composer to Default mode.
+5. Queue a second message (`B`).
+6. Wait for the active turn to complete and let queued messages run automatically.
+7. Observe that `A` executes with Plan behavior and `B` executes with Default behavior.
+8. Repeat with the queued row `Steer` button and verify the steered queued message uses its stored mode.
+9. Confirm the composer’s current Plan/default toggle is not auto-flipped by queue execution.
+
+#### Expected Results
+- Queue processing uses each queued message’s stored collaboration mode (per-message freeze).
+- Mixed queues are supported (`A` Plan, `B` Default) when modes differ at queue time.
+- Processing queued messages does not mutate the user’s current composer mode selection.
+
+#### Rollback/Cleanup
+- No cleanup required.
+
 ### Feature: Approval request uses legacy in-conversation request card only
 
 #### Prerequisites


### PR DESCRIPTION
## Summary
- preserve collaboration mode per queued message at enqueue time
- execute queued and steered queued messages using their stored mode
- avoid mutating current composer mode while draining queue
- add manual test coverage in tests.md for mixed-mode queue behavior

## Validation
- pnpm run build