### PR TITLE
fix: persist password login sessions

### DIFF
--- a/src/server/authMiddleware.ts
+++ b/src/server/authMiddleware.ts
@@ -1,8 +1,21 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import type { IncomingMessage } from 'node:http'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
 import type { RequestHandler, Request, Response, NextFunction } from 'express'
 
 const TOKEN_COOKIE = 'portal_session'
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const SESSION_STORE_FILE = 'webui-auth-sessions.json'
+const MAX_PERSISTED_TOKENS = 128
+
+type PersistedAuthState = {
+  tokens?: Array<{
+    value?: unknown
+    expiresAt?: unknown
+  }>
+}
 
 function constantTimeCompare(a: string, b: string): boolean {
   const bufA = Buffer.from(a)
@@ -60,11 +73,85 @@ function isTrustedTailscaleRemote(remote: string): boolean {
   return isTrustedTailscaleIPv4(remote) || isTrustedTailscaleIPv6(remote)
 }
 
+function getCodexHomeDir(): string {
+  const codexHome = process.env.CODEX_HOME?.trim()
+  return codexHome && codexHome.length > 0 ? codexHome : join(homedir(), '.codex')
+}
+
+function getSessionStorePath(): string {
+  return join(getCodexHomeDir(), SESSION_STORE_FILE)
+}
+
+function readPersistedSessions(): Map<string, number> {
+  const sessionStorePath = getSessionStorePath()
+  if (!existsSync(sessionStorePath)) return new Map()
+
+  try {
+    const raw = readFileSync(sessionStorePath, 'utf8')
+    const parsed = JSON.parse(raw) as PersistedAuthState
+    const now = Date.now()
+    const sessions = new Map<string, number>()
+    for (const entry of parsed.tokens ?? []) {
+      const token = typeof entry?.value === 'string' ? entry.value : ''
+      const expiresAt = typeof entry?.expiresAt === 'number' ? entry.expiresAt : 0
+      if (!token || !Number.isFinite(expiresAt) || expiresAt <= now) continue
+      sessions.set(token, expiresAt)
+    }
+    return sessions
+  } catch {
+    return new Map()
+  }
+}
+
+function persistSessions(validTokens: Map<string, number>): void {
+  const sessionStorePath = getSessionStorePath()
+  mkdirSync(dirname(sessionStorePath), { recursive: true })
+
+  const tokens = Array.from(validTokens.entries())
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, MAX_PERSISTED_TOKENS)
+    .map(([value, expiresAt]) => ({ value, expiresAt }))
+  const tmpPath = `${sessionStorePath}.tmp`
+  writeFileSync(tmpPath, `${JSON.stringify({ tokens }, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+  renameSync(tmpPath, sessionStorePath)
+}
+
+function tryPersistSessions(validTokens: Map<string, number>): void {
+  try {
+    persistSessions(validTokens)
+  } catch (error) {
+    console.warn('[auth] failed to persist login sessions:', error)
+  }
+}
+
+function pruneExpiredSessions(validTokens: Map<string, number>): boolean {
+  const now = Date.now()
+  let changed = false
+  for (const [token, expiresAt] of validTokens.entries()) {
+    if (expiresAt > now) continue
+    validTokens.delete(token)
+    changed = true
+  }
+  return changed
+}
+
+function buildSessionCookie(token: string, expiresAt: number): string {
+  const maxAgeSeconds = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000))
+  return [
+    `${TOKEN_COOKIE}=${token}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${String(maxAgeSeconds)}`,
+    `Expires=${new Date(expiresAt).toUTCString()}`,
+  ].join('; ')
+}
+
 function isAuthorizedByRequestLike(
   remoteAddress: string | undefined,
   hostHeader: string | undefined,
   cookieHeader: string | undefined,
-  validTokens: Set<string>,
+  validTokens: Map<string, number>,
 ): boolean {
   const remote = remoteAddress ?? ''
   // SSH reverse tunnels terminate on loopback, so remoteAddress alone is not enough
@@ -78,7 +165,9 @@ function isAuthorizedByRequestLike(
 
   const cookies = parseCookies(cookieHeader)
   const token = cookies[TOKEN_COOKIE]
-  return Boolean(token && validTokens.has(token))
+  if (!token) return false
+  const expiresAt = validTokens.get(token)
+  return typeof expiresAt === 'number' && expiresAt > Date.now()
 }
 
 const LOGIN_PAGE_HTML = `<!DOCTYPE html>
@@ -133,9 +222,16 @@ export type AuthSession = {
 }
 
 export function createAuthSession(password: string): AuthSession {
-  const validTokens = new Set<string>()
+  const validTokens = readPersistedSessions()
+  if (pruneExpiredSessions(validTokens)) {
+    tryPersistSessions(validTokens)
+  }
 
   const middleware: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+    if (pruneExpiredSessions(validTokens)) {
+      tryPersistSessions(validTokens)
+    }
+
     if (isAuthorizedByRequestLike(req.socket.remoteAddress, req.headers.host, req.headers.cookie, validTokens)) {
       next()
       return
@@ -147,22 +243,29 @@ export function createAuthSession(password: string): AuthSession {
       req.setEncoding('utf8')
       req.on('data', (chunk: string) => { body += chunk })
       req.on('end', () => {
+        let parsed: { password?: string }
         try {
-          const parsed = JSON.parse(body) as { password?: string }
-          const provided = typeof parsed.password === 'string' ? parsed.password : ''
-
-          if (!constantTimeCompare(provided, password)) {
-            res.status(401).json({ error: 'Invalid password' })
-            return
-          }
-
-          const token = randomBytes(32).toString('hex')
-          validTokens.add(token)
-
-          res.setHeader('Set-Cookie', `${TOKEN_COOKIE}=${token}; Path=/; HttpOnly; SameSite=Strict`)
-          res.json({ ok: true })
+          parsed = JSON.parse(body) as { password?: string }
         } catch {
           res.status(400).json({ error: 'Invalid request body' })
+          return
+        }
+
+        const provided = typeof parsed.password === 'string' ? parsed.password : ''
+        if (!constantTimeCompare(provided, password)) {
+          res.status(401).json({ error: 'Invalid password' })
+          return
+        }
+
+        try {
+          const token = randomBytes(32).toString('hex')
+          const expiresAt = Date.now() + SESSION_TTL_MS
+          validTokens.set(token, expiresAt)
+          tryPersistSessions(validTokens)
+          res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt))
+          res.json({ ok: true })
+        } catch {
+          res.status(500).json({ error: 'Failed to create login session' })
         }
       })
       return
@@ -173,8 +276,10 @@ export function createAuthSession(password: string): AuthSession {
       const provided = req.path.slice('/password='.length)
       if (constantTimeCompare(provided, password)) {
         const token = randomBytes(32).toString('hex')
-        validTokens.add(token)
-        res.setHeader('Set-Cookie', `${TOKEN_COOKIE}=${token}; Path=/; HttpOnly; SameSite=Strict`)
+        const expiresAt = Date.now() + SESSION_TTL_MS
+        validTokens.set(token, expiresAt)
+        tryPersistSessions(validTokens)
+        res.setHeader('Set-Cookie', buildSessionCookie(token, expiresAt))
         res.redirect(302, '/')
         return
       }


### PR DESCRIPTION
## Summary
- persist password-based login sessions to a CODEX_HOME-backed auth store
- restore valid sessions on server startup and prune expired tokens
- issue long-lived login cookies so browser sessions survive app restarts

## Testing
- pnpm build
- verified login returns persistent Set-Cookie headers with Max-Age and Expires
- verified old cookie still authorizes after restarting a temporary server instance