### PR TITLE
Add directory try actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -494,6 +494,7 @@
               :cwd="directoryCwd"
               :thread-id="routeThreadId"
               @skills-changed="onSkillsChanged"
+              @try-item="onTryDirectoryItem"
             />
           </template>
           <template v-else-if="isHomeRoute">
@@ -892,6 +893,13 @@ const SETTINGS_HELP = {
 } as const
 
 type ChatWidthMode = 'standard' | 'wide' | 'extra-wide'
+
+type DirectoryTryItemPayload = {
+  kind: 'app' | 'plugin' | 'skill'
+  name: string
+  displayName: string
+  skillPath?: string
+}
 
 type ChatWidthPreset = {
   label: string
@@ -3351,6 +3359,28 @@ async function submitFirstMessageForNewThread(
     scheduleMobileConversationJumpToLatest()
   } catch {
     // Error is already reflected in state.
+  }
+}
+
+function buildDirectoryTryPrompt(payload: DirectoryTryItemPayload): string {
+  const label = payload.displayName.trim() || payload.name.trim()
+  const itemType = payload.kind === 'skill' ? 'skill' : payload.kind === 'plugin' ? 'plugin' : 'app'
+  return `Test ${label} ${itemType}. Give me a list of what it can do and one useful example.`
+}
+
+async function onTryDirectoryItem(payload: DirectoryTryItemPayload): Promise<void> {
+  const text = buildDirectoryTryPrompt(payload)
+  const skills = payload.kind === 'skill' && payload.skillPath
+    ? [{ name: payload.name, path: payload.skillPath }]
+    : []
+  try {
+    const targetCwd = directoryCwd.value.trim() || composerCwd.value.trim()
+    const threadId = await sendMessageToNewThread(text, targetCwd, [], skills, [])
+    if (!threadId) return
+    await router.replace({ name: 'thread', params: { threadId } })
+    scheduleMobileConversationJumpToLatest()
+  } catch {
+    // Error is already reflected in shared thread state.
   }
 }
 

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -175,6 +175,9 @@
             <button v-if="app.installUrl" class="directory-action-link" type="button" @click="openExternalUrl(app.installUrl)">
               {{ app.isAccessible ? 'Manage' : 'Login' }}
             </button>
+            <button v-if="app.isAccessible" class="directory-action" type="button" @click="tryApp(app)">
+              Try it!
+            </button>
           </div>
         </article>
       </div>
@@ -247,7 +250,11 @@
       </div>
     </section>
 
-    <SkillsHub v-else @skills-changed="$emit('skills-changed')" />
+    <SkillsHub
+      v-else
+      @skills-changed="emit('skills-changed')"
+      @try-item="(payload) => emit('try-item', payload)"
+    />
 
     <Teleport to="body">
       <div v-if="isPluginDetailOpen" class="directory-modal-overlay" @click.self="closePluginDetail">
@@ -358,6 +365,15 @@
             >
               {{ selectedPlugin.enabled ? 'Disable' : 'Enable' }}
             </button>
+            <button
+              v-if="selectedPlugin && selectedPlugin.installed && selectedPlugin.enabled"
+              class="directory-action primary"
+              type="button"
+              :disabled="isPluginActionInFlight"
+              @click="tryPlugin(selectedPlugin)"
+            >
+              Try it!
+            </button>
           </div>
         </article>
       </div>
@@ -441,8 +457,16 @@ const props = defineProps<{
   threadId?: string
 }>()
 
-defineEmits<{
+export type DirectoryTryItemPayload = {
+  kind: 'app' | 'plugin' | 'skill'
+  name: string
+  displayName: string
+  skillPath?: string
+}
+
+const emit = defineEmits<{
   'skills-changed': []
+  'try-item': [payload: DirectoryTryItemPayload]
 }>()
 
 const tabs: Array<{ id: DirectoryTab; label: string; subtitle: string }> = [
@@ -695,6 +719,22 @@ function pluginIconSrc(plugin: DirectoryPluginSummary | null): string {
 
 function appLogoSrc(app: DirectoryAppInfo): string {
   return localAssetSrc(app.logoUrlDark || app.logoUrl)
+}
+
+function tryApp(app: DirectoryAppInfo): void {
+  emit('try-item', {
+    kind: 'app',
+    name: app.id,
+    displayName: app.name,
+  })
+}
+
+function tryPlugin(plugin: DirectoryPluginSummary): void {
+  emit('try-item', {
+    kind: 'plugin',
+    name: plugin.name,
+    displayName: plugin.displayName,
+  })
 }
 
 function openExternalUrl(rawUrl: string): void {

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -175,7 +175,7 @@
             <button v-if="app.installUrl" class="directory-action-link" type="button" @click="openExternalUrl(app.installUrl)">
               {{ app.isAccessible ? 'Manage' : 'Login' }}
             </button>
-            <button v-if="app.isAccessible" class="directory-action" type="button" @click="tryApp(app)">
+            <button v-if="app.isAccessible && app.isEnabled" class="directory-action" type="button" @click="tryApp(app)">
               Try it!
             </button>
           </div>

--- a/src/components/content/SkillDetailModal.vue
+++ b/src/components/content/SkillDetailModal.vue
@@ -65,6 +65,16 @@
             </button>
 
             <button
+              v-if="skill.installed && effectiveEnabled"
+              class="sdm-btn sdm-btn-primary"
+              type="button"
+              :disabled="isActing"
+              @click="onTry"
+            >
+              Try it!
+            </button>
+
+            <button
               v-if="skill.installed && skillDirPath"
               class="sdm-btn sdm-btn-secondary"
               type="button"
@@ -109,6 +119,7 @@ const emit = defineEmits<{
   install: [skill: HubSkill]
   uninstall: [skill: HubSkill]
   'toggle-enabled': [skill: HubSkill, enabled: boolean]
+  try: [skill: HubSkill]
 }>()
 
 const localEnabled = ref<boolean | null>(null)
@@ -192,6 +203,10 @@ function onToggleEnabled(): void {
   const next = !effectiveEnabled.value
   localEnabled.value = next
   emit('toggle-enabled', props.skill, next)
+}
+
+function onTry(): void {
+  emit('try', props.skill)
 }
 
 function onBrowseFiles(): void {

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -109,6 +109,7 @@
       @install="handleInstall"
       @uninstall="handleUninstall"
       @toggle-enabled="handleToggleEnabled"
+      @try="handleTrySkill"
     />
   </div>
 </template>
@@ -147,6 +148,7 @@ const { t } = useUiLanguage()
 
 const emit = defineEmits<{
   'skills-changed': []
+  'try-item': [payload: { kind: 'skill'; name: string; displayName: string; skillPath?: string }]
 }>()
 
 const sortLabel = computed(() => sortMode.value === 'date' ? t('Newest') : t('A-Z'))
@@ -342,6 +344,17 @@ async function handleToggleEnabled(skill: HubSkill, enabled: boolean): Promise<v
   } catch (e) {
     showToast(e instanceof Error ? e.message : 'Failed to update skill', 'error')
   }
+}
+
+function handleTrySkill(skill: HubSkill): void {
+  if (!skill.installed || skill.enabled === false) return
+  emit('try-item', {
+    kind: 'skill',
+    name: skill.name,
+    displayName: skill.displayName || skill.name,
+    skillPath: skill.path,
+  })
+  isDetailOpen.value = false
 }
 
 const {

--- a/tests.md
+++ b/tests.md
@@ -3134,12 +3134,15 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 7. Switch to `Apps` and verify app cards load, or the unavailable/empty state appears without breaking the page
 8. On `Apps`, verify the default sort control is `Popular`, app icons render, connected apps show `Manage`, and disconnected apps show `Login`
 9. Click a disconnected app `Login` button and verify it opens the app login/manage URL
-10. Install a plugin whose install response includes `appsNeedingAuth`, and verify the first required app login/manage URL opens automatically
-11. Switch Apps sorting to `A-Z` and verify apps reorder alphabetically; switch to `Date` and verify app-server catalog order is restored; switch back to `Popular` and verify casual-user relevant apps are prioritized and capped to 100 when no search is active
-12. Search Apps and verify matching results are not capped to the Popular top 100 list
-13. Switch to `MCPs` and verify MCP server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
-14. Verify MCPs also support `Popular`, `A-Z`, `Date`, and search
-15. Switch to `Skills` and verify existing Skills Hub search, install, uninstall, sync, and enable/disable behavior still works
+10. Click `Try it!` for a connected app and verify a new thread opens with an auto-submitted prompt asking what the app can do
+11. Open an installed/enabled plugin detail, click `Try it!`, and verify a new thread opens with an auto-submitted plugin test prompt
+12. Open an installed/enabled skill detail, click `Try it!`, and verify a new thread opens with an auto-submitted skill test prompt and the skill attached
+13. Install a plugin whose install response includes `appsNeedingAuth`, and verify the first required app login/manage URL opens automatically
+14. Switch Apps sorting to `A-Z` and verify apps reorder alphabetically; switch to `Date` and verify app-server catalog order is restored; switch back to `Popular` and verify casual-user relevant apps are prioritized and capped to 100 when no search is active
+15. Search Apps and verify matching results are not capped to the Popular top 100 list
+16. Switch to `MCPs` and verify MCP server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
+17. Verify MCPs also support `Popular`, `A-Z`, `Date`, and search
+18. Switch to `Skills` and verify existing Skills Hub search, install, uninstall, sync, and enable/disable behavior still works
 
 #### Expected Results
 - The directory tabs render without a full-page error
@@ -3149,6 +3152,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 - Plugin detail shows bundled MCP login state and can launch MCP OAuth for `notLoggedIn` servers
 - Disconnected apps are labeled `Login`; connected apps are labeled `Manage`
 - Plugin install opens the first required app login/manage page before falling back to bundled MCP OAuth login
+- Connected apps and installed/enabled plugins/skills expose `Try it!`, creating a new chat with an auto-submitted test prompt
 - Plugins, Apps, and MCPs default to local popularity-style ordering because app-server does not expose numeric popularity fields
 - `Date` uses the app-server/catalog order as the available freshness proxy because app/plugin/MCP APIs do not expose created or published timestamps
 - Popular views show only the top 100 when no search is active; search results can show all matches

--- a/tests.md
+++ b/tests.md
@@ -3134,7 +3134,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 7. Switch to `Apps` and verify app cards load, or the unavailable/empty state appears without breaking the page
 8. On `Apps`, verify the default sort control is `Popular`, app icons render, connected apps show `Manage`, and disconnected apps show `Login`
 9. Click a disconnected app `Login` button and verify it opens the app login/manage URL
-10. Click `Try it!` for a connected app and verify a new thread opens with an auto-submitted prompt asking what the app can do
+10. Click `Try it!` for a connected and enabled app and verify a new thread opens with an auto-submitted prompt asking what the app can do
 11. Open an installed/enabled plugin detail, click `Try it!`, and verify a new thread opens with an auto-submitted plugin test prompt
 12. Open an installed/enabled skill detail, click `Try it!`, and verify a new thread opens with an auto-submitted skill test prompt and the skill attached
 13. Install a plugin whose install response includes `appsNeedingAuth`, and verify the first required app login/manage URL opens automatically
@@ -3152,7 +3152,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 - Plugin detail shows bundled MCP login state and can launch MCP OAuth for `notLoggedIn` servers
 - Disconnected apps are labeled `Login`; connected apps are labeled `Manage`
 - Plugin install opens the first required app login/manage page before falling back to bundled MCP OAuth login
-- Connected apps and installed/enabled plugins/skills expose `Try it!`, creating a new chat with an auto-submitted test prompt
+- Connected and enabled apps, plus installed/enabled plugins/skills, expose `Try it!`, creating a new chat with an auto-submitted test prompt
 - Plugins, Apps, and MCPs default to local popularity-style ordering because app-server does not expose numeric popularity fields
 - `Date` uses the app-server/catalog order as the available freshness proxy because app/plugin/MCP APIs do not expose created or published timestamps
 - Popular views show only the top 100 when no search is active; search results can show all matches


### PR DESCRIPTION
## Summary
- Add `Try it!` actions for connected/enabled apps and installed/enabled plugins/skills
- Create a new chat and auto-submit a short capability prompt from each Try action
- Hide app Try actions when the app is disabled

## Verification
- `pnpm run build`
- Playwright verified app Try flow creates a new thread with the submitted prompt
- Playwright verified plugin and skill detail surfaces expose `Try it!`
