### PR TITLE
[codex] Add terminal edge-case tests and UI polish

### DIFF
--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -636,3 +636,10 @@ After each feature implementation session that uses this skill:
   - exposes a conversation snapshot shape `{ cwd, shell, buffer, truncated }`
   - emits renderer messages including `terminal-data`, `terminal-init-log`, `terminal-attached`, `terminal-exit`, and `terminal-error`
 - Web parity implementation should use `/codex-api/ws` and HTTP endpoints instead of Electron IPC, but preserve the same event names and snapshot shape where practical.
+- Web implementation lessons from screenshot review and edge-case tests:
+  - Keep the terminal panel outside the pending-request/composer `v-if` / `v-else` pair; otherwise the composer can disappear when the terminal is open.
+  - Collapse the mobile sidebar immediately on first render for direct thread routes; otherwise the drawer can cover terminal screenshots.
+  - Normalize PTY locale (`en_US.UTF-8` on macOS) and remove `TERMINFO` / `TERMINFO_DIRS` to avoid visible shell startup warnings.
+  - Restore executable permissions on `node-pty` `spawn-helper` at runtime when pnpm ignores native package build scripts.
+  - Unit-test terminal manager behavior through dependency injection instead of spawning real shells for every edge case.
+  - Edge cases worth preserving in tests: missing thread id rejection, cwd fallback, dimension clamping, 16 KiB buffer truncation, reattach init-log emission, shell-quoted cwd sync, new-session replacement, and close/exit snapshot cleanup.

--- a/llm-wiki/raw/features/integrated-terminal.md
+++ b/llm-wiki/raw/features/integrated-terminal.md
@@ -1,0 +1,75 @@
+# Integrated Terminal Implementation Source
+
+Date captured: 2026-04-22
+
+## Context
+The `codex-web-local` project added a Codex.app-style integrated terminal for local/worktree threads.
+
+## Implementation Facts
+- Runtime dependencies:
+  - `@xterm/xterm`
+  - `@xterm/addon-fit`
+  - `node-pty`
+- Server entry point:
+  - `src/server/terminalManager.ts`
+- Frontend terminal panel:
+  - `src/components/content/ThreadTerminalPanel.vue`
+- Frontend integration:
+  - `src/App.vue`
+  - `src/api/codexGateway.ts`
+  - `src/composables/useDesktopState.ts`
+- Tests:
+  - `src/server/terminalManager.test.ts`
+  - `vitest.config.ts`
+  - `package.json` script `test:unit`
+
+## Codex.app Parity Facts
+- Codex.app package inspected: `26.417.41555`.
+- Codex.app ships `node-pty@1.1.0`.
+- Codex.app terminal shortcut: `CmdOrCtrl+J`.
+- Codex.app terminal UI strings include:
+  - `Toggle terminal`
+  - `New terminal`
+  - `Close`
+- Codex.app terminal manager behavior includes:
+  - `TERM=xterm-256color`
+  - 16 KiB rolling output buffer
+  - snapshot shape `{ cwd, shell, buffer, truncated }`
+  - events/messages such as `terminal-data`, `terminal-init-log`, `terminal-attached`, `terminal-exit`, and `terminal-error`
+
+## Web Implementation Decisions
+- Web transport uses `/codex-api/ws` and HTTP endpoints instead of Electron IPC.
+- Terminal endpoints include:
+  - `POST /codex-api/thread-terminal/attach`
+  - `POST /codex-api/thread-terminal/input`
+  - `POST /codex-api/thread-terminal/resize`
+  - `POST /codex-api/thread-terminal/close`
+  - `GET /codex-api/thread-terminal-snapshot?threadId=<id>`
+- The snapshot endpoint returns `{ session: { cwd, shell, buffer, truncated } | null }`.
+- The current web UI keeps one active terminal session per thread; `New terminal` replaces the active PTY.
+- `ThreadTerminalManager` has dependency injection for tests, including PTY spawn, filesystem existence checks, cwd/home fallback, platform, shell, and helper setup.
+
+## Fixes From Visual Review
+- The terminal panel must not be part of the pending-request/composer `v-if`/`v-else` pair; otherwise the composer disappears when the terminal is open.
+- On mobile, sidebar collapse must run immediately on first render to avoid the drawer covering the terminal.
+- Mobile terminal height and padding are constrained so the terminal and composer remain visible in the viewport.
+- PTY locale is normalized (`en_US.UTF-8` on macOS) to avoid shell startup warnings such as `setlocale` / `Bad file descriptor`.
+- `node-pty` `spawn-helper` may need executable permissions restored at runtime because pnpm can ignore native package build scripts.
+
+## Verification
+- `pnpm run test:unit`: 7 terminal manager edge-case tests passed.
+- `pnpm run build`: frontend and CLI builds passed.
+- CJS smoke confirmed `node-pty.spawn` and `dist-cli/index.js`.
+- Playwright terminal checklist verified:
+  - header toggle and `Cmd/Ctrl+J`
+  - `pwd` output matches thread cwd
+  - snapshot buffer contains command output
+  - no locale startup warnings
+  - hide/reopen and refresh/reopen reattach behavior
+  - `New terminal` replacement behavior
+  - close cleanup
+  - desktop/mobile/tablet layout without horizontal overflow
+
+## PRs
+- Main implementation PR: `friuns2/codexUI#69`
+- Follow-up tests and visual polish PR: `friuns2/codexUI#70`

--- a/llm-wiki/wiki/concepts/integrated-terminal.md
+++ b/llm-wiki/wiki/concepts/integrated-terminal.md
@@ -1,0 +1,62 @@
+# Integrated Terminal
+
+## Summary
+The integrated terminal feature adds a Codex.app-style xterm panel to local/worktree threads in `codex-web-local`. It gives each thread an interactive PTY scoped to the thread working directory and exposes a readable snapshot endpoint for recent terminal output.
+
+## Source
+- [Integrated terminal implementation source](../../raw/features/integrated-terminal.md)
+
+## Architecture
+- The browser renders the terminal with `@xterm/xterm` and `@xterm/addon-fit` in `ThreadTerminalPanel.vue`.
+- The server bridge manages PTYs with `node-pty` in `terminalManager.ts`.
+- Terminal notifications reuse the existing `/codex-api/ws` stream with Codex.app-style event names:
+  - `terminal-attached`
+  - `terminal-init-log`
+  - `terminal-data`
+  - `terminal-exit`
+  - `terminal-error`
+- HTTP endpoints handle attach, input, resize, close, and snapshot reads.
+
+## Parity Decisions
+- Match Codex.app copy and shortcut basics:
+  - `Toggle terminal`
+  - `New terminal`
+  - `Close`
+  - `CmdOrCtrl+J`
+- Match core terminal runtime behavior:
+  - `TERM=xterm-256color`
+  - 16 KiB rolling output buffer
+  - snapshot shape `{ cwd, shell, buffer, truncated }`
+- Use web transports instead of Electron IPC:
+  - `/codex-api/ws`
+  - `/codex-api/thread-terminal/*`
+
+## Important Edge Cases
+- Invalid cwd falls back to home, then process cwd.
+- Dimension values are clamped before PTY spawn and resize.
+- PTY locale should be normalized to avoid macOS shell warnings.
+- `node-pty` `spawn-helper` may need executable permissions restored when pnpm skips native build scripts.
+- Reattach must emit init log before attached state so hidden/reopened terminals restore recent output.
+- Changed cwd on reattach must be shell-quoted before writing `cd <path>`.
+- `New terminal` replaces the active thread PTY in the current web implementation.
+- Close and PTY exit must clear the active thread snapshot.
+
+## UI Lessons
+- Keep the terminal outside the pending-request/composer `v-if`/`v-else` pair. If the terminal is inserted between them, Vue pairs `v-else` with the terminal instead of the pending request and hides the composer while the terminal is open.
+- On mobile, sidebar collapse should run immediately on first render. Otherwise screenshot or direct-route loads can leave the drawer covering the terminal.
+- Keep mobile terminal height constrained so both terminal and composer remain visible.
+
+## Verification
+- Unit coverage lives in `src/server/terminalManager.test.ts`.
+- Manual and browser verification is documented in `tests.md` and `whatToTest.md`.
+- The final browser checklist validated:
+  - keyboard toggle
+  - cwd output
+  - snapshot endpoint
+  - hide/reopen and refresh/reopen
+  - new terminal replacement
+  - close cleanup
+  - desktop/mobile/tablet layout
+
+## Related Pages
+- [Entity: codex-web-local](../entities/codex-web-local.md)

--- a/llm-wiki/wiki/entities/codex-web-local.md
+++ b/llm-wiki/wiki/entities/codex-web-local.md
@@ -12,7 +12,10 @@
 - Frequent branch merges into local `main`
 - Strong conflict-resolution policy (intentional per-file merges)
 - Manual regression documentation in `tests.md`
+- Integrated terminal uses a Node PTY bridge plus an xterm frontend for local/worktree threads
 
 ## Source links
 - [Source snapshot](../../raw/projects/codex-web-local.md)
+- [Integrated terminal source](../../raw/features/integrated-terminal.md)
+- [Integrated terminal concept](../concepts/integrated-terminal.md)
 - [Merge-to-main workflow concept](../concepts/merge-to-main-workflow.md)

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -7,9 +7,11 @@
 - [entities/codex-web-local.md](./entities/codex-web-local.md): project identity, stack, and operational profile.
 
 ## Concepts
+- [concepts/integrated-terminal.md](./concepts/integrated-terminal.md): Codex.app-style integrated xterm/PTY terminal architecture, edge cases, and verification.
 - [concepts/merge-to-main-workflow.md](./concepts/merge-to-main-workflow.md): branch integration and conflict-resolution workflow.
 - [concepts/opencode-zen-big-pickle.md](./concepts/opencode-zen-big-pickle.md): OpenCode Zen Big Pickle model configuration for Codex CLI and OpenCode CLI.
 
 ## Sources
+- [../raw/features/integrated-terminal.md](../raw/features/integrated-terminal.md): source facts for the integrated terminal implementation and follow-up tests.
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## [2026-04-22] ingest | integrated terminal implementation
+- Added source: `raw/features/integrated-terminal.md`.
+- Created wiki page: `concepts/integrated-terminal.md`.
+- Documents: Codex.app terminal parity facts, web endpoint design, PTY manager edge cases, visual review fixes, and verification coverage.
+- Updated `overview.md`, `entities/codex-web-local.md`, and `index.md`.
+
 ## [2026-04-13] ingest | OpenCode Zen Big Pickle + Codex CLI fix
 - Added source: `raw/fixes/opencode-zen-big-pickle-codex-cli.md`.
 - Created wiki page: `concepts/opencode-zen-big-pickle.md`.

--- a/llm-wiki/wiki/overview.md
+++ b/llm-wiki/wiki/overview.md
@@ -6,10 +6,13 @@ This wiki tracks knowledge about the `codex-web-local` project and related workf
 - Project architecture and tooling
 - Release/sync workflow on `main`
 - Manual verification practices (`tests.md`)
+- Codex.app-style integrated terminal implementation and tests
 
 ## Primary source
 - [codex-web-local project snapshot](../raw/projects/codex-web-local.md)
+- [integrated terminal implementation source](../raw/features/integrated-terminal.md)
 
 ## Linked pages
 - [Entity: codex-web-local](./entities/codex-web-local.md)
+- [Concept: Integrated terminal](./concepts/integrated-terminal.md)
 - [Concept: Merge-to-main workflow](./concepts/merge-to-main-workflow.md)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:frontend": "vue-tsc --noEmit && vite build",
     "build:cli": "tsup",
     "build": "pnpm run build:frontend && pnpm run build:cli",
+    "test:unit": "vitest run",
     "preview": "vite preview",
     "prepublishOnly": "pnpm run build",
     "profile:browser": "node scripts/profile-browser-runtime.cjs",
@@ -69,6 +70,7 @@
     "tsup": "^8.4.0",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",
+    "vitest": "^4.1.5",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4",
     "vue-tsc": "^2.2.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -750,13 +750,6 @@
                     @steer="steerQueuedMessage"
                     @delete="removeQueuedMessage"
                   />
-                  <ThreadPendingRequestPanel
-                    v-if="selectedThreadPendingRequest"
-                    :request="selectedThreadPendingRequest"
-                    :request-count="selectedThreadServerRequests.length"
-                    :has-queue-above="selectedThreadQueuedMessages.length > 0"
-                    @respond-server-request="onRespondServerRequest"
-                  />
                   <ThreadTerminalPanel
                     v-if="selectedThreadTerminalOpen && selectedThreadId && composerCwd"
                     class="content-thread-terminal-panel"
@@ -764,7 +757,17 @@
                     :cwd="composerCwd"
                     @hide="setThreadTerminalOpen(selectedThreadId, false)"
                   />
-                  <ThreadComposer v-else ref="threadComposerRef" :active-thread-id="composerThreadContextId"
+                  <ThreadPendingRequestPanel
+                    v-if="selectedThreadPendingRequest"
+                    :request="selectedThreadPendingRequest"
+                    :request-count="selectedThreadServerRequests.length"
+                    :has-queue-above="selectedThreadQueuedMessages.length > 0"
+                    @respond-server-request="onRespondServerRequest"
+                  />
+                  <ThreadComposer
+                    v-else
+                    ref="threadComposerRef"
+                    :active-thread-id="composerThreadContextId"
                     :cwd="composerCwd"
                     :collaboration-modes="availableCollaborationModes"
                     :selected-collaboration-mode="selectedCollaborationMode"
@@ -3244,7 +3247,7 @@ watch(isMobile, (mobile) => {
   if (mobile && !isSidebarCollapsed.value) {
     setSidebarCollapsed(true)
   }
-})
+}, { immediate: true })
 
 async function submitFirstMessageForNewThread(
   text: string,

--- a/src/server/terminalManager.test.ts
+++ b/src/server/terminalManager.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ThreadTerminalManager,
+  type TerminalNotification,
+  type TerminalPty,
+} from './terminalManager'
+
+type ExitPayload = { exitCode: number, signal?: number }
+
+class FakePty implements TerminalPty {
+  writes: string[] = []
+  resizes: Array<{ cols: number, rows: number }> = []
+  killed = false
+  private dataHandlers: Array<(data: string) => void> = []
+  private exitHandlers: Array<(event: ExitPayload) => void> = []
+
+  write(data: string): void {
+    this.writes.push(data)
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows })
+  }
+
+  kill(): void {
+    this.killed = true
+  }
+
+  onData(handler: (data: string) => void): { dispose: () => void } {
+    this.dataHandlers.push(handler)
+    return { dispose: () => {} }
+  }
+
+  onExit(handler: (event: ExitPayload) => void): { dispose: () => void } {
+    this.exitHandlers.push(handler)
+    return { dispose: () => {} }
+  }
+
+  emitData(data: string): void {
+    for (const handler of this.dataHandlers) {
+      handler(data)
+    }
+  }
+
+  emitExit(event: ExitPayload = { exitCode: 0 }): void {
+    for (const handler of this.exitHandlers) {
+      handler(event)
+    }
+  }
+}
+
+function createHarness(options: {
+  exists?: (path: string) => boolean
+  homeDir?: () => string
+  cwd?: () => string
+  shell?: string
+} = {}) {
+  const ptys: FakePty[] = []
+  const spawnCalls: Array<{ file: string, opt: { cols?: number, rows?: number, cwd?: string, env?: Record<string, string | undefined> } }> = []
+  const notifications: TerminalNotification[] = []
+  let helperCalls = 0
+  const manager = new ThreadTerminalManager({
+    spawn: (file, _args, opt) => {
+      const pty = new FakePty()
+      ptys.push(pty)
+      spawnCalls.push({ file, opt })
+      return pty
+    },
+    exists: options.exists ?? ((value) => value === '/repo' || value === '/home/tester'),
+    homeDir: options.homeDir ?? (() => '/home/tester'),
+    cwd: options.cwd ?? (() => '/fallback-cwd'),
+    shell: options.shell ?? '/bin/zsh',
+    platform: 'darwin',
+    ensureSpawnHelperExecutable: () => {
+      helperCalls += 1
+    },
+  })
+  manager.subscribe((notification) => notifications.push(notification))
+  return {
+    manager,
+    ptys,
+    spawnCalls,
+    notifications,
+    get helperCalls() {
+      return helperCalls
+    },
+  }
+}
+
+describe('ThreadTerminalManager edge cases', () => {
+  it('rejects missing thread ids before spawning', () => {
+    const { manager, spawnCalls } = createHarness()
+
+    expect(() => manager.attach({ threadId: '   ', cwd: '/repo' })).toThrow('Missing threadId')
+    expect(spawnCalls).toHaveLength(0)
+  })
+
+  it('falls back from invalid cwd to home, then process cwd', () => {
+    const homeHarness = createHarness({
+      exists: (value) => value === '/home/tester',
+    })
+    const homeSession = homeHarness.manager.attach({ threadId: 'thread-1', cwd: '/missing' })
+
+    expect(homeSession.cwd).toBe('/home/tester')
+    expect(homeHarness.spawnCalls[0]?.opt.cwd).toBe('/home/tester')
+
+    const cwdHarness = createHarness({
+      exists: () => false,
+      cwd: () => '/process-cwd',
+    })
+    const cwdSession = cwdHarness.manager.attach({ threadId: 'thread-1', cwd: '/missing' })
+
+    expect(cwdSession.cwd).toBe('/process-cwd')
+    expect(cwdHarness.spawnCalls[0]?.opt.cwd).toBe('/process-cwd')
+  })
+
+  it('clamps initial and resize dimensions', () => {
+    const { manager, ptys, spawnCalls } = createHarness()
+    const session = manager.attach({
+      threadId: 'thread-1',
+      cwd: '/repo',
+      cols: 9999,
+      rows: -10,
+    })
+
+    expect(spawnCalls[0]?.opt.cols).toBe(500)
+    expect(spawnCalls[0]?.opt.rows).toBe(1)
+
+    manager.resize(session.id, 0, 9999)
+
+    expect(ptys[0]?.resizes).toEqual([{ cols: 1, rows: 500 }])
+  })
+
+  it('normalizes PTY environment for macOS locale and node-pty helper', () => {
+    const harness = createHarness()
+    const { manager, spawnCalls } = harness
+
+    manager.attach({ threadId: 'thread-1', cwd: '/repo' })
+
+    expect(harness.helperCalls).toBe(1)
+    expect(spawnCalls[0]?.opt.env?.TERM).toBe('xterm-256color')
+    expect(spawnCalls[0]?.opt.env?.LANG).toBe('en_US.UTF-8')
+    expect(spawnCalls[0]?.opt.env?.LC_ALL).toBe('en_US.UTF-8')
+    expect(spawnCalls[0]?.opt.env?.LC_CTYPE).toBe('en_US.UTF-8')
+    expect(spawnCalls[0]?.opt.env).not.toHaveProperty('TERMINFO')
+    expect(spawnCalls[0]?.opt.env).not.toHaveProperty('TERMINFO_DIRS')
+  })
+
+  it('truncates snapshots to the last 16 KiB and marks them truncated', () => {
+    const { manager, ptys, notifications } = createHarness()
+    manager.attach({ threadId: 'thread-1', cwd: '/repo' })
+
+    const longOutput = `${'a'.repeat(20 * 1024)}tail`
+    ptys[0]?.emitData(longOutput)
+    const snapshot = manager.getSnapshotForThread('thread-1')
+
+    expect(snapshot?.truncated).toBe(true)
+    expect(snapshot?.buffer).toHaveLength(16 * 1024)
+    expect(snapshot?.buffer.endsWith('tail')).toBe(true)
+    expect(notifications.some((notification) => notification.method === 'terminal-data')).toBe(true)
+  })
+
+  it('reattaches an existing session, emits init log, and syncs changed cwd safely', () => {
+    const { manager, ptys, notifications } = createHarness({
+      exists: (value) => value === '/repo' || value === "/repo/with ' quote",
+    })
+    const first = manager.attach({ threadId: 'thread-1', cwd: '/repo' })
+    ptys[0]?.emitData('previous output')
+    notifications.splice(0, notifications.length)
+
+    const second = manager.attach({
+      threadId: 'thread-1',
+      cwd: "/repo/with ' quote",
+      sessionId: first.id,
+    })
+
+    expect(second.id).toBe(first.id)
+    expect(second.cwd).toBe("/repo/with ' quote")
+    expect(ptys[0]?.writes.at(-1)).toBe("cd '/repo/with '\\'' quote'\r")
+    expect(notifications.map((notification) => notification.method)).toEqual([
+      'terminal-init-log',
+      'terminal-attached',
+    ])
+  })
+
+  it('replaces active sessions and removes snapshots on close/exit', () => {
+    const { manager, ptys, notifications } = createHarness()
+    const first = manager.attach({ threadId: 'thread-1', cwd: '/repo', sessionId: 'first' })
+    const second = manager.attach({ threadId: 'thread-1', cwd: '/repo', sessionId: 'second', newSession: true })
+
+    expect(first.id).toBe('first')
+    expect(second.id).toBe('second')
+    expect(ptys[0]?.killed).toBe(true)
+    expect(manager.getSnapshotForThread('thread-1')?.id).toBe('second')
+    expect(notifications.some((notification) => notification.method === 'terminal-exit')).toBe(true)
+
+    manager.close('second')
+
+    expect(ptys[1]?.killed).toBe(true)
+    expect(manager.getSnapshotForThread('thread-1')).toBeNull()
+
+    const third = manager.attach({ threadId: 'thread-1', cwd: '/repo', sessionId: 'third' })
+    expect(third.id).toBe('third')
+    ptys[2]?.emitExit({ exitCode: 7 })
+
+    expect(manager.getSnapshotForThread('thread-1')).toBeNull()
+  })
+})

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
-import { spawn as spawnPty, type IPty } from 'node-pty'
+import { spawn as spawnPty, type IPty, type IPtyForkOptions } from 'node-pty'
 
 const TERMINAL_BUFFER_LIMIT = 16 * 1024
 const DEFAULT_COLS = 80
@@ -30,9 +30,27 @@ type TerminalSession = {
   threadId: string
   cwd: string
   shell: string
-  pty: IPty
+  pty: TerminalPty
   buffer: string
   truncated: boolean
+}
+
+export type TerminalPty = Pick<IPty, 'write' | 'resize' | 'kill' | 'onData' | 'onExit'>
+
+type SpawnTerminal = (
+  file: string,
+  args: string[],
+  opt: IPtyForkOptions,
+) => TerminalPty
+
+export type TerminalManagerOptions = {
+  spawn?: SpawnTerminal
+  exists?: (path: string) => boolean
+  homeDir?: () => string
+  cwd?: () => string
+  platform?: NodeJS.Platform
+  shell?: string
+  ensureSpawnHelperExecutable?: () => void
 }
 
 export type TerminalAttachParams = {
@@ -48,6 +66,23 @@ export class ThreadTerminalManager {
   private readonly sessions = new Map<string, TerminalSession>()
   private readonly activeSessionIdByThreadId = new Map<string, string>()
   private readonly listeners = new Set<(notification: TerminalNotification) => void>()
+  private readonly spawn: SpawnTerminal
+  private readonly exists: (path: string) => boolean
+  private readonly homeDir: () => string
+  private readonly cwd: () => string
+  private readonly platform: NodeJS.Platform
+  private readonly shell: string | null
+  private readonly ensureSpawnHelperExecutable: () => void
+
+  constructor(options: TerminalManagerOptions = {}) {
+    this.spawn = options.spawn ?? spawnPty
+    this.exists = options.exists ?? existsSync
+    this.homeDir = options.homeDir ?? homedir
+    this.cwd = options.cwd ?? process.cwd
+    this.platform = options.platform ?? process.platform
+    this.shell = options.shell ?? null
+    this.ensureSpawnHelperExecutable = options.ensureSpawnHelperExecutable ?? ensureNodePtySpawnHelperExecutable
+  }
 
   subscribe(listener: (notification: TerminalNotification) => void): () => void {
     this.listeners.add(listener)
@@ -163,8 +198,8 @@ export class ThreadTerminalManager {
     delete env.TERMINFO
     delete env.TERMINFO_DIRS
 
-    ensureNodePtySpawnHelperExecutable()
-    const pty = spawnPty(shell, [], {
+    this.ensureSpawnHelperExecutable()
+    const pty = this.spawn(shell, [], {
       name: TERMINAL_NAME,
       cols: normalizeDimension(params.cols, DEFAULT_COLS),
       rows: normalizeDimension(params.rows, DEFAULT_ROWS),
@@ -264,7 +299,8 @@ export class ThreadTerminalManager {
   }
 
   private resolveShell(): string {
-    if (process.platform === 'win32') {
+    if (this.shell) return this.shell
+    if (this.platform === 'win32') {
       return process.env.COMSPEC || 'cmd.exe'
     }
     return process.env.SHELL || '/bin/zsh'
@@ -272,14 +308,14 @@ export class ThreadTerminalManager {
 
   private resolveCwd(value: string): string {
     const cwd = value.trim()
-    if (cwd && existsSync(cwd)) {
+    if (cwd && this.exists(cwd)) {
       return cwd
     }
-    const home = homedir()
-    if (home && existsSync(home)) {
+    const home = this.homeDir()
+    if (home && this.exists(home)) {
       return home
     }
-    return process.cwd()
+    return this.cwd()
   }
 
   private toSnapshot(session: TerminalSession): TerminalSessionSnapshot {

--- a/tests.md
+++ b/tests.md
@@ -2911,3 +2911,29 @@ Each local/worktree thread has an integrated xterm terminal that can be toggled 
 #### Rollback/Cleanup
 - Close the terminal session with the `Close` button
 - Stop any processes started inside the terminal before leaving the thread
+
+---
+
+### Integrated terminal manager edge cases
+
+#### Feature/Change Name
+Automated unit coverage for terminal manager edge cases that do not require a browser or real shell.
+
+#### Prerequisites/Setup
+1. Dependencies installed with `pnpm install`
+
+#### Steps
+1. Run `pnpm run test:unit`
+2. Optionally run the focused test file with `pnpm run test:unit -- src/server/terminalManager.test.ts`
+
+#### Expected Results
+- Missing thread ids are rejected before spawning a PTY
+- Invalid cwd falls back to home and then process cwd
+- Initial and resize dimensions are clamped
+- PTY env normalizes `TERM`, locale, and strips `TERMINFO` variables
+- Output snapshots truncate to the last 16 KiB and set `truncated`
+- Existing session reattach emits init/attached events and safely syncs changed cwd
+- New terminal replaces the active session, and close/exit removes snapshots
+
+#### Rollback/Cleanup
+- None

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    exclude: ['node_modules/**', 'dist/**', 'dist-cli/**', 'output/**'],
+  },
+})


### PR DESCRIPTION
## Summary

- Add a `vitest` unit-test target scoped to source tests.
- Add terminal manager edge-case tests with injected fake PTYs so coverage does not depend on real shells.
- Make `ThreadTerminalManager` injectable for spawn, filesystem checks, cwd/home fallback, platform, shell, and helper setup.
- Fix screenshot-visible terminal UI issues: keep the composer visible while the terminal is open and auto-collapse the mobile sidebar immediately on first render.
- Document the automated edge-case coverage in `tests.md`.

## Covered edge cases

- Missing thread ids reject before spawning.
- Invalid cwd falls back to home, then process cwd.
- Initial and resize dimensions are clamped.
- PTY env normalizes `TERM`, locale, and strips `TERMINFO` variables.
- Output snapshots truncate to the last 16 KiB and set `truncated`.
- Existing session reattach emits init/attached events and safely syncs changed cwd.
- New terminal replaces the active session; close and exit remove snapshots.

## Screenshot-driven fixes

- Composer now remains visible below the terminal drawer.
- Mobile drawer no longer appears over the terminal on initial mobile render.
- Verified terminal panel and composer stay in viewport on desktop, mobile, and tablet.

## Validation

- `pnpm run test:unit`
- `pnpm run build`
- CJS smoke: `node -e "const pty = require('node-pty'); if (typeof pty.spawn !== 'function') throw new Error('node-pty spawn export missing'); const fs = require('fs'); if (!fs.existsSync('./dist-cli/index.js')) throw new Error('dist-cli/index.js missing'); console.log('CJS smoke ok: node-pty.spawn function, dist-cli/index.js exists')"`
- Playwright terminal flow against `http://127.0.0.1:4173`
  - composer remains visible with terminal open
  - header toggle and `Cmd/Ctrl+J`
  - `pwd` and marker output in snapshot buffer
  - no `setlocale` / `Bad file descriptor` warnings
  - hide/reopen, refresh/reopen, new terminal replacement, close cleanup
  - desktop/mobile/tablet layout in viewport with no horizontal overflow

## Screenshots

- `output/playwright/final-integrated-terminal-desktop.png`
- `output/playwright/final-integrated-terminal-mobile.png`
- `output/playwright/final-integrated-terminal-tablet.png`
