### PR TITLE
Group plugin skills under root labels

### DIFF
--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -2694,10 +2694,44 @@ export async function generateThreadTitle(prompt: string, cwd: string | null): P
 
 export type SkillInfo = {
   name: string
+  displayName?: string
   description: string
   path: string
   scope: string
   enabled: boolean
+}
+
+function normalizeSkillMarkdownPath(skillPath: string): string {
+  if (!skillPath) return ''
+  return skillPath.endsWith('/SKILL.md') ? skillPath : `${skillPath}/SKILL.md`
+}
+
+function deriveGroupedSkillRoot(
+  skillPath: string,
+  knownPaths: Set<string>,
+): { rootPath: string; rootName: string; isNested: boolean } | null {
+  const normalizedPath = normalizeSkillMarkdownPath(skillPath)
+  const parts = normalizedPath.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+
+  const pluginSkillsIndex = parts.lastIndexOf('skills')
+  if (pluginSkillsIndex >= 2) {
+    const pluginName = parts[pluginSkillsIndex - 2] ?? ''
+    if (pluginName) {
+      const pluginRootPath = `/${[...parts.slice(0, pluginSkillsIndex + 1), pluginName, 'SKILL.md'].join('/')}`
+      if (knownPaths.has(pluginRootPath)) {
+        return { rootPath: pluginRootPath, rootName: pluginName, isNested: pluginRootPath !== normalizedPath }
+      }
+    }
+  }
+
+  const firstSkillsIndex = parts.indexOf('skills')
+  if (firstSkillsIndex < 0 || firstSkillsIndex + 1 >= parts.length - 1) return null
+  const rootName = parts[firstSkillsIndex + 1] ?? ''
+  if (!rootName) return null
+  const rootPath = `/${[...parts.slice(0, firstSkillsIndex + 2), 'SKILL.md'].join('/')}`
+  if (!knownPaths.has(rootPath)) return { rootPath, rootName, isNested: rootPath !== normalizedPath }
+  return { rootPath, rootName, isNested: rootPath !== normalizedPath }
 }
 
 type SkillsListResponseEntry = {
@@ -2718,22 +2752,45 @@ export async function getSkillsList(cwds?: string[]): Promise<SkillInfo[]> {
     const params: Record<string, unknown> = {}
     if (cwds && cwds.length > 0) params.cwds = cwds
     const payload = await callRpc<{ data: SkillsListResponseEntry[] }>('skills/list', params)
-    const skills: SkillInfo[] = []
-    const seen = new Set<string>()
+    const allSkills = payload.data.flatMap((entry) => entry.skills)
+    const pathSet = new Set(allSkills.map((skill) => normalizeSkillMarkdownPath(skill.path)).filter(Boolean))
+    const grouped = new Map<string, SkillInfo & { __hasRoot: boolean }>()
     for (const entry of payload.data) {
       for (const skill of entry.skills) {
-        if (!skill.name || seen.has(skill.path)) continue
-        seen.add(skill.path)
-        skills.push({
+        if (!skill.name) continue
+        const groupInfo = deriveGroupedSkillRoot(skill.path, pathSet)
+        const normalizedPath = normalizeSkillMarkdownPath(skill.path)
+        const shouldCollapseIntoRoot = Boolean(groupInfo?.isNested && pathSet.has(groupInfo.rootPath))
+        const key = shouldCollapseIntoRoot ? groupInfo!.rootPath : normalizedPath
+        const isRoot = normalizedPath === key
+        const existing = grouped.get(key)
+        const candidate: SkillInfo & { __hasRoot: boolean } = {
           name: skill.name,
+          displayName: groupInfo && key === groupInfo.rootPath ? groupInfo.rootName : undefined,
           description: skill.shortDescription || skill.description || '',
-          path: skill.path,
+          path: key,
           scope: skill.scope,
           enabled: skill.enabled,
-        })
+          __hasRoot: isRoot,
+        }
+        if (!existing) {
+          grouped.set(key, candidate)
+          continue
+        }
+        existing.enabled = existing.enabled || skill.enabled
+        if (!existing.__hasRoot && isRoot) {
+          grouped.set(key, candidate)
+          continue
+        }
+        if (!existing.displayName && candidate.displayName) {
+          existing.displayName = candidate.displayName
+        }
+        if (!existing.description && candidate.description) {
+          existing.description = candidate.description
+        }
       }
     }
-    return skills
+    return Array.from(grouped.values()).map(({ __hasRoot: _ignored, ...skill }) => skill)
   } catch {
     return []
   }

--- a/src/components/content/ComposerSkillPicker.vue
+++ b/src/components/content/ComposerSkillPicker.vue
@@ -22,7 +22,7 @@
           @click="$emit('select', skill)"
           @pointerenter="highlightIndex = idx"
         >
-          <span class="skill-picker-name">{{ skill.name }}</span>
+          <span class="skill-picker-name">{{ skill.displayName || skill.name }}</span>
           <span v-if="skill.description" class="skill-picker-desc">{{ skill.description }}</span>
         </button>
       </li>
@@ -37,6 +37,7 @@ import { useUiLanguage } from '../../composables/useUiLanguage'
 
 export type SkillOption = {
   name: string
+  displayName?: string
   description: string
   path: string
 }
@@ -63,7 +64,10 @@ const filtered = computed(() => {
   const q = query.value.toLowerCase().trim()
   if (!q) return props.skills
   return props.skills.filter(
-    (s) => s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q),
+    (s) =>
+      s.name.toLowerCase().includes(q)
+      || (s.displayName ?? '').toLowerCase().includes(q)
+      || s.description.toLowerCase().includes(q),
   )
 })
 

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -64,11 +64,11 @@
 
       <div v-if="selectedSkills.length > 0" class="thread-composer-skill-chips">
         <span v-for="skill in selectedSkills" :key="skill.path" class="thread-composer-skill-chip">
-          <span class="thread-composer-skill-chip-name">{{ skill.name }}</span>
+          <span class="thread-composer-skill-chip-name">{{ skill.displayName || skill.name }}</span>
           <button
             class="thread-composer-skill-chip-remove"
             type="button"
-            :aria-label="`Remove skill ${skill.name}`"
+            :aria-label="`Remove skill ${skill.displayName || skill.name}`"
             @click="removeSkill(skill.path)"
           >×</button>
         </span>
@@ -395,7 +395,7 @@ import ComposerDropdown from './ComposerDropdown.vue'
 import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
 import ComposerSkillPicker from './ComposerSkillPicker.vue'
 
-type SkillItem = { name: string; description: string; path: string }
+type SkillItem = { name: string; displayName?: string; description: string; path: string }
 
 const props = defineProps<{
   activeThreadId: string
@@ -928,7 +928,7 @@ function replaceDraftState(payload: ComposerDraftPayload): void {
   }))
   selectedSkills.value = payload.skills.map((skill) => (
     (props.skills ?? []).find((item) => item.path === skill.path)
-    ?? { name: skill.name, description: '', path: skill.path }
+    ?? { name: skill.name, displayName: undefined, description: '', path: skill.path }
   ))
   fileAttachments.value = payload.fileAttachments.map((attachment) => ({ ...attachment }))
   folderUploadGroups.value = []

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -50,6 +50,65 @@ function getCodexHomeDir(): string {
   return codexHome && codexHome.length > 0 ? codexHome : join(homedir(), '.codex')
 }
 
+function splitAbsolutePath(pathValue: string): string[] {
+  return pathValue.split('/').filter(Boolean)
+}
+
+function buildAbsolutePath(parts: string[]): string {
+  return `/${parts.join('/')}`
+}
+
+function normalizeSkillMarkdownPath(skillPath: string): string {
+  if (!skillPath) return ''
+  return skillPath.endsWith('/SKILL.md') ? skillPath : `${skillPath}/SKILL.md`
+}
+
+function deriveSkillPathInfo(
+  skillPath: string,
+  knownPaths: Set<string> = new Set(),
+): {
+  normalizedPath: string
+  rootSkillPath: string
+  rootSkillName: string
+  installDir: string
+  isNestedSkill: boolean
+} | null {
+  const normalizedPath = normalizeSkillMarkdownPath(skillPath)
+  const parts = splitAbsolutePath(normalizedPath)
+  if (parts.length < 2) return null
+
+  const pluginSkillsIndex = parts.lastIndexOf('skills')
+  if (pluginSkillsIndex >= 2) {
+    const pluginName = parts[pluginSkillsIndex - 2] ?? ''
+    if (pluginName) {
+      const rootSkillPath = buildAbsolutePath([...parts.slice(0, pluginSkillsIndex + 1), pluginName, 'SKILL.md'])
+      if (knownPaths.has(rootSkillPath)) {
+        return {
+          normalizedPath,
+          rootSkillPath,
+          rootSkillName: pluginName,
+          installDir: buildAbsolutePath(parts.slice(0, pluginSkillsIndex + 1)),
+          isNestedSkill: normalizedPath !== rootSkillPath,
+        }
+      }
+    }
+  }
+
+  const firstSkillsIndex = parts.indexOf('skills')
+  if (firstSkillsIndex < 0 || firstSkillsIndex + 1 >= parts.length - 1) return null
+  const rootSkillName = parts[firstSkillsIndex + 1] ?? ''
+  if (!rootSkillName) return null
+  const rootParts = parts.slice(0, firstSkillsIndex + 2)
+  const installDirParts = parts.slice(0, firstSkillsIndex + 1)
+  return {
+    normalizedPath,
+    rootSkillPath: buildAbsolutePath([...rootParts, 'SKILL.md']),
+    rootSkillName,
+    installDir: buildAbsolutePath(installDirParts),
+    isNestedSkill: normalizedPath !== buildAbsolutePath([...rootParts, 'SKILL.md']),
+  }
+}
+
 function getSkillsInstallDir(): string {
   return join(getCodexHomeDir(), 'skills')
 }
@@ -154,9 +213,9 @@ async function detectUserSkillsDir(appServer: AppServerLike): Promise<string> {
     for (const entry of result.data ?? []) {
       for (const skill of entry.skills ?? []) {
         if (skill.scope !== 'user' || !skill.path) continue
-        const parts = skill.path.split('/').filter(Boolean)
-        if (parts.length < 2) continue
-        return `/${parts.slice(0, -2).join('/')}`
+        const skillInfo = deriveSkillPathInfo(skill.path)
+        if (!skillInfo) continue
+        return skillInfo.installDir
       }
     }
   } catch {}
@@ -298,6 +357,78 @@ function buildHubEntry(e: SkillsTreeEntry): SkillHubEntry {
     url: e.url,
     installed: false,
   }
+}
+
+type RpcSkillRecord = {
+  name?: string
+  description?: string
+  shortDescription?: string
+  path?: string
+  scope?: string
+  enabled?: boolean
+}
+
+function groupRpcSkillRecords<T extends RpcSkillRecord>(skills: T[]): T[] {
+  const normalizedPathSet = new Set(
+    skills
+      .map((skill) => normalizeSkillMarkdownPath(typeof skill.path === 'string' ? skill.path : ''))
+      .filter(Boolean),
+  )
+  const grouped = new Map<string, { preferred: T; hasRoot: boolean; anyEnabled: boolean }>()
+
+  for (const skill of skills) {
+    const rawPath = typeof skill.path === 'string' ? skill.path : ''
+    const pathInfo = rawPath ? deriveSkillPathInfo(rawPath, normalizedPathSet) : null
+    const groupingKey = pathInfo && pathInfo.isNestedSkill && normalizedPathSet.has(pathInfo.rootSkillPath)
+      ? pathInfo.rootSkillPath
+      : (pathInfo?.normalizedPath || rawPath || `${skill.scope ?? ''}:${skill.name ?? ''}`)
+    const existing = grouped.get(groupingKey)
+    const isRootEntry = pathInfo?.normalizedPath === groupingKey
+    const groupedName = pathInfo && groupingKey === pathInfo.rootSkillPath
+      ? pathInfo.rootSkillName
+      : skill.name
+
+    if (!existing) {
+      grouped.set(groupingKey, {
+        preferred: isRootEntry
+          ? {
+              ...skill,
+              name: groupedName,
+              path: groupingKey,
+            }
+          : {
+              ...skill,
+              name: groupedName,
+              path: groupingKey,
+            },
+        hasRoot: isRootEntry,
+        anyEnabled: skill.enabled !== false,
+      })
+      continue
+    }
+
+    existing.anyEnabled = existing.anyEnabled || skill.enabled !== false
+    if (!existing.hasRoot && isRootEntry) {
+      existing.preferred = {
+        ...skill,
+        name: groupedName,
+        path: groupingKey,
+      }
+      existing.hasRoot = true
+      continue
+    }
+    if (!existing.preferred.description && skill.description) {
+      existing.preferred = { ...existing.preferred, description: skill.description }
+    }
+    if (!existing.preferred.shortDescription && skill.shortDescription) {
+      existing.preferred = { ...existing.preferred, shortDescription: skill.shortDescription }
+    }
+  }
+
+  return Array.from(grouped.values()).map(({ preferred, anyEnabled }) => ({
+    ...preferred,
+    enabled: preferred.enabled ?? anyEnabled,
+  }))
 }
 
 type InstalledSkillInfo = { name: string; path: string; enabled: boolean }
@@ -949,14 +1080,16 @@ async function collectLocalSyncedSkills(appServer: AppServerLike): Promise<Synce
     }
   }
 
-  const skills = (await appServer.rpc('skills/list', {})) as { data?: Array<{ skills?: Array<{ name?: string; enabled?: boolean }> }> }
+  const skills = (await appServer.rpc('skills/list', {})) as {
+    data?: Array<{ skills?: Array<{ name?: string; enabled?: boolean; path?: string; scope?: string }> }>
+  }
   const seen = new Set<string>()
   const synced: SyncedSkill[] = []
   let ownersChanged = false
   for (const entry of skills.data ?? []) {
-    for (const skill of entry.skills ?? []) {
+    for (const skill of groupRpcSkillRecords(entry.skills ?? [])) {
       const name = typeof skill.name === 'string' ? skill.name : ''
-      if (!name || seen.has(name)) continue
+      if (!name || skill.scope !== 'user' || seen.has(name)) continue
       seen.add(name)
       let owner = owners[name]
       if (!owner) {
@@ -1148,9 +1281,11 @@ export async function handleSkillsRoutes(
 
       const installedMap = await scanInstalledSkillsFromDisk()
       try {
-        const result = (await appServer.rpc('skills/list', {})) as { data?: Array<{ skills?: Array<{ name?: string; path?: string; enabled?: boolean }> }> }
+        const result = (await appServer.rpc('skills/list', {})) as {
+          data?: Array<{ skills?: Array<{ name?: string; path?: string; enabled?: boolean }> }>
+        }
         for (const entry of result.data ?? []) {
-          for (const skill of entry.skills ?? []) {
+          for (const skill of groupRpcSkillRecords(entry.skills ?? [])) {
             if (skill.name) {
               installedMap.set(skill.name, { name: skill.name, path: skill.path ?? '', enabled: skill.enabled !== false })
             }

--- a/tests.md
+++ b/tests.md
@@ -3319,3 +3319,31 @@ Terminal focus on mobile keeps the terminal as a bottom panel instead of expandi
 
 #### Rollback/Cleanup
 - Close the terminal panel
+
+---
+
+### Feature: Nested skill bundles are grouped in discovery
+
+#### Feature/Change Name
+Composer skill discovery collapses nested `skills/<subskill>/SKILL.md` entries under their top-level bundle skill when the bundle root skill is also present, including curated plugin skill packs such as `cloudflare:*`.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Open a thread whose cwd can access installed skills
+3. At least one installed skill bundle or curated plugin pack contains a top-level/root `SKILL.md` plus additional subskills
+
+#### Steps
+1. Open the thread composer skill picker
+2. Search for a grouped bundle or plugin root such as `cloudflare`
+3. Confirm the grouped root appears once in the picker
+4. Search for one nested subskill or prefixed plugin skill name such as `agents-sdk` or `cloudflare:workers-best-practices`
+5. Refresh the page or switch threads and reopen the skill picker
+
+#### Expected Results
+- The picker shows a single top-level entry for the bundled skill or plugin root
+- Nested subskill folder names and plugin-prefixed variants do not appear as separate skill discovery entries when the parent/root entry exists
+- Grouped plugin roots render a clean label such as `cloudflare` instead of `cloudflare:cloudflare`
+- The grouped result remains stable after refresh or thread switching
+
+#### Rollback/Cleanup
+- None


### PR DESCRIPTION
## Summary
- group nested skill bundles and curated plugin skill packs under a single root entry
- preserve executable skill identifiers while rendering clean grouped labels like cloudflare
- update manual test coverage for grouped skill discovery

## Verification
- pnpm run build:frontend
- Playwright screenshots for the Skills tab desktop/mobile
