### PR TITLE
[codex] Add integrated thread terminal

### DIFF
--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -78,6 +78,85 @@ if idx >= 0:
 3. Trace the component to find **hooks/composables**, **API calls**, and **event handlers**.
 4. Check the **main process** bundle for any server-side proxying or Electron IPC handling.
 
+## Mandatory CDP Frontend Inspection
+
+For every feature UI or user-visible fix, inspect the live Codex.app frontend over Chrome DevTools Protocol before implementing. Bundle search is still useful, but it is not enough by itself when a visual/interaction surface exists.
+
+### Required CDP Evidence
+
+- Connect to Codex.app over CDP.
+- Navigate or interact until the relevant feature UI, closest equivalent UI, or broken/fixed state is visible.
+- Capture a screenshot under `output/playwright/` with a task-specific filename.
+- Record in the final response:
+  - CDP endpoint/port
+  - Codex.app target URL/title
+  - screenshot absolute path
+  - what was visually confirmed
+
+If the exact UI cannot be reached, capture the closest relevant Codex.app surface and state the gap.
+
+## Mandatory Comparison and Fix Iteration
+
+For every feature UI or user-visible fix, compare Codex.app against the web UI **before and after implementation**.
+
+Required artifacts:
+
+- `codex-reference`: Codex.app CDP screenshot of the target feature UI or closest equivalent.
+- `web-before`: current web UI screenshot before code changes, showing the existing gap or missing behavior.
+- `web-after`: web UI screenshot after implementation, showing the proposed parity result.
+
+Required comparison notes:
+
+- Before coding, write a short parity gap list from `codex-reference` vs `web-before`.
+- After coding, compare `web-after` against `codex-reference`.
+- Classify every notable mismatch as:
+  - `fixed`: matched or acceptably aligned
+  - `intentional deviation`: documented reason
+  - `needs follow-up`: not fixed in this task
+- If `web-after` reveals a fixable mismatch in layout, copy, visibility, interaction, or state handling, do another implementation iteration and capture a new `web-after` screenshot.
+- Do not report completion until the iteration has either resolved the mismatch or documented why it remains.
+
+Use task-specific screenshot names under `output/playwright/`, for example:
+
+- `output/playwright/<task>-codex-reference.png`
+- `output/playwright/<task>-web-before.png`
+- `output/playwright/<task>-web-after.png`
+
+### Reliable CDP Launch Pattern
+
+If Codex.app is already running without CDP, `open -a "Codex" --args --remote-debugging-port=3434` usually does **not** enable CDP because Electron reuses the existing app instance. Restart Codex.app with the port enabled.
+
+```bash
+pkill -TERM -f "/Applications/Codex.app" 2>/dev/null || true
+sleep 2
+if pgrep -f "/Applications/Codex.app" >/dev/null 2>&1; then
+  pkill -KILL -f "/Applications/Codex.app" 2>/dev/null || true
+  sleep 1
+fi
+
+CDP_PORT=3434
+while lsof -i :"$CDP_PORT" >/dev/null 2>&1; do
+  CDP_PORT=$((CDP_PORT + 1))
+done
+
+nohup "/Applications/Codex.app/Contents/MacOS/Codex" \
+  --remote-debugging-port="$CDP_PORT" \
+  >/tmp/codex-cdp.log 2>&1 &
+
+until curl -fsS "http://127.0.0.1:$CDP_PORT/json/list" >/tmp/codex-cdp-list.json; do
+  sleep 1
+done
+```
+
+Pick the page target from `/json/list` where `type == "page"` and `url` starts with `app://-/index.html`. For Playwright screenshots, prefer `chromium.connectOverCDP("http://127.0.0.1:$CDP_PORT")`, select that page, wait briefly for React/app-server hydration, and save the screenshot.
+
+Important caveats:
+
+- Use `nohup` or a long-lived shell; short one-shot launches can drop the CDP listener when the shell exits.
+- `browser.close()` may close or drop the CDP endpoint. Use `browser.disconnect()` when the Codex.app session should remain open.
+- Existing helper processes can keep stale non-CDP state alive; killing all `/Applications/Codex.app` processes is more reliable than only `pkill -x Codex`.
+- CDP inspection can expose local thread titles and workspace names. Avoid pasting sensitive screenshot contents into public artifacts.
+
 ### Architecture Notes
 
 - **Renderer → Main Process**: The renderer uses a `Uu` HTTP client class that sends `fetch-request` IPC messages to the main process. The main process class `tle` handles these, adds auth tokens, and uses `electron.net.fetch` to make actual HTTP calls.
@@ -95,6 +174,8 @@ if idx >= 0:
 - Locate the implementation in `app.asar` (extract and search built assets as needed).
 - Find relevant strings/keys/functions/components for the feature (status labels, event names, item types, summaries, collapse/expand behavior, etc.).
 - Capture the closest equivalent pattern if exact parity is not present.
+- Connect to the live Codex.app frontend over CDP and capture a screenshot of the target UI or closest equivalent before coding.
+- Capture the current web UI before screenshot and list concrete gaps versus Codex.app.
 
 3. Build a parity checklist from Codex.app:
 - Data model shape (fields used by UI).
@@ -113,12 +194,16 @@ if idx >= 0:
 - Confirm each checklist item.
 - Run local build/tests.
 - Re-check UI behavior against Codex.app reference.
+- Compare the implemented web UI screenshot against the Codex.app CDP reference screenshot.
+- Iterate on fixable mismatches, then recapture the web UI after screenshot.
 
 ## Response Requirements (When delivering feature changes)
 
 For feature tasks, include:
 
 - `Codex.app analysis`: what was inspected (files/areas/patterns).
+- `Codex.app CDP evidence`: target URL/title, screenshot path, and visual behavior confirmed.
+- `Before/after comparison`: screenshot paths, gap list, and fix iteration result.
 - `Parity result`: matched items and any explicit deviations.
 - `Fallback note` only if Codex.app could not be inspected or had no equivalent.
 
@@ -139,7 +224,9 @@ If Codex.app cannot be inspected (missing app, extraction/search failure) or has
 ## Completion Verification Requirement
 
 - After completing a task that changes behavior or UI, always run a Playwright verification in **headless** mode.
-- Always capture a screenshot of the changed result and display that screenshot in chat when reporting completion.
+- Always capture a screenshot of the changed web result and display that screenshot in chat when reporting completion.
+- Also keep the Codex.app CDP reference screenshot path in the completion report for user-visible feature/fix work.
+- Include web-before and web-after screenshot paths, plus a short comparison result.
 
 ## Self-Improvement Protocol
 

--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -619,3 +619,20 @@ After each feature implementation session that uses this skill:
   - `<instructions>`
 - Local automation storage uses `$CODEX_HOME/automations/<id>/automation.toml`; heartbeat records include `kind = "heartbeat"` and `target_thread_id`.
 
+## Findings: Integrated Terminal (2026-04-22)
+
+- Codex.app `26.417.41555` ships `node-pty@1.1.0` in `/tmp/codex-app-extracted/package.json`.
+- Renderer bundle terminal UI strings:
+  - `threadPage.toggleTerminal` -> `Toggle terminal`
+  - `terminal.bottomPanel.new` -> `New terminal`
+  - `terminal.bottomPanel.close` -> `Close`
+  - `codex.command.toggleTerminal` -> `Toggle terminal`
+- Shortcut mapping in packaged build includes `toggleTerminal: CmdOrCtrl+J`.
+- Main process terminal manager in `/tmp/codex-app-extracted/.vite/build/main-CUDSf52Z.js`:
+  - creates local terminal sessions with `node-pty.spawn`
+  - maps sessions by window/conversation id
+  - keeps a rolling terminal buffer capped at `16 * 1024` bytes
+  - uses `TERM=xterm-256color`
+  - exposes a conversation snapshot shape `{ cwd, shell, buffer, truncated }`
+  - emits renderer messages including `terminal-data`, `terminal-init-log`, `terminal-attached`, `terminal-exit`, and `terminal-error`
+- Web parity implementation should use `/codex-api/ws` and HTTP endpoints instead of Electron IPC, but preserve the same event names and snapshot shape where practical.

--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -124,7 +124,29 @@ Use task-specific screenshot names under `output/playwright/`, for example:
 
 ### Reliable CDP Launch Pattern
 
-If Codex.app is already running without CDP, `open -a "Codex" --args --remote-debugging-port=3434` usually does **not** enable CDP because Electron reuses the existing app instance. Restart Codex.app with the port enabled.
+Prefer running a separate Codex.app debug instance so the user's normal Codex session is not interrupted and the CDP target can stay alive after tests.
+
+Use a fresh app instance with its own profile directory:
+
+```bash
+CDP_PORT=3434
+while lsof -i :"$CDP_PORT" >/dev/null 2>&1; do
+  CDP_PORT=$((CDP_PORT + 1))
+done
+
+CDP_PROFILE_DIR="/tmp/codex-cdp-$CDP_PORT"
+mkdir -p "$CDP_PROFILE_DIR"
+
+open -na "Codex" --args \
+  --remote-debugging-port="$CDP_PORT" \
+  --user-data-dir="$CDP_PROFILE_DIR"
+
+until curl -fsS "http://127.0.0.1:$CDP_PORT/json/list" >/tmp/codex-cdp-list.json; do
+  sleep 1
+done
+```
+
+Fallback only when a separate instance cannot be used: restart all Codex.app processes and launch the binary with `nohup`.
 
 ```bash
 pkill -TERM -f "/Applications/Codex.app" 2>/dev/null || true
@@ -134,26 +156,20 @@ if pgrep -f "/Applications/Codex.app" >/dev/null 2>&1; then
   sleep 1
 fi
 
-CDP_PORT=3434
-while lsof -i :"$CDP_PORT" >/dev/null 2>&1; do
-  CDP_PORT=$((CDP_PORT + 1))
-done
-
 nohup "/Applications/Codex.app/Contents/MacOS/Codex" \
   --remote-debugging-port="$CDP_PORT" \
   >/tmp/codex-cdp.log 2>&1 &
-
-until curl -fsS "http://127.0.0.1:$CDP_PORT/json/list" >/tmp/codex-cdp-list.json; do
-  sleep 1
-done
 ```
 
 Pick the page target from `/json/list` where `type == "page"` and `url` starts with `app://-/index.html`. For Playwright screenshots, prefer `chromium.connectOverCDP("http://127.0.0.1:$CDP_PORT")`, select that page, wait briefly for React/app-server hydration, and save the screenshot.
 
 Important caveats:
 
-- Use `nohup` or a long-lived shell; short one-shot launches can drop the CDP listener when the shell exits.
-- `browser.close()` may close or drop the CDP endpoint. Use `browser.disconnect()` when the Codex.app session should remain open.
+- `open -na "Codex"` is required for a true separate instance; `open -a "Codex"` reuses an existing app process and often does not enable CDP flags.
+- Always pass an isolated `--user-data-dir` for the debug instance to avoid profile lock contention and cross-session side effects.
+- If launched via raw binary, use `nohup` or a long-lived shell; short one-shot launches can drop the CDP listener when the shell exits.
+- Do not call `browser.close()` when the Codex.app session should remain open.
+- In Playwright builds where `browser.disconnect()` is unavailable for CDP sessions, connect, inspect/capture, and exit the test process without `close()`; this preserves the running Codex.app instance.
 - Existing helper processes can keep stale non-CDP state alive; killing all `/Applications/Codex.app` processes is more reliable than only `pkill -x Codex`.
 - CDP inspection can expose local thread titles and workspace names. Avoid pasting sensitive screenshot contents into public artifacts.
 

--- a/package.json
+++ b/package.json
@@ -46,10 +46,13 @@
     "profile:thread": "PROFILE_ROUTE='#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c' node scripts/profile-browser-runtime.cjs"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "commander": "^13.1.0",
     "express": "^5.1.0",
     "firebase": "^12.2.1",
     "highlight.js": "^11.11.1",
+    "node-pty": "^1.1.0",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -451,6 +451,18 @@
             />
           </template>
           <template #actions>
+            <button
+              v-if="route.name === 'thread' && selectedThreadId"
+              class="content-header-terminal-toggle"
+              type="button"
+              :aria-pressed="selectedThreadTerminalOpen"
+              :title="`Toggle terminal (${terminalShortcutLabel})`"
+              aria-label="Toggle terminal"
+              @click="toggleSelectedThreadTerminal"
+            >
+              <IconTablerTerminal class="content-header-terminal-toggle-icon" />
+              <span class="content-header-terminal-shortcut">{{ terminalShortcutLabel }}</span>
+            </button>
             <ComposerDropdown
               v-if="route.name === 'thread' && selectedThreadId"
               class="content-header-branch-dropdown"
@@ -769,6 +781,13 @@
                     @update:selected-reasoning-effort="onSelectReasoningEffort"
                     @update:selected-speed-mode="onSelectSpeedMode"
                     @interrupt="onInterruptTurn" />
+                  <ThreadTerminalPanel
+                    v-if="selectedThreadTerminalOpen && selectedThreadId && composerCwd"
+                    class="content-thread-terminal-panel"
+                    :thread-id="selectedThreadId"
+                    :cwd="composerCwd"
+                    @hide="setThreadTerminalOpen(selectedThreadId, false)"
+                  />
                 </div>
               </template>
             </div>
@@ -794,6 +813,7 @@ import ComposerRuntimeDropdown from './components/content/ComposerRuntimeDropdow
 import SidebarThreadControls from './components/sidebar/SidebarThreadControls.vue'
 import IconTablerSearch from './components/icons/IconTablerSearch.vue'
 import IconTablerSettings from './components/icons/IconTablerSettings.vue'
+import IconTablerTerminal from './components/icons/IconTablerTerminal.vue'
 import IconTablerX from './components/icons/IconTablerX.vue'
 import { useDesktopState } from './composables/useDesktopState'
 import { useMobile } from './composables/useMobile'
@@ -825,6 +845,7 @@ import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider
 import { getPathLeafName, getPathParent, normalizePathForUi } from './pathUtils.js'
 
 const ThreadConversation = defineAsyncComponent(() => import('./components/content/ThreadConversation.vue'))
+const ThreadTerminalPanel = defineAsyncComponent(() => import('./components/content/ThreadTerminalPanel.vue'))
 const ReviewPane = defineAsyncComponent(() => import('./components/content/ReviewPane.vue'))
 const SkillsHub = defineAsyncComponent(() => import('./components/content/SkillsHub.vue'))
 
@@ -979,6 +1000,7 @@ const {
   selectedThread,
   selectedThreadTokenUsage,
   selectedThreadScrollState,
+  selectedThreadTerminalOpen,
   selectedThreadServerRequests,
   selectedLiveOverlay,
   codexQuota,
@@ -1003,6 +1025,8 @@ const {
   selectThread,
   ensureThreadMessagesLoaded,
   setThreadScrollState,
+  setThreadTerminalOpen,
+  toggleSelectedThreadTerminal,
   archiveThreadById,
   forkThreadById,
   renameThreadById,
@@ -1388,6 +1412,12 @@ const githubTipsScopeOptions = computed<Array<{ value: GithubTipsScope; label: s
   { value: 'trending-monthly', label: 'Trending monthly' },
 ])
 const chatWidthLabel = computed(() => CHAT_WIDTH_PRESETS[chatWidth.value].label)
+const terminalShortcutLabel = computed(() => {
+  if (typeof navigator !== 'undefined' && /mac|iphone|ipad|ipod/i.test(navigator.platform)) {
+    return '⌘J'
+  }
+  return 'Ctrl+J'
+})
 const contentStyle = computed(() => {
   const preset = CHAT_WIDTH_PRESETS[chatWidth.value]
   return {
@@ -1958,9 +1988,16 @@ function onWindowKeyDown(event: KeyboardEvent): void {
   }
   if (!event.ctrlKey && !event.metaKey) return
   if (event.shiftKey || event.altKey) return
-  if (event.key.toLowerCase() !== 'b') return
-  event.preventDefault()
-  setSidebarCollapsed(!isSidebarCollapsed.value)
+  const key = event.key.toLowerCase()
+  if (key === 'b') {
+    event.preventDefault()
+    setSidebarCollapsed(!isSidebarCollapsed.value)
+    return
+  }
+  if (key === 'j' && route.name === 'thread' && selectedThreadId.value) {
+    event.preventDefault()
+    toggleSelectedThreadTerminal()
+  }
 }
 
 function onDocumentPointerDown(event: PointerEvent): void {
@@ -3365,7 +3402,27 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .composer-with-queue {
-  @apply w-full shrink-0 px-2 sm:px-6;
+  @apply w-full shrink-0 px-2 sm:px-6 flex flex-col gap-2;
+}
+
+.content-thread-terminal-panel {
+  @apply w-full;
+}
+
+.content-header-terminal-toggle {
+  @apply flex h-8 items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 text-xs text-zinc-700 transition hover:bg-zinc-50;
+}
+
+.content-header-terminal-toggle[aria-pressed='true'] {
+  @apply border-zinc-300 bg-zinc-100 text-zinc-950;
+}
+
+.content-header-terminal-toggle-icon {
+  @apply h-4 w-4;
+}
+
+.content-header-terminal-shortcut {
+  @apply hidden text-[11px] text-zinc-500 sm:inline;
 }
 
 .content-header-branch-dropdown :deep(.composer-dropdown-trigger) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -757,6 +757,13 @@
                     :has-queue-above="selectedThreadQueuedMessages.length > 0"
                     @respond-server-request="onRespondServerRequest"
                   />
+                  <ThreadTerminalPanel
+                    v-if="selectedThreadTerminalOpen && selectedThreadId && composerCwd"
+                    class="content-thread-terminal-panel"
+                    :thread-id="selectedThreadId"
+                    :cwd="composerCwd"
+                    @hide="setThreadTerminalOpen(selectedThreadId, false)"
+                  />
                   <ThreadComposer v-else ref="threadComposerRef" :active-thread-id="composerThreadContextId"
                     :cwd="composerCwd"
                     :collaboration-modes="availableCollaborationModes"
@@ -781,13 +788,6 @@
                     @update:selected-reasoning-effort="onSelectReasoningEffort"
                     @update:selected-speed-mode="onSelectSpeedMode"
                     @interrupt="onInterruptTurn" />
-                  <ThreadTerminalPanel
-                    v-if="selectedThreadTerminalOpen && selectedThreadId && composerCwd"
-                    class="content-thread-terminal-panel"
-                    :thread-id="selectedThreadId"
-                    :cwd="composerCwd"
-                    @hide="setThreadTerminalOpen(selectedThreadId, false)"
-                  />
                 </div>
               </template>
             </div>

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -164,6 +164,24 @@ export type LocalDirectoryListing = {
   entries: LocalDirectoryEntry[]
 }
 
+export type ThreadTerminalSession = {
+  id: string
+  threadId: string
+  cwd: string
+  shell: string
+  buffer: string
+  truncated: boolean
+}
+
+export type ThreadTerminalAttachInput = {
+  threadId: string
+  cwd: string
+  sessionId?: string
+  cols?: number
+  rows?: number
+  newSession?: boolean
+}
+
 function normalizeGithubProjectDescription(fullName: string, rawDescription: string): string {
   const description = rawDescription.trim()
   if (!description) return ''
@@ -875,6 +893,73 @@ export function subscribeCodexNotifications(onNotification: (value: RpcNotificat
 }
 
 export type { RpcNotification }
+
+function normalizeThreadTerminalSession(value: unknown): ThreadTerminalSession | null {
+  const record = asRecord(value)
+  if (!record) return null
+  const id = readString(record.id)
+  const threadId = readString(record.threadId)
+  const cwd = readString(record.cwd)
+  const shell = readString(record.shell)
+  if (!id || !threadId || !cwd || !shell) return null
+  return {
+    id,
+    threadId,
+    cwd,
+    shell,
+    buffer: typeof record.buffer === 'string' ? record.buffer : '',
+    truncated: readBoolean(record.truncated) ?? false,
+  }
+}
+
+async function fetchTerminalJson(path: string, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(path, init)
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, `Terminal request failed with HTTP ${response.status}`))
+  }
+  return payload
+}
+
+export async function attachThreadTerminal(input: ThreadTerminalAttachInput): Promise<ThreadTerminalSession> {
+  const payload = await fetchTerminalJson('/codex-api/thread-terminal/attach', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const session = normalizeThreadTerminalSession(asRecord(payload)?.session)
+  if (!session) throw new Error('Terminal attach response was malformed')
+  return session
+}
+
+export async function sendThreadTerminalInput(sessionId: string, data: string): Promise<void> {
+  await fetchTerminalJson('/codex-api/thread-terminal/input', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId, data }),
+  })
+}
+
+export async function resizeThreadTerminal(sessionId: string, cols: number, rows: number): Promise<void> {
+  await fetchTerminalJson('/codex-api/thread-terminal/resize', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId, cols, rows }),
+  })
+}
+
+export async function closeThreadTerminal(sessionId: string): Promise<void> {
+  await fetchTerminalJson('/codex-api/thread-terminal/close', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId }),
+  })
+}
+
+export async function getThreadTerminalSnapshot(threadId: string): Promise<ThreadTerminalSession | null> {
+  const payload = await fetchTerminalJson(`/codex-api/thread-terminal-snapshot?threadId=${encodeURIComponent(threadId)}`)
+  return normalizeThreadTerminalSession(asRecord(payload)?.session)
+}
 
 export async function replyToServerRequest(
   id: number,

--- a/src/components/content/ThreadTerminalPanel.vue
+++ b/src/components/content/ThreadTerminalPanel.vue
@@ -1,0 +1,306 @@
+<template>
+  <section class="thread-terminal-panel" :class="{ 'is-error': Boolean(errorMessage) }">
+    <header class="thread-terminal-header">
+      <div class="thread-terminal-tabs">
+        <button class="thread-terminal-tab" type="button" :title="terminalTitle">
+          <span class="thread-terminal-dot" :data-status="terminalStatus" />
+          <span class="thread-terminal-title">{{ terminalTitle }}</span>
+        </button>
+      </div>
+      <div class="thread-terminal-actions">
+        <button class="thread-terminal-action" type="button" title="New terminal" @click="onNewTerminal">
+          New terminal
+        </button>
+        <button class="thread-terminal-action" type="button" title="Hide terminal" @click="$emit('hide')">
+          Hide
+        </button>
+        <button class="thread-terminal-action" type="button" title="Close" @click="onCloseTerminal">
+          Close
+        </button>
+      </div>
+    </header>
+    <p v-if="errorMessage" class="thread-terminal-error">{{ errorMessage }}</p>
+    <div ref="terminalHostRef" class="thread-terminal-host" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import {
+  attachThreadTerminal,
+  closeThreadTerminal,
+  resizeThreadTerminal,
+  sendThreadTerminalInput,
+  subscribeCodexNotifications,
+  type RpcNotification,
+} from '../../api/codexGateway'
+
+const props = defineProps<{
+  threadId: string
+  cwd: string
+}>()
+
+const emit = defineEmits<{
+  hide: []
+}>()
+
+const terminalHostRef = ref<HTMLElement | null>(null)
+const sessionId = ref('')
+const shellLabel = ref('terminal')
+const errorMessage = ref('')
+const isAttached = ref(false)
+
+let terminal: Terminal | null = null
+let fitAddon: FitAddon | null = null
+let resizeObserver: ResizeObserver | null = null
+let unsubscribeNotifications: (() => void) | null = null
+let resizeFrame = 0
+
+const terminalStatus = computed(() => {
+  if (errorMessage.value) return 'error'
+  return isAttached.value ? 'attached' : 'connecting'
+})
+
+const terminalTitle = computed(() => {
+  if (shellLabel.value && shellLabel.value !== 'terminal') return shellLabel.value
+  return 'Terminal'
+})
+
+onMounted(() => {
+  createTerminal()
+  unsubscribeNotifications = subscribeCodexNotifications(handleNotification)
+  void attachToThread(false)
+})
+
+onBeforeUnmount(() => {
+  if (resizeFrame) {
+    window.cancelAnimationFrame(resizeFrame)
+    resizeFrame = 0
+  }
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  unsubscribeNotifications?.()
+  unsubscribeNotifications = null
+  terminal?.dispose()
+  terminal = null
+  fitAddon = null
+})
+
+watch(
+  () => [props.threadId, props.cwd] as const,
+  () => {
+    void attachToThread(false)
+  },
+)
+
+function createTerminal(): void {
+  if (!terminalHostRef.value) return
+  terminal = new Terminal({
+    cursorBlink: true,
+    fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+    fontSize: 12,
+    lineHeight: 1.25,
+    scrollback: 10000,
+    theme: {
+      background: '#050505',
+      foreground: '#e5e7eb',
+      cursor: '#f4f4f5',
+      selectionBackground: '#475569',
+      black: '#18181b',
+      red: '#f87171',
+      green: '#86efac',
+      yellow: '#fde68a',
+      blue: '#93c5fd',
+      magenta: '#d8b4fe',
+      cyan: '#67e8f9',
+      white: '#f4f4f5',
+    },
+  })
+  fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+  terminal.open(terminalHostRef.value)
+  terminal.onData((data) => {
+    if (!sessionId.value) return
+    void sendThreadTerminalInput(sessionId.value, data).catch((error: unknown) => {
+      errorMessage.value = error instanceof Error ? error.message : 'Terminal input failed'
+    })
+  })
+
+  resizeObserver = new ResizeObserver(() => {
+    scheduleFitAndResize()
+  })
+  resizeObserver.observe(terminalHostRef.value)
+  scheduleFitAndResize()
+}
+
+async function attachToThread(newSession: boolean): Promise<void> {
+  if (!props.threadId || !props.cwd || !terminal) return
+  errorMessage.value = ''
+  isAttached.value = false
+  await nextTick()
+  fitTerminal()
+  try {
+    const session = await attachThreadTerminal({
+      threadId: props.threadId,
+      cwd: props.cwd,
+      sessionId: newSession ? undefined : sessionId.value || undefined,
+      cols: terminal.cols,
+      rows: terminal.rows,
+      newSession,
+    })
+    sessionId.value = session.id
+    shellLabel.value = session.shell || 'terminal'
+    if (newSession) {
+      terminal.clear()
+    }
+    isAttached.value = true
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Terminal attach failed'
+  }
+}
+
+function handleNotification(notification: RpcNotification): void {
+  const params = asRecord(notification.params)
+  const notificationSessionId = readString(params?.sessionId)
+  if (!notificationSessionId || notificationSessionId !== sessionId.value || !terminal) return
+
+  if (notification.method === 'terminal-attached') {
+    shellLabel.value = readString(params?.shell) || shellLabel.value
+    isAttached.value = true
+    return
+  }
+  if (notification.method === 'terminal-init-log') {
+    terminal.clear()
+    terminal.write(readString(params?.log) || '')
+    return
+  }
+  if (notification.method === 'terminal-data') {
+    terminal.write(readString(params?.data) || '')
+    return
+  }
+  if (notification.method === 'terminal-exit') {
+    isAttached.value = false
+    terminal.writeln('')
+    terminal.writeln('[terminal exited]')
+    return
+  }
+  if (notification.method === 'terminal-error') {
+    errorMessage.value = readString(params?.message) || 'Terminal error'
+  }
+}
+
+function onNewTerminal(): void {
+  void attachToThread(true)
+}
+
+function onCloseTerminal(): void {
+  const currentSessionId = sessionId.value
+  sessionId.value = ''
+  isAttached.value = false
+  terminal?.clear()
+  if (currentSessionId) {
+    void closeThreadTerminal(currentSessionId).catch((error: unknown) => {
+      errorMessage.value = error instanceof Error ? error.message : 'Terminal close failed'
+    })
+  }
+  emit('hide')
+}
+
+function scheduleFitAndResize(): void {
+  if (resizeFrame) return
+  resizeFrame = window.requestAnimationFrame(() => {
+    resizeFrame = 0
+    fitTerminal()
+    if (terminal && sessionId.value) {
+      void resizeThreadTerminal(sessionId.value, terminal.cols, terminal.rows).catch(() => {})
+    }
+  })
+}
+
+function fitTerminal(): void {
+  try {
+    fitAddon?.fit()
+  } catch {
+    // xterm-fit can throw before fonts/layout settle; the next resize observer tick retries.
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+</script>
+
+<style scoped>
+@reference "tailwindcss";
+
+.thread-terminal-panel {
+  @apply overflow-hidden rounded-lg border border-zinc-800 bg-black shadow-lg;
+  height: min(34vh, 20rem);
+  min-height: 13rem;
+}
+
+.thread-terminal-header {
+  @apply flex h-9 items-center justify-between border-b border-zinc-800 bg-zinc-950 px-2;
+}
+
+.thread-terminal-tabs {
+  @apply min-w-0 flex-1;
+}
+
+.thread-terminal-tab {
+  @apply flex h-7 min-w-0 max-w-full items-center gap-2 rounded-md border border-zinc-800 bg-zinc-900 px-2 text-xs text-zinc-200;
+}
+
+.thread-terminal-dot {
+  @apply h-2 w-2 shrink-0 rounded-full bg-zinc-500;
+}
+
+.thread-terminal-dot[data-status='attached'] {
+  @apply bg-emerald-400;
+}
+
+.thread-terminal-dot[data-status='error'] {
+  @apply bg-rose-400;
+}
+
+.thread-terminal-title {
+  @apply truncate;
+}
+
+.thread-terminal-actions {
+  @apply flex shrink-0 items-center gap-1;
+}
+
+.thread-terminal-action {
+  @apply rounded-md border border-transparent px-2 py-1 text-xs text-zinc-300 transition hover:border-zinc-700 hover:bg-zinc-900 hover:text-white;
+}
+
+.thread-terminal-error {
+  @apply m-0 border-b border-rose-900 bg-rose-950 px-3 py-1.5 text-xs text-rose-200;
+}
+
+.thread-terminal-host {
+  @apply h-[calc(100%-2.25rem)] min-h-0 w-full overflow-hidden px-2 py-2;
+}
+
+.thread-terminal-panel.is-error .thread-terminal-host {
+  @apply h-[calc(100%-4.625rem)];
+}
+
+.thread-terminal-host :deep(.xterm) {
+  @apply h-full;
+}
+
+.thread-terminal-host :deep(.xterm-viewport) {
+  @apply bg-black;
+}
+</style>

--- a/src/components/content/ThreadTerminalPanel.vue
+++ b/src/components/content/ThreadTerminalPanel.vue
@@ -303,4 +303,23 @@ function readString(value: unknown): string {
 .thread-terminal-host :deep(.xterm-viewport) {
   @apply bg-black;
 }
+
+@media (max-width: 767px) {
+  .thread-terminal-panel {
+    height: min(28vh, 14rem);
+    min-height: 9rem;
+  }
+
+  .thread-terminal-header {
+    @apply px-1.5;
+  }
+
+  .thread-terminal-action {
+    @apply px-1.5 text-[11px];
+  }
+
+  .thread-terminal-host {
+    @apply px-1.5 py-1.5;
+  }
+}
 </style>

--- a/src/components/icons/IconTablerTerminal.vue
+++ b/src/components/icons/IconTablerTerminal.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M5 7l5 5-5 5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 17h7"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -64,6 +64,7 @@ function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
 const READ_STATE_STORAGE_KEY = 'codex-web-local.thread-read-state.v1'
 const SCROLL_STATE_STORAGE_KEY = 'codex-web-local.thread-scroll-state.v1'
 const THREAD_TOKEN_USAGE_STORAGE_KEY = 'codex-web-local.thread-token-usage.v1'
+const THREAD_TERMINAL_OPEN_STORAGE_KEY = 'codex-web-local.thread-terminal-open.v1'
 const SELECTED_THREAD_STORAGE_KEY = 'codex-web-local.selected-thread-id.v1'
 const SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY = 'codex-web-local.selected-model-by-context.v1'
 const LEGACY_SELECTED_MODEL_STORAGE_KEY = 'codex-web-local.selected-model-id.v1'
@@ -412,6 +413,33 @@ function loadThreadTokenUsageMap(): Record<string, UiThreadTokenUsage> {
 function saveThreadTokenUsageMap(state: Record<string, UiThreadTokenUsage>): void {
   if (typeof window === 'undefined') return
   window.localStorage.setItem(THREAD_TOKEN_USAGE_STORAGE_KEY, JSON.stringify(state))
+}
+
+function loadThreadTerminalOpenMap(): Record<string, boolean> {
+  if (typeof window === 'undefined') return {}
+
+  try {
+    const raw = window.localStorage.getItem(THREAD_TERMINAL_OPEN_STORAGE_KEY)
+    if (!raw) return {}
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
+    const normalizedMap: Record<string, boolean> = {}
+    for (const [threadId, isOpen] of Object.entries(parsed as Record<string, unknown>)) {
+      if (threadId && typeof isOpen === 'boolean') {
+        normalizedMap[threadId] = isOpen
+      }
+    }
+    return normalizedMap
+  } catch {
+    return {}
+  }
+}
+
+function saveThreadTerminalOpenMap(state: Record<string, boolean>): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(THREAD_TERMINAL_OPEN_STORAGE_KEY, JSON.stringify(state))
 }
 
 function loadSelectedThreadId(): string {
@@ -1045,6 +1073,7 @@ export function useDesktopState() {
   const pendingTurnRequestByThreadId = ref<Record<string, PendingTurnRequest>>({})
   const codexRateLimit = ref<UiRateLimitSnapshot | null>(null)
   const threadTokenUsageByThreadId = ref<Record<string, UiThreadTokenUsage>>(loadThreadTokenUsageMap())
+  const terminalOpenByThreadId = ref<Record<string, boolean>>(loadThreadTerminalOpenMap())
 
   const threadTitleById = ref<Record<string, string>>({})
 
@@ -1120,6 +1149,10 @@ export function useDesktopState() {
   const selectedThreadScrollState = computed<ThreadScrollState | null>(
     () => scrollStateByThreadId.value[selectedThreadId.value] ?? null,
   )
+  const selectedThreadTerminalOpen = computed(() => {
+    const threadId = selectedThreadId.value
+    return Boolean(threadId && terminalOpenByThreadId.value[threadId] === true)
+  })
   const isSelectedThreadInterruptPending = computed(() => {
     const threadId = selectedThreadId.value
     if (!threadId) return false
@@ -1971,6 +2004,24 @@ export function useDesktopState() {
       [threadId]: normalizedState,
     }
     saveThreadScrollStateMap(scrollStateByThreadId.value)
+  }
+
+  function setThreadTerminalOpen(threadId: string, isOpen: boolean): void {
+    if (!threadId) return
+    const next = { ...terminalOpenByThreadId.value }
+    if (isOpen) {
+      next[threadId] = true
+    } else {
+      delete next[threadId]
+    }
+    terminalOpenByThreadId.value = next
+    saveThreadTerminalOpenMap(next)
+  }
+
+  function toggleSelectedThreadTerminal(): void {
+    const threadId = selectedThreadId.value
+    if (!threadId) return
+    setThreadTerminalOpen(threadId, !selectedThreadTerminalOpen.value)
   }
 
   function setPersistedMessagesForThread(threadId: string, nextMessages: UiMessage[]): void {
@@ -4827,6 +4878,7 @@ export function useDesktopState() {
     selectedThread,
     selectedThreadTokenUsage,
     selectedThreadScrollState,
+    selectedThreadTerminalOpen,
     isSelectedThreadInterruptPending,
     selectedThreadServerRequests,
     selectedLiveOverlay,
@@ -4855,6 +4907,8 @@ export function useDesktopState() {
     loadMessages,
     ensureThreadMessagesLoaded,
     setThreadScrollState,
+    setThreadTerminalOpen,
+    toggleSelectedThreadTerminal,
     archiveThreadById,
     renameThreadById,
     forkThreadById,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -29,6 +29,7 @@ import {
 import { handleOpenRouterProxyRequest } from './openRouterProxy.js'
 import { handleZenProxyRequest } from './zenProxy.js'
 import { handleCustomEndpointProxyRequest } from './customEndpointProxy.js'
+import { ThreadTerminalManager } from './terminalManager.js'
 import { getSpawnInvocation } from '../utils/commandInvocation.js'
 import {
   resolveCodexCommand,
@@ -3076,6 +3077,7 @@ type CodexBridgeMiddleware = ((req: IncomingMessage, res: ServerResponse, next: 
 type SharedBridgeState = {
   version: string
   appServer: AppServerProcess
+  terminalManager: ThreadTerminalManager
   methodCatalog: MethodCatalog
   telegramBridge: TelegramThreadBridge
 }
@@ -3090,16 +3092,19 @@ function getSharedBridgeState(): SharedBridgeState {
 
   const existing = globalScope[SHARED_BRIDGE_KEY]
   if (existing) {
-    if (existing.version === SHARED_BRIDGE_VERSION) {
+    if (existing.version === SHARED_BRIDGE_VERSION && existing.terminalManager) {
       return existing
     }
     existing.appServer.dispose()
+    existing.terminalManager?.dispose()
   }
 
   const appServer = new AppServerProcess()
+  const terminalManager = new ThreadTerminalManager()
   const created: SharedBridgeState = {
     version: SHARED_BRIDGE_VERSION,
     appServer,
+    terminalManager,
     methodCatalog: new MethodCatalog(),
     telegramBridge: new TelegramThreadBridge(appServer, {
       onChatSeen: (chatId) => {
@@ -3188,7 +3193,7 @@ async function buildThreadSearchIndex(appServer: AppServerProcess): Promise<Thre
 }
 
 export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
-  const { appServer, methodCatalog, telegramBridge } = getSharedBridgeState()
+  const { appServer, terminalManager, methodCatalog, telegramBridge } = getSharedBridgeState()
   let threadSearchIndex: ThreadSearchIndex | null = null
   let threadSearchIndexPromise: Promise<ThreadSearchIndex> | null = null
 
@@ -3516,6 +3521,73 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       if (await handleReviewRoutes(req, res, url, { readJsonBody })) {
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/attach') {
+        const body = asRecord(await readJsonBody(req))
+        const threadId = readNonEmptyString(body?.threadId)
+        const cwd = readNonEmptyString(body?.cwd)
+        if (!threadId || !cwd) {
+          setJson(res, 400, { error: 'Missing threadId or cwd' })
+          return
+        }
+        const session = terminalManager.attach({
+          threadId,
+          cwd,
+          sessionId: readNonEmptyString(body?.sessionId) || undefined,
+          cols: typeof body?.cols === 'number' ? body.cols : undefined,
+          rows: typeof body?.rows === 'number' ? body.rows : undefined,
+          newSession: body?.newSession === true,
+        })
+        setJson(res, 200, { session })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/input') {
+        const body = asRecord(await readJsonBody(req))
+        const sessionId = readNonEmptyString(body?.sessionId)
+        const data = typeof body?.data === 'string' ? body.data : ''
+        if (!sessionId) {
+          setJson(res, 400, { error: 'Missing sessionId' })
+          return
+        }
+        terminalManager.write(sessionId, data)
+        setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/resize') {
+        const body = asRecord(await readJsonBody(req))
+        const sessionId = readNonEmptyString(body?.sessionId)
+        if (!sessionId) {
+          setJson(res, 400, { error: 'Missing sessionId' })
+          return
+        }
+        terminalManager.resize(sessionId, body?.cols, body?.rows)
+        setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/close') {
+        const body = asRecord(await readJsonBody(req))
+        const sessionId = readNonEmptyString(body?.sessionId)
+        if (!sessionId) {
+          setJson(res, 400, { error: 'Missing sessionId' })
+          return
+        }
+        terminalManager.close(sessionId)
+        setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-terminal-snapshot') {
+        const threadId = url.searchParams.get('threadId')?.trim() ?? ''
+        if (!threadId) {
+          setJson(res, 400, { error: 'Missing threadId' })
+          return
+        }
+        setJson(res, 200, { session: terminalManager.getSnapshotForThread(threadId) })
         return
       }
 
@@ -4489,17 +4561,28 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
   middleware.dispose = () => {
     threadSearchIndex = null
     telegramBridge.stop()
+    terminalManager.dispose()
     appServer.dispose()
   }
   middleware.subscribeNotifications = (
     listener: (value: { method: string; params: unknown; atIso: string }) => void,
   ) => {
-    return appServer.onNotification((notification: { method: string; params: unknown }) => {
+    const unsubscribeAppServer = appServer.onNotification((notification: { method: string; params: unknown }) => {
       listener({
         ...notification,
         atIso: new Date().toISOString(),
       })
     })
+    const unsubscribeTerminal = terminalManager.subscribe((notification) => {
+      listener({
+        ...notification,
+        atIso: new Date().toISOString(),
+      })
+    })
+    return () => {
+      unsubscribeAppServer()
+      unsubscribeTerminal()
+    }
   }
 
   return middleware

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -1,0 +1,318 @@
+import { chmodSync, existsSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { basename, dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { spawn as spawnPty, type IPty } from 'node-pty'
+
+const TERMINAL_BUFFER_LIMIT = 16 * 1024
+const DEFAULT_COLS = 80
+const DEFAULT_ROWS = 24
+const TERMINAL_NAME = 'xterm-256color'
+const require = createRequire(import.meta.url)
+
+export type TerminalNotification = {
+  method: string
+  params: unknown
+}
+
+export type TerminalSessionSnapshot = {
+  id: string
+  threadId: string
+  cwd: string
+  shell: string
+  buffer: string
+  truncated: boolean
+}
+
+type TerminalSession = {
+  id: string
+  threadId: string
+  cwd: string
+  shell: string
+  pty: IPty
+  buffer: string
+  truncated: boolean
+}
+
+export type TerminalAttachParams = {
+  threadId: string
+  cwd: string
+  sessionId?: string
+  cols?: number
+  rows?: number
+  newSession?: boolean
+}
+
+export class ThreadTerminalManager {
+  private readonly sessions = new Map<string, TerminalSession>()
+  private readonly activeSessionIdByThreadId = new Map<string, string>()
+  private readonly listeners = new Set<(notification: TerminalNotification) => void>()
+
+  subscribe(listener: (notification: TerminalNotification) => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  attach(params: TerminalAttachParams): TerminalSessionSnapshot {
+    const threadId = params.threadId.trim()
+    if (!threadId) {
+      throw new Error('Missing threadId')
+    }
+
+    const requestedSessionId = params.sessionId?.trim() || ''
+    const existingSessionId = params.newSession
+      ? ''
+      : requestedSessionId || this.activeSessionIdByThreadId.get(threadId) || ''
+    const existing = existingSessionId ? this.sessions.get(existingSessionId) : null
+    if (existing) {
+      this.resize(existing.id, params.cols, params.rows)
+      const nextCwd = this.resolveCwd(params.cwd)
+      if (nextCwd !== existing.cwd) {
+        existing.cwd = nextCwd
+        existing.pty.write(`cd ${shellQuote(nextCwd)}\r`)
+      }
+      this.emitInit(existing)
+      this.emitAttached(existing)
+      return this.toSnapshot(existing)
+    }
+
+    if (params.newSession) {
+      const previousSessionId = this.activeSessionIdByThreadId.get(threadId)
+      if (previousSessionId) {
+        this.close(previousSessionId)
+      }
+    }
+
+    const session = this.createSession({
+      threadId,
+      cwd: params.cwd,
+      sessionId: requestedSessionId || randomUUID(),
+      cols: params.cols,
+      rows: params.rows,
+    })
+    this.sessions.set(session.id, session)
+    this.activeSessionIdByThreadId.set(threadId, session.id)
+    this.emitAttached(session)
+    return this.toSnapshot(session)
+  }
+
+  write(sessionId: string, data: string): void {
+    const session = this.requireSession(sessionId)
+    session.pty.write(data)
+  }
+
+  resize(sessionId: string, cols: unknown, rows: unknown): void {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+
+    const nextCols = normalizeDimension(cols, DEFAULT_COLS)
+    const nextRows = normalizeDimension(rows, DEFAULT_ROWS)
+    session.pty.resize(nextCols, nextRows)
+  }
+
+  close(sessionId: string): void {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    this.sessions.delete(session.id)
+    if (this.activeSessionIdByThreadId.get(session.threadId) === session.id) {
+      this.activeSessionIdByThreadId.delete(session.threadId)
+    }
+    session.pty.kill()
+    this.emit({
+      method: 'terminal-exit',
+      params: {
+        sessionId: session.id,
+        threadId: session.threadId,
+        code: null,
+        signal: null,
+      },
+    })
+  }
+
+  getSnapshotForThread(threadId: string): TerminalSessionSnapshot | null {
+    const sessionId = this.activeSessionIdByThreadId.get(threadId.trim())
+    if (!sessionId) return null
+    const session = this.sessions.get(sessionId)
+    return session ? this.toSnapshot(session) : null
+  }
+
+  dispose(): void {
+    for (const sessionId of Array.from(this.sessions.keys())) {
+      this.close(sessionId)
+    }
+    this.listeners.clear()
+  }
+
+  private createSession(params: {
+    threadId: string
+    cwd: string
+    sessionId: string
+    cols?: number
+    rows?: number
+  }): TerminalSession {
+    const cwd = this.resolveCwd(params.cwd)
+    const shell = this.resolveShell()
+    const env: Record<string, string> = {
+      ...process.env,
+      TERM: TERMINAL_NAME,
+    } as Record<string, string>
+    delete env.TERMINFO
+    delete env.TERMINFO_DIRS
+
+    ensureNodePtySpawnHelperExecutable()
+    const pty = spawnPty(shell, [], {
+      name: TERMINAL_NAME,
+      cols: normalizeDimension(params.cols, DEFAULT_COLS),
+      rows: normalizeDimension(params.rows, DEFAULT_ROWS),
+      cwd,
+      env,
+    })
+
+    const session: TerminalSession = {
+      id: params.sessionId,
+      threadId: params.threadId,
+      cwd,
+      shell: basename(shell),
+      pty,
+      buffer: '',
+      truncated: false,
+    }
+
+    pty.onData((data) => {
+      this.appendOutput(session, data)
+    })
+    pty.onExit(({ exitCode, signal }) => {
+      if (this.sessions.get(session.id) === session) {
+        this.sessions.delete(session.id)
+      }
+      if (this.activeSessionIdByThreadId.get(session.threadId) === session.id) {
+        this.activeSessionIdByThreadId.delete(session.threadId)
+      }
+      this.emit({
+        method: 'terminal-exit',
+        params: {
+          sessionId: session.id,
+          threadId: session.threadId,
+          code: exitCode,
+          signal: signal == null ? null : String(signal),
+        },
+      })
+    })
+
+    return session
+  }
+
+  private appendOutput(session: TerminalSession, data: string): void {
+    const next = `${session.buffer}${data}`
+    if (next.length > TERMINAL_BUFFER_LIMIT) {
+      session.buffer = next.slice(-TERMINAL_BUFFER_LIMIT)
+      session.truncated = true
+    } else {
+      session.buffer = next
+    }
+    this.emit({
+      method: 'terminal-data',
+      params: {
+        sessionId: session.id,
+        threadId: session.threadId,
+        data,
+      },
+    })
+  }
+
+  private emitInit(session: TerminalSession): void {
+    if (!session.buffer) return
+    this.emit({
+      method: 'terminal-init-log',
+      params: {
+        sessionId: session.id,
+        threadId: session.threadId,
+        log: session.buffer,
+        truncated: session.truncated,
+      },
+    })
+  }
+
+  private emitAttached(session: TerminalSession): void {
+    this.emit({
+      method: 'terminal-attached',
+      params: {
+        sessionId: session.id,
+        threadId: session.threadId,
+        cwd: session.cwd,
+        shell: session.shell,
+      },
+    })
+  }
+
+  private emit(notification: TerminalNotification): void {
+    for (const listener of this.listeners) {
+      listener(notification)
+    }
+  }
+
+  private requireSession(sessionId: string): TerminalSession {
+    const session = this.sessions.get(sessionId.trim())
+    if (!session) {
+      throw new Error('Terminal session missing')
+    }
+    return session
+  }
+
+  private resolveShell(): string {
+    if (process.platform === 'win32') {
+      return process.env.COMSPEC || 'cmd.exe'
+    }
+    return process.env.SHELL || '/bin/zsh'
+  }
+
+  private resolveCwd(value: string): string {
+    const cwd = value.trim()
+    if (cwd && existsSync(cwd)) {
+      return cwd
+    }
+    const home = homedir()
+    if (home && existsSync(home)) {
+      return home
+    }
+    return process.cwd()
+  }
+
+  private toSnapshot(session: TerminalSession): TerminalSessionSnapshot {
+    return {
+      id: session.id,
+      threadId: session.threadId,
+      cwd: session.cwd,
+      shell: session.shell,
+      buffer: session.buffer,
+      truncated: session.truncated,
+    }
+  }
+}
+
+function normalizeDimension(value: unknown, fallback: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(1, Math.min(500, Math.trunc(parsed)))
+}
+
+function ensureNodePtySpawnHelperExecutable(): void {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return
+  try {
+    const nodePtyEntry = require.resolve('node-pty')
+    const packageRoot = join(dirname(nodePtyEntry), '..')
+    const helperPath = join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
+    if (existsSync(helperPath)) {
+      chmodSync(helperPath, 0o755)
+    }
+  } catch {
+    // If node-pty changes layout, let node-pty surface its own spawn error.
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -159,6 +159,7 @@ export class ThreadTerminalManager {
       ...process.env,
       TERM: TERMINAL_NAME,
     } as Record<string, string>
+    normalizeLocaleEnv(env)
     delete env.TERMINFO
     delete env.TERMINFO_DIRS
 
@@ -311,6 +312,13 @@ function ensureNodePtySpawnHelperExecutable(): void {
   } catch {
     // If node-pty changes layout, let node-pty surface its own spawn error.
   }
+}
+
+function normalizeLocaleEnv(env: Record<string, string>): void {
+  const locale = process.platform === 'darwin' ? 'en_US.UTF-8' : 'C.UTF-8'
+  env.LANG = locale
+  env.LC_ALL = locale
+  env.LC_CTYPE = locale
 }
 
 function shellQuote(value: string): string {

--- a/tests.md
+++ b/tests.md
@@ -2871,3 +2871,43 @@ Codex app-server generated image items render as assistant image previews.
 
 #### Rollback/Cleanup
 - Delete any temporary generated image files if they were created only for this test
+
+---
+
+### Codex.app-style integrated terminal
+
+#### Feature/Change Name
+Each local/worktree thread has an integrated xterm terminal that can be toggled from the header, uses the thread working directory, preserves recent output, and exposes a terminal snapshot endpoint.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. An existing local or worktree thread with a valid working directory
+3. Browser focused on that thread
+
+#### Steps
+1. Click the terminal button in the top-right thread header
+2. Confirm the bottom terminal drawer opens
+3. Press `Cmd+J` on macOS or `Ctrl+J` on other platforms
+4. Confirm the terminal drawer toggles closed/open
+5. Run `pwd`
+6. Confirm the printed path matches the thread/project working directory
+7. Run `echo terminal-ok`
+8. Confirm `terminal-ok` appears in the xterm output
+9. Fetch `/codex-api/thread-terminal-snapshot?threadId=<thread-id>`
+10. Confirm the JSON `session.buffer` contains `terminal-ok`
+11. Refresh the page and reopen the same thread
+12. Toggle the terminal open again
+13. Resize the browser window
+14. Click `Close`
+
+#### Expected Results
+- The terminal button shows a pressed state when the drawer is open
+- The terminal is scoped to the selected thread working directory
+- Recent output is restored after hiding/reopening or refreshing the thread
+- The terminal resizes without clipping the prompt
+- The snapshot endpoint returns `{ session: { cwd, shell, buffer, truncated } }` while a session exists
+- `Close` terminates the PTY and hides the drawer
+
+#### Rollback/Cleanup
+- Close the terminal session with the `Close` button
+- Stop any processes started inside the terminal before leaving the thread

--- a/whatToTest.md
+++ b/whatToTest.md
@@ -1,0 +1,42 @@
+# What To Test
+
+## Codex.app-Style Integrated Terminal
+
+### Prerequisites
+- Run the dev server at `http://127.0.0.1:4173`.
+- Open an existing local or worktree thread with a valid working directory.
+
+### Core Flow
+1. Click the terminal button in the top-right thread header.
+2. Confirm the terminal drawer opens below the composer.
+3. Press `Cmd+J` on macOS or `Ctrl+J` elsewhere.
+4. Confirm the drawer toggles closed/open and the header button pressed state updates.
+5. Type `pwd` and press Enter.
+6. Confirm the printed path matches the thread/project working directory.
+7. Type `echo terminal-ok` and press Enter.
+8. Confirm `terminal-ok` appears in the terminal output.
+
+### Snapshot API
+1. With the terminal session still running, request:
+   `/codex-api/thread-terminal-snapshot?threadId=<thread-id>`
+2. Confirm the response includes `session.cwd`, `session.shell`, `session.buffer`, and `session.truncated`.
+3. Confirm `session.buffer` contains `terminal-ok`.
+
+### Session Behavior
+1. Hide the terminal, then reopen it.
+2. Confirm recent output is restored.
+3. Refresh the browser and reopen the same thread.
+4. Confirm the terminal can reattach and continue accepting input.
+5. Click `New terminal`.
+6. Confirm the active terminal session is replaced.
+7. Click `Close`.
+8. Confirm the PTY exits and the drawer hides.
+
+### Layout
+1. Resize the desktop browser window.
+2. Confirm the prompt is not clipped and the terminal refits.
+3. Repeat at `375x812` and `768x1024`.
+4. Confirm there is no horizontal page overflow and the terminal remains usable.
+
+### Expected Result
+- Terminal behavior matches Codex.app-style integrated terminal basics: per-thread terminal, project-scoped cwd, header toggle, keyboard shortcut, recent output buffer, and readable snapshot endpoint.


### PR DESCRIPTION
## Summary

- Add a Codex.app-style integrated xterm terminal per local/worktree thread.
- Add server-side PTY session management with a 16 KB output buffer and snapshot endpoint.
- Wire terminal UI into the thread header/composer area with `Cmd/Ctrl+J`, `New terminal`, `Hide`, and `Close` controls.
- Document manual coverage in `tests.md` and `whatToTest.md`, and record Codex.app terminal parity findings.
- Fix visible issues from screenshot review: keep the terminal in-frame on mobile and normalize PTY locale env to avoid shell startup warnings.

## Validation

- `pnpm run build`
- CJS smoke: `node -e "const pty = require('node-pty'); if (typeof pty.spawn !== 'function') throw new Error('node-pty spawn export missing'); const fs = require('fs'); if (!fs.existsSync('./dist-cli/index.js')) throw new Error('dist-cli/index.js missing'); console.log('CJS smoke ok: node-pty.spawn function, dist-cli/index.js exists')"`
- Playwright checklist from `whatToTest.md` against `http://127.0.0.1:4173`
  - header toggle and `Cmd/Ctrl+J`
  - `pwd` and `echo` terminal output
  - snapshot endpoint shape and buffer content
  - hide/reopen, refresh/reopen, new terminal replacement, close behavior
  - desktop/mobile/tablet layout with no horizontal overflow
- Fresh screenshot verification after visible fixes:
  - `output/playwright/fixed-integrated-terminal-desktop-2026-04-22T07-41-36-850Z.png`
  - `output/playwright/fixed-integrated-terminal-mobile-2026-04-22T07-41-36-850Z.png`
  - `output/playwright/fixed-integrated-terminal-tablet-2026-04-22T07-41-36-850Z.png`

## Notes

- The web implementation uses `/codex-api/ws` and HTTP endpoints instead of Electron IPC while preserving Codex.app-style event names and snapshot shape where practical.
- For v1, `New terminal` replaces the active per-thread PTY rather than rendering a full multi-tab strip.
