### PR TITLE
docs(telegram): update README with current bot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,17 @@ To find your Telegram user ID:
 
 Bot commands:
 
+- `/start` show quick help and thread picker
+- `/threads` list recent threads and pick one
 - `/newthread` create and map a new Codex thread for this Telegram chat
 - `/thread <threadId>` map current Telegram chat to an existing thread
-- Any other text message is forwarded to the mapped thread
+- `/current` show currently connected thread for this chat
+- `/history` show recent history for current thread
+- `/status` show bridge/mapping status
+- `/whoami` show your Telegram user/chat IDs and authorization state
+- `/help` show command reference
+
+Outgoing assistant messages are sent with Telegram `parse_mode=HTML` for formatting, with automatic plain-text fallback if HTML delivery fails.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR updates the Telegram Bot Bridge section in `README.md` to reflect the command set and behavior already implemented in code (merged earlier in #61).

## What changed
- Updated the documented Telegram commands list to include:
  - `/start`
  - `/threads`
  - `/newthread`
  - `/thread <threadId>`
  - `/current`
  - `/history`
  - `/status`
  - `/whoami`
  - `/help`
- Added a note that outgoing assistant messages use Telegram `parse_mode=HTML` with automatic plain-text fallback if HTML delivery fails.

## Why
After #61, README still showed an older, partial command list. This caused a docs mismatch with actual runtime behavior.

## Scope
Documentation only. No runtime or API changes.

## Validation
- Verified command list against `src/server/telegramThreadBridge.ts`.
- Confirmed README section now matches current Telegram bridge behavior.
