### PR TITLE
Add integrated terminal with Android fallback

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+side-effects-cache=false
+package-import-method=copy

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "files": [
     "dist/",
     "dist-cli/",
+    "scripts/dev.cjs",
     "scripts/fix-pty-native-build.cjs"
   ],
   "pnpm": {
@@ -45,7 +46,7 @@
     ]
   },
   "scripts": {
-    "dev": "pnpm install && CODEXUI_SANDBOX_MODE=danger-full-access CODEXUI_APPROVAL_POLICY=never vite",
+    "dev": "node scripts/dev.cjs",
     "dev:open": "pnpm run build:cli && sh -c 'pnpm run dev & VPID=$!; node dist-cli/index.js --open-project \"${1:-.}\"; wait $VPID' --",
     "build:frontend": "vue-tsc --noEmit && vite build",
     "build:cli": "tsup",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,25 @@
   },
   "files": [
     "dist/",
-    "dist-cli/"
+    "dist-cli/",
+    "scripts/fix-pty-native-build.cjs"
   ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "esbuild",
+      "node-pty",
+      "node-pty-prebuilt-multiarch",
+      "protobufjs"
+    ]
+  },
   "scripts": {
     "dev": "pnpm install && CODEXUI_SANDBOX_MODE=danger-full-access CODEXUI_APPROVAL_POLICY=never vite",
     "dev:open": "pnpm run build:cli && sh -c 'pnpm run dev & VPID=$!; node dist-cli/index.js --open-project \"${1:-.}\"; wait $VPID' --",
     "build:frontend": "vue-tsc --noEmit && vite build",
     "build:cli": "tsup",
     "build": "pnpm run build:frontend && pnpm run build:cli",
+    "postinstall": "node scripts/fix-pty-native-build.cjs",
     "test:unit": "vitest run",
     "preview": "vite preview",
     "prepublishOnly": "pnpm run build",
@@ -54,6 +65,7 @@
     "firebase": "^12.2.1",
     "highlight.js": "^11.11.1",
     "node-pty": "^1.1.0",
+    "node-pty-prebuilt-multiarch": "0.10.1-pre.5",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"
   },

--- a/publish-android
+++ b/publish-android
@@ -52,13 +52,6 @@ packageJson.bin = {
   ...(packageJson.bin || {}),
   'codexui-android': 'dist-cli/index.js',
 };
-packageJson.bundleDependencies = [
-  'nan',
-  'node-addon-api',
-  'node-pty',
-  'node-pty-prebuilt-multiarch',
-  'prebuild-install',
-];
 packageJson.scripts = {
   ...(packageJson.scripts || {}),
 };
@@ -71,6 +64,29 @@ NODE
   cd "$publish_dir"
   npm install --ignore-scripts --package-lock=false
 )
+
+mkdir -p "$publish_dir/vendor/node_modules"
+for dep in nan node-addon-api node-pty node-pty-prebuilt-multiarch; do
+  cp -R "$publish_dir/node_modules/$dep" "$publish_dir/vendor/node_modules/$dep"
+done
+
+node - "$publish_dir/package.json" <<'NODE'
+const fs = require('node:fs');
+
+const [packageJsonPath] = process.argv.slice(2);
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+for (const dep of ['node-pty', 'node-pty-prebuilt-multiarch']) {
+  delete packageJson.dependencies?.[dep];
+  delete packageJson.optionalDependencies?.[dep];
+  delete packageJson.devDependencies?.[dep];
+}
+delete packageJson.bundleDependencies;
+delete packageJson.bundledDependencies;
+packageJson.files = Array.from(new Set([...(packageJson.files || []), 'vendor/node_modules/']));
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+NODE
 
 echo "Publishing $package_name@$next_version"
 (cd "$publish_dir" && npm publish --access public --ignore-scripts)

--- a/publish-android
+++ b/publish-android
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required" >&2
+  exit 1
+fi
+
+package_name="codexui-android"
+current_version=$(node -p "require('./package.json').version")
+published_version=$(pnpm view "$package_name" dist-tags.latest 2>/dev/null || true)
+
+next_version=$(node -e "
+const parse = (v) => v.split('.').map((n) => Number(n));
+const gt = (a, b) => {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+};
+const current = parse(process.argv[1]);
+const published = process.argv[2] ? parse(process.argv[2]) : [0, 0, 0];
+const base = gt(current, published) ? current : published;
+base[2] += 1;
+console.log(base.join('.'));
+" "$current_version" "$published_version")
+
+pnpm run build
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+publish_dir="$tmp_dir/codexui-android"
+
+rsync -a \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude 'output' \
+  --exclude '.vite' \
+  --exclude 'dist/.vite' \
+  ./ "$publish_dir/"
+
+node - "$publish_dir/package.json" "$package_name" "$next_version" <<'NODE'
+const fs = require('node:fs');
+
+const [packageJsonPath, packageName, nextVersion] = process.argv.slice(2);
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+packageJson.name = packageName;
+packageJson.version = nextVersion;
+packageJson.bin = {
+  ...(packageJson.bin || {}),
+  'codexui-android': 'dist-cli/index.js',
+};
+packageJson.scripts = {
+  ...(packageJson.scripts || {}),
+};
+delete packageJson.scripts.prepublishOnly;
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+NODE
+
+echo "Publishing $package_name@$next_version"
+(cd "$publish_dir" && pnpm publish --access public --no-git-checks)

--- a/publish-android
+++ b/publish-android
@@ -56,26 +56,6 @@ packageJson.scripts = {
   ...(packageJson.scripts || {}),
 };
 delete packageJson.scripts.prepublishOnly;
-
-fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
-NODE
-
-(
-  cd "$publish_dir"
-  npm install --ignore-scripts --package-lock=false
-)
-
-mkdir -p "$publish_dir/vendor/node_modules"
-for dep in nan node-addon-api node-pty node-pty-prebuilt-multiarch; do
-  cp -R "$publish_dir/node_modules/$dep" "$publish_dir/vendor/node_modules/$dep"
-done
-
-node - "$publish_dir/package.json" <<'NODE'
-const fs = require('node:fs');
-
-const [packageJsonPath] = process.argv.slice(2);
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-
 for (const dep of ['node-pty', 'node-pty-prebuilt-multiarch']) {
   delete packageJson.dependencies?.[dep];
   delete packageJson.optionalDependencies?.[dep];
@@ -83,7 +63,7 @@ for (const dep of ['node-pty', 'node-pty-prebuilt-multiarch']) {
 }
 delete packageJson.bundleDependencies;
 delete packageJson.bundledDependencies;
-packageJson.files = Array.from(new Set([...(packageJson.files || []), 'vendor/node_modules/']));
+packageJson.files = (packageJson.files || []).filter((entry) => !entry.startsWith('vendor/'));
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 NODE

--- a/publish-android
+++ b/publish-android
@@ -52,6 +52,13 @@ packageJson.bin = {
   ...(packageJson.bin || {}),
   'codexui-android': 'dist-cli/index.js',
 };
+packageJson.bundleDependencies = [
+  'nan',
+  'node-addon-api',
+  'node-pty',
+  'node-pty-prebuilt-multiarch',
+  'prebuild-install',
+];
 packageJson.scripts = {
   ...(packageJson.scripts || {}),
 };
@@ -59,6 +66,11 @@ delete packageJson.scripts.prepublishOnly;
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 NODE
+
+(
+  cd "$publish_dir"
+  npm install --ignore-scripts --package-lock=false
+)
 
 echo "Publishing $package_name@$next_version"
 (cd "$publish_dir" && pnpm publish --access public --no-git-checks)

--- a/publish-android
+++ b/publish-android
@@ -73,4 +73,4 @@ NODE
 )
 
 echo "Publishing $package_name@$next_version"
-(cd "$publish_dir" && pnpm publish --access public --no-git-checks)
+(cd "$publish_dir" && npm publish --access public --ignore-scripts)

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,0 +1,58 @@
+const { execFileSync, spawnSync } = require('node:child_process')
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+function isAndroidRuntime() {
+  if (process.platform === 'android') return true
+  if (process.env.TERMUX_VERSION) return true
+  if (process.env.PREFIX?.includes('/com.termux/')) return true
+  if (existsSync('/system/build.prop')) return true
+  try {
+    return execFileSync('uname', ['-r'], { encoding: 'utf8' }).toLowerCase().includes('android')
+  } catch {
+    return false
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      CODEXUI_SANDBOX_MODE: process.env.CODEXUI_SANDBOX_MODE || 'danger-full-access',
+      CODEXUI_APPROVAL_POLICY: process.env.CODEXUI_APPROVAL_POLICY || 'never',
+    },
+    ...options,
+  })
+  if (result.error) {
+    throw result.error
+  }
+  process.exit(result.status ?? 1)
+}
+
+const passthroughArgs = process.argv.slice(2)
+
+if (isAndroidRuntime()) {
+  const cliPath = join(process.cwd(), 'dist-cli', 'index.js')
+  if (!existsSync(cliPath)) {
+    run('pnpm', ['run', 'build:cli'])
+  }
+  run('node', [
+    cliPath,
+    '--no-open',
+    '--no-tunnel',
+    '--no-login',
+    '--no-password',
+    ...passthroughArgs,
+  ])
+}
+
+const install = spawnSync('pnpm', ['install'], { stdio: 'inherit', env: process.env })
+if (install.error) {
+  throw install.error
+}
+if (install.status !== 0) {
+  process.exit(install.status ?? 1)
+}
+
+run(join(process.cwd(), 'node_modules', '.bin', process.platform === 'win32' ? 'vite.cmd' : 'vite'), passthroughArgs)

--- a/scripts/fix-pty-native-build.cjs
+++ b/scripts/fix-pty-native-build.cjs
@@ -1,0 +1,62 @@
+const { existsSync, lstatSync, readFileSync, realpathSync, rmSync, writeFileSync } = require('node:fs')
+const { dirname, join } = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const PTY_PACKAGES = [
+  'node-pty-prebuilt-multiarch',
+  'node-pty',
+]
+
+function packageRoot(name) {
+  try {
+    return dirname(require.resolve(`${name}/package.json`))
+  } catch {
+    return null
+  }
+}
+
+function isBrokenSymlink(path) {
+  try {
+    return lstatSync(path).isSymbolicLink() && !existsSync(realpathSync(path))
+  } catch {
+    try {
+      return lstatSync(path).isSymbolicLink() && !existsSync(path)
+    } catch {
+      return false
+    }
+  }
+}
+
+function patchMakefile(makefile) {
+  const source = readFileSync(makefile, 'utf8')
+  const patched = source.replace(
+    /^cmd_copy = ln -f "\$<" "\$@" 2>\/dev\/null \|\| \(rm -rf "\$@" && cp -af "\$<" "\$@"\)$/m,
+    'cmd_copy = rm -rf "$@" && cp -af "$<" "$@"',
+  )
+  if (patched !== source) {
+    writeFileSync(makefile, patched)
+  }
+}
+
+for (const name of PTY_PACKAGES) {
+  const root = packageRoot(name)
+  if (!root) continue
+
+  const buildDir = join(root, 'build')
+  const makefile = join(buildDir, 'Makefile')
+  const binary = join(buildDir, 'Release', 'pty.node')
+  if (!existsSync(makefile) || !isBrokenSymlink(binary)) continue
+
+  try {
+    patchMakefile(makefile)
+    rmSync(binary, { force: true })
+    const result = spawnSync('make', ['BUILDTYPE=Release', '-C', buildDir], {
+      stdio: 'inherit',
+    })
+    if (result.status !== 0) {
+      console.warn(`[postinstall] Failed to repair ${name} native PTY build`)
+    }
+  } catch (error) {
+    console.warn(`[postinstall] Failed to repair ${name} native PTY build: ${error.message}`)
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -866,6 +866,7 @@ import {
   getTelegramConfig,
   getProjectRootSuggestion,
   getTelegramStatus,
+  getThreadTerminalStatus,
   getWorkspaceRootsState,
   listLocalDirectories,
   openProjectRoot,
@@ -1106,6 +1107,7 @@ const threadConversationRef = ref<{ jumpToLatest: () => void } | null>(null)
 const homeTerminalOpen = ref(false)
 const isTerminalInputFocused = ref(false)
 const isTerminalKeyboardFocusFallbackActive = ref(false)
+const isThreadTerminalAvailable = ref(true)
 const trendingProjects = ref<GithubTrendingProject[]>([])
 const isTrendingProjectsLoading = ref(false)
 const githubTipsScope = ref<GithubTipsScope>('trending-daily')
@@ -1271,8 +1273,10 @@ const composerCwd = computed(() => {
   return selectedThread.value?.cwd?.trim() ?? ''
 })
 const canShowTerminalToggle = computed(() => (
-  (isHomeRoute.value && composerCwd.value.length > 0) ||
-  (route.name === 'thread' && selectedThreadId.value.length > 0)
+  isThreadTerminalAvailable.value && (
+    (isHomeRoute.value && composerCwd.value.length > 0) ||
+    (route.name === 'thread' && selectedThreadId.value.length > 0)
+  )
 ))
 const isComposerTerminalOpen = computed(() => (
   isHomeRoute.value ? homeTerminalOpen.value : selectedThreadTerminalOpen.value
@@ -1529,6 +1533,7 @@ onMounted(() => {
   void refreshTelegramConfig()
   void refreshTelegramStatus()
   void loadFreeModeStatus()
+  void refreshThreadTerminalStatus()
   if (showGithubTrendingProjects.value) {
     void loadTrendingProjects()
   }
@@ -2100,6 +2105,7 @@ function onWindowKeyDown(event: KeyboardEvent): void {
 }
 
 function toggleComposerTerminal(): void {
+  if (!isThreadTerminalAvailable.value) return
   if (isHomeRoute.value) {
     if (!composerCwd.value) return
     homeTerminalOpen.value = !homeTerminalOpen.value
@@ -2153,6 +2159,22 @@ function clearTerminalKeyboardFocusFallbackTimer(): void {
   if (!terminalKeyboardFocusFallbackTimer) return
   clearTimeout(terminalKeyboardFocusFallbackTimer)
   terminalKeyboardFocusFallbackTimer = null
+}
+
+async function refreshThreadTerminalStatus(): Promise<void> {
+  try {
+    const status = await getThreadTerminalStatus()
+    isThreadTerminalAvailable.value = status.available
+    if (!status.available) {
+      homeTerminalOpen.value = false
+      if (selectedThreadId.value) {
+        setThreadTerminalOpen(selectedThreadId.value, false)
+      }
+    }
+  } catch {
+    isThreadTerminalAvailable.value = false
+    homeTerminalOpen.value = false
+  }
 }
 
 function onDocumentPointerDown(event: PointerEvent): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3596,28 +3596,13 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   min-height: 0;
 }
 
-.content-root.is-virtual-keyboard-open.is-terminal-open .content-thread,
-.content-root.is-virtual-keyboard-open.is-terminal-open .new-thread-empty {
-  display: none;
-}
-
 .content-root.is-virtual-keyboard-open .composer-with-queue {
   gap: 0.375rem;
   padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
 }
 
-.content-root.is-virtual-keyboard-open.is-terminal-open .composer-with-queue {
-  flex: 1 1 auto;
-  min-height: 0;
-  justify-content: flex-end;
-}
-
 .content-root.is-virtual-keyboard-open .content-thread-terminal-panel {
   min-height: 0;
-}
-
-.content-root.is-virtual-keyboard-open.is-terminal-open .content-thread-terminal-panel {
-  flex: 1 1 auto;
 }
 
 .content-root.is-virtual-keyboard-open .content-keyboard-spacer {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1029,6 +1029,15 @@ export async function attachThreadTerminal(input: ThreadTerminalAttachInput): Pr
   return session
 }
 
+export async function getThreadTerminalStatus(): Promise<{ available: boolean, reason: string | null }> {
+  const payload = await fetchTerminalJson('/codex-api/thread-terminal/status')
+  const record = asRecord(payload)
+  return {
+    available: readBoolean(record?.available) ?? false,
+    reason: readString(record?.reason) || null,
+  }
+}
+
 export async function sendThreadTerminalInput(sessionId: string, data: string): Promise<void> {
   await fetchTerminalJson('/codex-api/thread-terminal/input', {
     method: 'POST',

--- a/src/components/content/ThreadTerminalPanel.vue
+++ b/src/components/content/ThreadTerminalPanel.vue
@@ -674,9 +674,5 @@ function readString(value: unknown): string {
     @apply px-1.5 py-1.5;
   }
 
-  :global(.content-root.is-virtual-keyboard-open.is-terminal-open) .thread-terminal-panel {
-    height: 100%;
-    min-height: 13rem;
-  }
 }
 </style>

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3682,6 +3682,11 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-terminal/status') {
+        setJson(res, 200, terminalManager.getAvailability())
+        return
+      }
+
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/attach') {
         const body = asRecord(await readJsonBody(req))
         const threadId = readNonEmptyString(body?.threadId)

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3688,6 +3688,11 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/attach') {
+        const availability = terminalManager.getAvailability()
+        if (!availability.available) {
+          setJson(res, 503, { error: availability.reason || 'Integrated terminal is unavailable on this host' })
+          return
+        }
         const body = asRecord(await readJsonBody(req))
         const threadId = readNonEmptyString(body?.threadId)
         const cwd = readNonEmptyString(body?.cwd)
@@ -3708,6 +3713,11 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/input') {
+        const availability = terminalManager.getAvailability()
+        if (!availability.available) {
+          setJson(res, 503, { error: availability.reason || 'Integrated terminal is unavailable on this host' })
+          return
+        }
         const body = asRecord(await readJsonBody(req))
         const sessionId = readNonEmptyString(body?.sessionId)
         const data = typeof body?.data === 'string' ? body.data : ''
@@ -3721,6 +3731,11 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/resize') {
+        const availability = terminalManager.getAvailability()
+        if (!availability.available) {
+          setJson(res, 503, { error: availability.reason || 'Integrated terminal is unavailable on this host' })
+          return
+        }
         const body = asRecord(await readJsonBody(req))
         const sessionId = readNonEmptyString(body?.sessionId)
         if (!sessionId) {
@@ -3733,6 +3748,11 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       }
 
       if (req.method === 'POST' && url.pathname === '/codex-api/thread-terminal/close') {
+        const availability = terminalManager.getAvailability()
+        if (!availability.available) {
+          setJson(res, 503, { error: availability.reason || 'Integrated terminal is unavailable on this host' })
+          return
+        }
         const body = asRecord(await readJsonBody(req))
         const sessionId = readNonEmptyString(body?.sessionId)
         if (!sessionId) {

--- a/src/server/terminalManager.test.ts
+++ b/src/server/terminalManager.test.ts
@@ -95,6 +95,19 @@ describe('ThreadTerminalManager edge cases', () => {
     expect(spawnCalls).toHaveLength(0)
   })
 
+  it('reports terminal unavailable instead of failing construction', () => {
+    const manager = new ThreadTerminalManager({
+      spawn: null,
+      shell: '/bin/zsh',
+    })
+
+    expect(manager.getAvailability()).toEqual({
+      available: false,
+      reason: 'Integrated terminal is unavailable on this host',
+    })
+    expect(() => manager.attach({ threadId: 'thread-1', cwd: '/repo' })).toThrow('Integrated terminal is unavailable')
+  })
+
   it('falls back from invalid cwd to home, then process cwd', () => {
     const homeHarness = createHarness({
       exists: (value) => value === '/home/tester',

--- a/src/server/terminalManager.test.ts
+++ b/src/server/terminalManager.test.ts
@@ -131,7 +131,7 @@ describe('ThreadTerminalManager edge cases', () => {
     expect(ptys[0]?.resizes).toEqual([{ cols: 1, rows: 500 }])
   })
 
-  it('normalizes PTY environment for macOS locale and node-pty helper', () => {
+  it('normalizes PTY environment for macOS locale and PTY helper', () => {
     const harness = createHarness()
     const { manager, spawnCalls } = harness
 

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import type { IPty, IPtyForkOptions } from 'node-pty-prebuilt-multiarch'
 
 const TERMINAL_BUFFER_LIMIT = 16 * 1024
@@ -337,24 +338,28 @@ function loadTerminalSpawn(): SpawnTerminal {
 
   if (resolveNodePtyPrebuiltPath()) {
     try {
-      const terminal = require('node-pty-prebuilt-multiarch') as { spawn: SpawnTerminal }
+      const terminal = requirePtyPackage('node-pty-prebuilt-multiarch')
       return terminal.spawn
     } catch {
       // Fall back to maintained node-pty when the legacy prebuild exists but cannot load.
     }
   }
-  const terminal = require('node-pty') as { spawn: SpawnTerminal }
+  const terminal = requirePtyPackage('node-pty')
   return terminal.spawn
 }
 
 function repairNativePtyBuild(packageName: string): void {
   try {
-    const packageJson = require.resolve(`${packageName}/package.json`)
-    const packageRoot = dirname(packageJson)
+    const packageRoot = resolvePtyPackageRoot(packageName)
+    if (!packageRoot) return
     const buildDir = join(packageRoot, 'build')
     const makefile = join(buildDir, 'Makefile')
     const binary = join(buildDir, 'Release', 'pty.node')
-    if (!existsSync(makefile) || !isBrokenSymlink(binary)) return
+    if (!existsSync(binary) && !existsSync(makefile)) {
+      runNodeGypRebuild(packageRoot)
+    }
+    if (existsSync(binary) && !isBrokenSymlink(binary)) return
+    if (!existsSync(makefile)) return
 
     const source = readFileSync(makefile, 'utf8')
     const patched = source.replace(
@@ -369,6 +374,62 @@ function repairNativePtyBuild(packageName: string): void {
   } catch {
     // Native PTY load below will surface the actionable error if repair fails.
   }
+}
+
+function requirePtyPackage(packageName: string): { spawn: SpawnTerminal } {
+  const vendorRoot = resolveVendorPtyPackageRoot(packageName)
+  if (vendorRoot) {
+    try {
+      return require(vendorRoot) as { spawn: SpawnTerminal }
+    } catch {
+      // Prefer the regular dependency if the vendored package is present but unusable.
+    }
+  }
+  return require(packageName) as { spawn: SpawnTerminal }
+}
+
+function resolvePtyPackageRoot(packageName: string): string | null {
+  try {
+    return dirname(require.resolve(`${packageName}/package.json`))
+  } catch {
+    return resolveVendorPtyPackageRoot(packageName)
+  }
+}
+
+function resolveVendorPtyPackageRoot(packageName: string): string | null {
+  try {
+    const moduleDir = dirname(fileURLToPath(import.meta.url))
+    const candidate = join(moduleDir, '..', 'vendor', 'node_modules', packageName)
+    return existsSync(join(candidate, 'package.json')) ? candidate : null
+  } catch {
+    return null
+  }
+}
+
+function runNodeGypRebuild(packageRoot: string): void {
+  const nodeGyp = resolveNodeGypCli()
+  if (!nodeGyp) return
+  spawnSync(process.execPath, [nodeGyp, 'rebuild'], {
+    cwd: packageRoot,
+    stdio: 'ignore',
+  })
+}
+
+function resolveNodeGypCli(): string | null {
+  if (process.env.npm_config_node_gyp && existsSync(process.env.npm_config_node_gyp)) {
+    return process.env.npm_config_node_gyp
+  }
+  try {
+    return require.resolve('node-gyp/bin/node-gyp.js')
+  } catch {
+    // npm commonly vendors node-gyp without exposing it as a regular package.
+  }
+  const npmRoot = spawnSync('npm', ['root', '-g'], { encoding: 'utf8' }).stdout.trim()
+  const candidates = [
+    join(npmRoot, 'node-gyp', 'bin', 'node-gyp.js'),
+    join(npmRoot, 'npm', 'node_modules', 'node-gyp', 'bin', 'node-gyp.js'),
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? null
 }
 
 function isBrokenSymlink(path: string): boolean {
@@ -386,8 +447,8 @@ function isBrokenSymlink(path: string): boolean {
 
 function resolveNodePtyPrebuiltPath(): string | null {
   try {
-    const packageJson = require.resolve('node-pty-prebuilt-multiarch/package.json')
-    const packageRoot = dirname(packageJson)
+    const packageRoot = resolvePtyPackageRoot('node-pty-prebuilt-multiarch')
+    if (!packageRoot) return null
     const builtPath = join(packageRoot, 'build', 'Release', 'pty.node')
     if (existsSync(builtPath)) {
       return builtPath
@@ -405,8 +466,8 @@ function resolveNodePtyPrebuiltPath(): string | null {
 function ensureNodePtyPrebuiltExecutable(): void {
   if (process.platform !== 'darwin' && process.platform !== 'linux') return
   try {
-    const nodePtyEntry = require.resolve('node-pty-prebuilt-multiarch')
-    const packageRoot = join(dirname(nodePtyEntry), '..')
+    const packageRoot = resolvePtyPackageRoot('node-pty-prebuilt-multiarch')
+    if (!packageRoot) return
     const helperPath = join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
     if (existsSync(helperPath)) {
       chmodSync(helperPath, 0o755)

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -4,7 +4,6 @@ import { createRequire } from 'node:module'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
 import type { IPty, IPtyForkOptions } from 'node-pty-prebuilt-multiarch'
 
 const TERMINAL_BUFFER_LIMIT = 16 * 1024
@@ -46,13 +45,18 @@ type SpawnTerminal = (
 ) => TerminalPty
 
 export type TerminalManagerOptions = {
-  spawn?: SpawnTerminal
+  spawn?: SpawnTerminal | null
   exists?: (path: string) => boolean
   homeDir?: () => string
   cwd?: () => string
   platform?: NodeJS.Platform
   shell?: string
   ensureSpawnHelperExecutable?: () => void
+}
+
+export type TerminalAvailability = {
+  available: boolean
+  reason: string | null
 }
 
 export type TerminalAttachParams = {
@@ -68,7 +72,8 @@ export class ThreadTerminalManager {
   private readonly sessions = new Map<string, TerminalSession>()
   private readonly activeSessionIdByThreadId = new Map<string, string>()
   private readonly listeners = new Set<(notification: TerminalNotification) => void>()
-  private readonly spawn: SpawnTerminal
+  private readonly spawn: SpawnTerminal | null
+  private readonly unavailableReason: string | null
   private readonly exists: (path: string) => boolean
   private readonly homeDir: () => string
   private readonly cwd: () => string
@@ -77,7 +82,9 @@ export class ThreadTerminalManager {
   private readonly ensureSpawnHelperExecutable: () => void
 
   constructor(options: TerminalManagerOptions = {}) {
-    this.spawn = options.spawn ?? loadTerminalSpawn()
+    const terminalSpawn = loadOptionalTerminalSpawn(options.spawn)
+    this.spawn = terminalSpawn.spawn
+    this.unavailableReason = terminalSpawn.reason
     this.exists = options.exists ?? existsSync
     this.homeDir = options.homeDir ?? homedir
     this.cwd = options.cwd ?? process.cwd
@@ -93,7 +100,15 @@ export class ThreadTerminalManager {
     }
   }
 
+  getAvailability(): TerminalAvailability {
+    return {
+      available: this.spawn !== null,
+      reason: this.unavailableReason,
+    }
+  }
+
   attach(params: TerminalAttachParams): TerminalSessionSnapshot {
+    this.requireAvailable()
     const threadId = params.threadId.trim()
     if (!threadId) {
       throw new Error('Missing threadId')
@@ -131,6 +146,7 @@ export class ThreadTerminalManager {
   }
 
   write(sessionId: string, data: string): void {
+    this.requireAvailable()
     const session = this.requireSession(sessionId)
     session.pty.write(data)
   }
@@ -195,6 +211,9 @@ export class ThreadTerminalManager {
     delete env.TERMINFO_DIRS
 
     this.ensureSpawnHelperExecutable()
+    if (!this.spawn) {
+      throw new Error(this.unavailableReason || 'Integrated terminal is unavailable on this host')
+    }
     const pty = this.spawn(shell, [], {
       name: TERMINAL_NAME,
       cols: normalizeDimension(params.cols, DEFAULT_COLS),
@@ -294,6 +313,11 @@ export class ThreadTerminalManager {
     return session
   }
 
+  private requireAvailable(): void {
+    if (this.spawn) return
+    throw new Error(this.unavailableReason || 'Integrated terminal is unavailable on this host')
+  }
+
   private resolveShell(): string {
     if (this.shell) return this.shell
     if (this.platform === 'win32') {
@@ -326,6 +350,24 @@ export class ThreadTerminalManager {
   }
 }
 
+function loadOptionalTerminalSpawn(spawn: SpawnTerminal | null | undefined): { spawn: SpawnTerminal | null, reason: string | null } {
+  if (spawn) {
+    return { spawn, reason: null }
+  }
+  if (spawn === null) {
+    return { spawn: null, reason: 'Integrated terminal is unavailable on this host' }
+  }
+  try {
+    return { spawn: loadTerminalSpawn(), reason: null }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      spawn: null,
+      reason: `Integrated terminal is unavailable on this host: ${message}`,
+    }
+  }
+}
+
 function normalizeDimension(value: unknown, fallback: number): number {
   const parsed = typeof value === 'number' ? value : Number(value)
   if (!Number.isFinite(parsed)) return fallback
@@ -338,28 +380,25 @@ function loadTerminalSpawn(): SpawnTerminal {
 
   if (resolveNodePtyPrebuiltPath()) {
     try {
-      const terminal = requirePtyPackage('node-pty-prebuilt-multiarch')
+      const terminal = require('node-pty-prebuilt-multiarch') as { spawn: SpawnTerminal }
       return terminal.spawn
     } catch {
       // Fall back to maintained node-pty when the legacy prebuild exists but cannot load.
     }
   }
-  const terminal = requirePtyPackage('node-pty')
+  const terminal = require('node-pty') as { spawn: SpawnTerminal }
   return terminal.spawn
 }
 
 function repairNativePtyBuild(packageName: string): void {
   try {
-    const packageRoot = resolvePtyPackageRoot(packageName)
-    if (!packageRoot) return
+    const packageJson = require.resolve(`${packageName}/package.json`)
+    const packageRoot = dirname(packageJson)
     const buildDir = join(packageRoot, 'build')
     const makefile = join(buildDir, 'Makefile')
     const binary = join(buildDir, 'Release', 'pty.node')
-    if (!existsSync(binary) && !existsSync(makefile)) {
-      runNodeGypRebuild(packageRoot)
-    }
-    if (existsSync(binary) && !isBrokenSymlink(binary)) return
     if (!existsSync(makefile)) return
+    if (!isBrokenSymlink(binary)) return
 
     const source = readFileSync(makefile, 'utf8')
     const patched = source.replace(
@@ -374,62 +413,6 @@ function repairNativePtyBuild(packageName: string): void {
   } catch {
     // Native PTY load below will surface the actionable error if repair fails.
   }
-}
-
-function requirePtyPackage(packageName: string): { spawn: SpawnTerminal } {
-  const vendorRoot = resolveVendorPtyPackageRoot(packageName)
-  if (vendorRoot) {
-    try {
-      return require(vendorRoot) as { spawn: SpawnTerminal }
-    } catch {
-      // Prefer the regular dependency if the vendored package is present but unusable.
-    }
-  }
-  return require(packageName) as { spawn: SpawnTerminal }
-}
-
-function resolvePtyPackageRoot(packageName: string): string | null {
-  try {
-    return dirname(require.resolve(`${packageName}/package.json`))
-  } catch {
-    return resolveVendorPtyPackageRoot(packageName)
-  }
-}
-
-function resolveVendorPtyPackageRoot(packageName: string): string | null {
-  try {
-    const moduleDir = dirname(fileURLToPath(import.meta.url))
-    const candidate = join(moduleDir, '..', 'vendor', 'node_modules', packageName)
-    return existsSync(join(candidate, 'package.json')) ? candidate : null
-  } catch {
-    return null
-  }
-}
-
-function runNodeGypRebuild(packageRoot: string): void {
-  const nodeGyp = resolveNodeGypCli()
-  if (!nodeGyp) return
-  spawnSync(process.execPath, [nodeGyp, 'rebuild'], {
-    cwd: packageRoot,
-    stdio: 'ignore',
-  })
-}
-
-function resolveNodeGypCli(): string | null {
-  if (process.env.npm_config_node_gyp && existsSync(process.env.npm_config_node_gyp)) {
-    return process.env.npm_config_node_gyp
-  }
-  try {
-    return require.resolve('node-gyp/bin/node-gyp.js')
-  } catch {
-    // npm commonly vendors node-gyp without exposing it as a regular package.
-  }
-  const npmRoot = spawnSync('npm', ['root', '-g'], { encoding: 'utf8' }).stdout.trim()
-  const candidates = [
-    join(npmRoot, 'node-gyp', 'bin', 'node-gyp.js'),
-    join(npmRoot, 'npm', 'node_modules', 'node-gyp', 'bin', 'node-gyp.js'),
-  ]
-  return candidates.find((candidate) => existsSync(candidate)) ?? null
 }
 
 function isBrokenSymlink(path: string): boolean {
@@ -447,8 +430,8 @@ function isBrokenSymlink(path: string): boolean {
 
 function resolveNodePtyPrebuiltPath(): string | null {
   try {
-    const packageRoot = resolvePtyPackageRoot('node-pty-prebuilt-multiarch')
-    if (!packageRoot) return null
+    const packageJson = require.resolve('node-pty-prebuilt-multiarch/package.json')
+    const packageRoot = dirname(packageJson)
     const builtPath = join(packageRoot, 'build', 'Release', 'pty.node')
     if (existsSync(builtPath)) {
       return builtPath
@@ -466,8 +449,8 @@ function resolveNodePtyPrebuiltPath(): string | null {
 function ensureNodePtyPrebuiltExecutable(): void {
   if (process.platform !== 'darwin' && process.platform !== 'linux') return
   try {
-    const packageRoot = resolvePtyPackageRoot('node-pty-prebuilt-multiarch')
-    if (!packageRoot) return
+    const nodePtyEntry = require.resolve('node-pty-prebuilt-multiarch')
+    const packageRoot = join(dirname(nodePtyEntry), '..')
     const helperPath = join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
     if (existsSync(helperPath)) {
       chmodSync(helperPath, 0o755)

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -1,8 +1,9 @@
-import { chmodSync, existsSync } from 'node:fs'
+import { chmodSync, existsSync, lstatSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
+import { spawnSync } from 'node:child_process'
 import type { IPty, IPtyForkOptions } from 'node-pty-prebuilt-multiarch'
 
 const TERMINAL_BUFFER_LIMIT = 16 * 1024
@@ -331,6 +332,9 @@ function normalizeDimension(value: unknown, fallback: number): number {
 }
 
 function loadTerminalSpawn(): SpawnTerminal {
+  repairNativePtyBuild('node-pty-prebuilt-multiarch')
+  repairNativePtyBuild('node-pty')
+
   if (resolveNodePtyPrebuiltPath()) {
     try {
       const terminal = require('node-pty-prebuilt-multiarch') as { spawn: SpawnTerminal }
@@ -341,6 +345,43 @@ function loadTerminalSpawn(): SpawnTerminal {
   }
   const terminal = require('node-pty') as { spawn: SpawnTerminal }
   return terminal.spawn
+}
+
+function repairNativePtyBuild(packageName: string): void {
+  try {
+    const packageJson = require.resolve(`${packageName}/package.json`)
+    const packageRoot = dirname(packageJson)
+    const buildDir = join(packageRoot, 'build')
+    const makefile = join(buildDir, 'Makefile')
+    const binary = join(buildDir, 'Release', 'pty.node')
+    if (!existsSync(makefile) || !isBrokenSymlink(binary)) return
+
+    const source = readFileSync(makefile, 'utf8')
+    const patched = source.replace(
+      /^cmd_copy = ln -f "\$<" "\$@" 2>\/dev\/null \|\| \(rm -rf "\$@" && cp -af "\$<" "\$@"\)$/m,
+      'cmd_copy = rm -rf "$@" && cp -af "$<" "$@"',
+    )
+    if (patched !== source) {
+      writeFileSync(makefile, patched)
+    }
+    rmSync(binary, { force: true })
+    spawnSync('make', ['BUILDTYPE=Release', '-C', buildDir], { stdio: 'ignore' })
+  } catch {
+    // Native PTY load below will surface the actionable error if repair fails.
+  }
+}
+
+function isBrokenSymlink(path: string): boolean {
+  try {
+    if (!lstatSync(path).isSymbolicLink()) return false
+    try {
+      return !existsSync(realpathSync(path))
+    } catch {
+      return true
+    }
+  } catch {
+    return false
+  }
 }
 
 function resolveNodePtyPrebuiltPath(): string | null {

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -361,11 +361,19 @@ function loadOptionalTerminalSpawn(spawn: SpawnTerminal | null | undefined): { s
     return { spawn: loadTerminalSpawn(), reason: null }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    const suffix = message.includes('Cannot find module')
+      ? 'Native PTY support is not installed.'
+      : sanitizeUnavailableReason(message)
     return {
       spawn: null,
-      reason: `Integrated terminal is unavailable on this host: ${message}`,
+      reason: `Integrated terminal is unavailable on this host. ${suffix}`,
     }
   }
+}
+
+function sanitizeUnavailableReason(message: string): string {
+  const firstLine = message.split('\n')[0]?.trim() || ''
+  return firstLine ? firstLine : 'Native PTY support could not be loaded.'
 }
 
 function normalizeDimension(value: unknown, fallback: number): number {

--- a/src/server/terminalManager.ts
+++ b/src/server/terminalManager.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
-import { spawn as spawnPty, type IPty, type IPtyForkOptions } from 'node-pty'
+import type { IPty, IPtyForkOptions } from 'node-pty-prebuilt-multiarch'
 
 const TERMINAL_BUFFER_LIMIT = 16 * 1024
 const DEFAULT_COLS = 80
@@ -75,13 +75,13 @@ export class ThreadTerminalManager {
   private readonly ensureSpawnHelperExecutable: () => void
 
   constructor(options: TerminalManagerOptions = {}) {
-    this.spawn = options.spawn ?? spawnPty
+    this.spawn = options.spawn ?? loadTerminalSpawn()
     this.exists = options.exists ?? existsSync
     this.homeDir = options.homeDir ?? homedir
     this.cwd = options.cwd ?? process.cwd
     this.platform = options.platform ?? process.platform
     this.shell = options.shell ?? null
-    this.ensureSpawnHelperExecutable = options.ensureSpawnHelperExecutable ?? ensureNodePtySpawnHelperExecutable
+    this.ensureSpawnHelperExecutable = options.ensureSpawnHelperExecutable ?? ensureNodePtyPrebuiltExecutable
   }
 
   subscribe(listener: (notification: TerminalNotification) => void): () => void {
@@ -188,7 +188,7 @@ export class ThreadTerminalManager {
       ...process.env,
       TERM: TERMINAL_NAME,
     } as Record<string, string>
-    normalizeLocaleEnv(env)
+    normalizeLocaleEnv(env, this.platform)
     delete env.TERMINFO
     delete env.TERMINFO_DIRS
 
@@ -330,22 +330,53 @@ function normalizeDimension(value: unknown, fallback: number): number {
   return Math.max(1, Math.min(500, Math.trunc(parsed)))
 }
 
-function ensureNodePtySpawnHelperExecutable(): void {
+function loadTerminalSpawn(): SpawnTerminal {
+  if (resolveNodePtyPrebuiltPath()) {
+    try {
+      const terminal = require('node-pty-prebuilt-multiarch') as { spawn: SpawnTerminal }
+      return terminal.spawn
+    } catch {
+      // Fall back to maintained node-pty when the legacy prebuild exists but cannot load.
+    }
+  }
+  const terminal = require('node-pty') as { spawn: SpawnTerminal }
+  return terminal.spawn
+}
+
+function resolveNodePtyPrebuiltPath(): string | null {
+  try {
+    const packageJson = require.resolve('node-pty-prebuilt-multiarch/package.json')
+    const packageRoot = dirname(packageJson)
+    const builtPath = join(packageRoot, 'build', 'Release', 'pty.node')
+    if (existsSync(builtPath)) {
+      return builtPath
+    }
+    const runtime = Object.prototype.hasOwnProperty.call(process.versions, 'electron') ? 'electron' : 'node'
+    const libc = process.platform === 'linux' && existsSync('/etc/alpine-release') ? '.musl' : ''
+    const binaryName = `${runtime}.abi${process.versions.modules}${libc}.node`
+    const binaryPath = join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, binaryName)
+    return existsSync(binaryPath) ? binaryPath : null
+  } catch {
+    return null
+  }
+}
+
+function ensureNodePtyPrebuiltExecutable(): void {
   if (process.platform !== 'darwin' && process.platform !== 'linux') return
   try {
-    const nodePtyEntry = require.resolve('node-pty')
+    const nodePtyEntry = require.resolve('node-pty-prebuilt-multiarch')
     const packageRoot = join(dirname(nodePtyEntry), '..')
     const helperPath = join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
     if (existsSync(helperPath)) {
       chmodSync(helperPath, 0o755)
     }
   } catch {
-    // If node-pty changes layout, let node-pty surface its own spawn error.
+    // If the PTY package changes layout, let it surface its own spawn error.
   }
 }
 
-function normalizeLocaleEnv(env: Record<string, string>): void {
-  const locale = process.platform === 'darwin' ? 'en_US.UTF-8' : 'C.UTF-8'
+function normalizeLocaleEnv(env: Record<string, string>, platform: NodeJS.Platform): void {
+  const locale = platform === 'darwin' ? 'en_US.UTF-8' : 'C.UTF-8'
   env.LANG = locale
   env.LC_ALL = locale
   env.LC_CTYPE = locale

--- a/tests.md
+++ b/tests.md
@@ -1556,6 +1556,26 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Stop running dev servers and unset temporary env overrides.
 
+### Feature: npm run dev uses CLI server on Android
+
+#### Prerequisites
+- Android SSH helper exists and is executable: `/Users/igor/Git-projects/codex-web-local-android/andClaw/ssh.sh`.
+- Dependencies are installed on the Android clone.
+
+#### Steps
+1. On Android, run `npm run dev -- --port 4173`.
+2. Confirm startup logs show `Codex Web Local is running!`.
+3. In a second Android shell, run `curl -fsS http://127.0.0.1:4173/ | head -5`.
+4. Stop the dev server.
+
+#### Expected Results
+- Android starts `node dist-cli/index.js`, not raw Vite.
+- The server binds successfully and returns the app HTML.
+- The Vite `uv_interface_addresses` Android error does not occur.
+
+#### Rollback/Cleanup
+- Stop the Android dev server.
+
 ### Feature: Approval request uses legacy in-conversation request card only
 
 #### Prerequisites

--- a/tests.md
+++ b/tests.md
@@ -3289,3 +3289,31 @@ Thread and new-chat header action buttons stay pinned to the right edge while lo
 
 #### Rollback/Cleanup
 - Remove generated screenshots under `output/playwright/` if they are not needed
+
+---
+
+### Terminal focus does not fullscreen panel
+
+#### Feature/Change Name
+Terminal focus on mobile keeps the terminal as a bottom panel instead of expanding it to full screen.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. A thread or new-chat project with the terminal toggle available
+3. Mobile viewport or Android device browser
+
+#### Steps
+1. Open a thread or new chat with a valid project path
+2. Tap the terminal toggle
+3. Tap inside the terminal area
+4. If the virtual keyboard appears, keep focus in the terminal
+5. Hide and reopen the terminal
+
+#### Expected Results
+- Terminal remains a bottom panel and does not take over the full viewport
+- Conversation/new-chat content is not forcibly hidden by terminal focus
+- Composer keeps its normal compact placement instead of stretching above the terminal
+- Terminal can still fit within the available viewport when the keyboard changes size
+
+#### Rollback/Cleanup
+- Close the terminal panel


### PR DESCRIPTION
## Summary
- add integrated terminal support and Android dev/publish handling
- keep Android npx startup working by disabling terminal when native PTY is unavailable
- prevent terminal focus from fullscreening the panel

## Tests
- pnpm run test:unit
- pnpm run build
- Android npx smoke via andClaw/ssh.sh for codexui-android@0.1.97