### PR TITLE
Fix content header action alignment

### DIFF
--- a/src/components/content/ContentHeader.vue
+++ b/src/components/content/ContentHeader.vue
@@ -28,7 +28,7 @@ defineProps<{
 }
 
 .content-actions {
-  @apply flex shrink-0 items-center justify-end gap-1;
+  @apply ml-auto flex shrink-0 items-center justify-end gap-1;
 }
 
 .content-leading {

--- a/tests.md
+++ b/tests.md
@@ -3242,3 +3242,30 @@ Thread rows now select when clicking anywhere on the highlighted row area (inclu
 
 #### Rollback/Cleanup
 - None
+
+---
+
+### Content header actions remain right aligned
+
+#### Feature/Change Name
+Thread and new-chat header action buttons stay pinned to the right edge while long titles remain constrained and truncated.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. Sidebar collapsed or viewport wide enough to show content header actions
+3. Terminal toggle available in the header
+
+#### Steps
+1. Open `http://127.0.0.1:4173/#/`
+2. Inspect the header row containing `Start new thread`
+3. Verify the terminal toggle is aligned to the far right of the content header, not immediately after the title
+4. Open a thread with a long title and repeat the alignment check
+5. Confirm the title truncates with a tooltip and does not overlap the terminal or branch controls
+
+#### Expected Results
+- Header actions use the available right edge of the content header
+- Long title truncation does not pull action buttons toward the center
+- Terminal and branch controls remain visible and clickable
+
+#### Rollback/Cleanup
+- Remove generated screenshots under `output/playwright/` if they are not needed


### PR DESCRIPTION
## Summary
- Keep content header action buttons pinned to the right edge after long-title truncation changes
- Add manual test coverage for header action alignment

## Validation
- pnpm run test:unit
- pnpm run build:frontend
- Playwright header alignment check on home and thread routes