### PR TITLE
Add token-based theme system

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,61 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#020617" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Codex Web" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/icons/codexui-icon.svg" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icons/pwa-192x192.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
     <title>Codex Web</title>
+    <script>
+      (() => {
+        const appearanceKey = 'codex-web-local.dark-mode.v1'
+        const themeKey = 'codex-web-local.theme-id.v1'
+        const readStorage = (key) => {
+          try {
+            return window.localStorage.getItem(key)
+          } catch {
+            return null
+          }
+        }
+        const storedAppearance = readStorage(appearanceKey)
+        const storedTheme = readStorage(themeKey)
+        const appearance = storedAppearance === 'light' || storedAppearance === 'dark' || storedAppearance === 'system'
+          ? storedAppearance
+          : 'system'
+        const theme = storedTheme === 'graphite' || storedTheme === 'macos' ? storedTheme : 'default'
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        const themeMetaColors = {
+          default: { light: '#f1f5f9', dark: '#18181b' },
+          graphite: { light: '#eef2f7', dark: '#111827' },
+          macos: { light: '#f5f5f7', dark: '#1c1c1e' },
+        }
+        const effectiveAppearance = appearance === 'system'
+          ? (prefersDark ? 'dark' : 'light')
+          : appearance
+        const themeColor = themeMetaColors[theme]?.[effectiveAppearance] ?? themeMetaColors.default.light
+
+        document.documentElement.dataset.theme = theme
+        document.documentElement.dataset.appearance = effectiveAppearance
+        document.documentElement.classList.toggle('dark', effectiveAppearance === 'dark')
+
+        const themeColorMeta = document.querySelector('meta[name="theme-color"]')
+        if (themeColorMeta) {
+          themeColorMeta.setAttribute('content', themeColor)
+        }
+
+        const statusBarMeta = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]')
+        if (statusBarMeta) {
+          statusBarMeta.setAttribute('content', effectiveAppearance === 'dark' ? 'black-translucent' : 'default')
+        }
+      })()
+    </script>
   </head>
-  <body class="bg-slate-950">
+  <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "playwright": "^1.59.1",
     "tailwindcss": "^4.1.18",
+    "tailwindcss-uikit-colors": "^1.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -191,6 +191,10 @@
                   <option v-for="option in uiLanguageOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
                 </select>
               </div>
+              <button class="sidebar-settings-row" type="button" :title="SETTINGS_HELP.theme" @click="cycleTheme">
+                <span class="sidebar-settings-label">{{ t('Theme') }}</span>
+                <span class="sidebar-settings-value">{{ currentThemeLabel }}</span>
+              </button>
               <button class="sidebar-settings-row" type="button" :title="SETTINGS_HELP.chatWidth" @click="cycleChatWidth">
                 <span class="sidebar-settings-label">{{ t('Chat width') }}</span>
                 <span class="sidebar-settings-value">{{ chatWidthLabel }}</span>
@@ -204,7 +208,7 @@
                 <span class="sidebar-settings-toggle" :class="{ 'is-on': dictationAutoSend }" />
               </button>
 
-              <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the API provider for the Codex backend')">
+              <div class="sidebar-settings-row sidebar-settings-row--select sidebar-settings-row--provider" :title="t('Choose the API provider for the Codex backend')">
                 <span class="sidebar-settings-label">{{ t('Provider') }}</span>
                 <select
                   class="sidebar-settings-provider-select"
@@ -357,7 +361,7 @@
                   </div>
                 </div>
               </div>
-              <div class="sidebar-settings-row sidebar-settings-row--select" :title="SETTINGS_HELP.dictationLanguage">
+              <div class="sidebar-settings-row sidebar-settings-row--select sidebar-settings-row--language" :title="SETTINGS_HELP.dictationLanguage">
                 <span class="sidebar-settings-label">{{ t('Dictation language') }}</span>
                 <ComposerDropdown
                   class="sidebar-settings-language-dropdown"
@@ -888,6 +892,8 @@ import type { ComposerDraftPayload, ThreadComposerExposed } from './components/c
 import type { LocalDirectoryEntry, TelegramStatus, WorktreeBranchOption } from './api/codexGateway'
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, normalizePathForUi } from './pathUtils.js'
+import { cycleAppearanceMode, getEffectiveTheme, getStoredAppearanceMode, type AppearanceMode } from './theme'
+import { BUILT_IN_THEMES, cycleThemeId, DEFAULT_THEME_ID, getStoredThemeId, getThemeMetaColor, normalizeMetaThemeColor, type ThemeId } from './theme/themes'
 
 const ThreadConversation = defineAsyncComponent(() => import('./components/content/ThreadConversation.vue'))
 const ThreadTerminalPanel = defineAsyncComponent(() => import('./components/content/ThreadTerminalPanel.vue'))
@@ -903,6 +909,7 @@ const SETTINGS_HELP = {
   sendWithEnter: t('When enabled, press Enter to send. When disabled, use Command+Enter to send.'),
   inProgressSendMode: t('If a turn is still running, choose whether a new prompt should steer the current turn or be queued.'),
   appearance: t('Switch between system theme, light mode, and dark mode.'),
+  theme: t('Switch between built-in color themes.'),
   chatWidth: t('Choose how wide the conversation column and composer can grow on desktop screens.'),
   dictationClickToToggle: t('Use click-to-start and click-to-stop dictation instead of hold-to-talk.'),
   dictationAutoSend: t('Automatically send transcribed dictation when recording stops.'),
@@ -1163,6 +1170,7 @@ const accountActionError = ref('')
 const SEND_WITH_ENTER_KEY = 'codex-web-local.send-with-enter.v1'
 const IN_PROGRESS_SEND_MODE_KEY = 'codex-web-local.in-progress-send-mode.v1'
 const DARK_MODE_KEY = 'codex-web-local.dark-mode.v1'
+const THEME_ID_KEY = 'codex-web-local.theme-id.v1'
 const DICTATION_CLICK_TO_TOGGLE_KEY = 'codex-web-local.dictation-click-to-toggle.v1'
 const DICTATION_AUTO_SEND_KEY = 'codex-web-local.dictation-auto-send.v1'
 const DICTATION_LANGUAGE_KEY = 'codex-web-local.dictation-language.v1'
@@ -1171,7 +1179,8 @@ const CHAT_WIDTH_KEY = 'codex-web-local.chat-width.v1'
 const MOBILE_RESUME_RELOAD_MIN_HIDDEN_MS = 400
 const sendWithEnter = ref(loadBoolPref(SEND_WITH_ENTER_KEY, true))
 const inProgressSendMode = ref<'steer' | 'queue'>(loadInProgressSendModePref())
-const darkMode = ref<'system' | 'light' | 'dark'>(loadDarkModePref())
+const darkMode = ref<AppearanceMode>(loadDarkModePref())
+const themeId = ref<ThemeId>(loadThemeIdPref())
 const chatWidth = ref<ChatWidthMode>(loadChatWidthPref())
 const dictationClickToToggle = ref(loadBoolPref(DICTATION_CLICK_TO_TOGGLE_KEY, false))
 const dictationAutoSend = ref(loadBoolPref(DICTATION_AUTO_SEND_KEY, true))
@@ -1504,6 +1513,9 @@ const terminalShortcutLabel = computed(() => {
   }
   return 'Ctrl+J'
 })
+const currentThemeLabel = computed(() => {
+  return BUILT_IN_THEMES.find((theme) => theme.id === themeId.value)?.label ?? 'Default'
+})
 const contentStyle = computed(() => {
   const preset = CHAT_WIDTH_PRESETS[chatWidth.value]
   const keyboardInset = Math.max(
@@ -1539,8 +1551,8 @@ onMounted(() => {
   window.visualViewport?.addEventListener('resize', updateVisualViewportState)
   window.visualViewport?.addEventListener('scroll', updateVisualViewportState)
   updateVisualViewportState()
-  applyDarkMode()
-  darkModeMediaQuery?.addEventListener('change', applyDarkMode)
+  applyThemeState()
+  darkModeMediaQuery?.addEventListener('change', applyThemeState)
   void initialize()
   void loadHomeDirectory()
   void loadFirstLaunchPluginsCardPreference()
@@ -1561,7 +1573,7 @@ onUnmounted(() => {
   window.removeEventListener('resize', updateVisualViewportState)
   window.visualViewport?.removeEventListener('resize', updateVisualViewportState)
   window.visualViewport?.removeEventListener('scroll', updateVisualViewportState)
-  darkModeMediaQuery?.removeEventListener('change', applyDarkMode)
+  darkModeMediaQuery?.removeEventListener('change', applyThemeState)
   if (accountStatePollTimer !== null) {
     window.clearInterval(accountStatePollTimer)
     accountStatePollTimer = null
@@ -2889,11 +2901,14 @@ function loadBoolPref(key: string, fallback: boolean): boolean {
   return v === '1'
 }
 
-function loadDarkModePref(): 'system' | 'light' | 'dark' {
+function loadDarkModePref(): AppearanceMode {
   if (typeof window === 'undefined') return 'system'
-  const v = window.localStorage.getItem(DARK_MODE_KEY)
-  if (v === 'light' || v === 'dark') return v
-  return 'system'
+  return getStoredAppearanceMode(window.localStorage.getItem(DARK_MODE_KEY))
+}
+
+function loadThemeIdPref(): ThemeId {
+  if (typeof window === 'undefined') return DEFAULT_THEME_ID
+  return getStoredThemeId(window.localStorage.getItem(THEME_ID_KEY))
 }
 
 function loadInProgressSendModePref(): 'steer' | 'queue' {
@@ -2919,11 +2934,15 @@ function cycleInProgressSendMode(): void {
 }
 
 function cycleDarkMode(): void {
-  const order: Array<'system' | 'light' | 'dark'> = ['system', 'light', 'dark']
-  const idx = order.indexOf(darkMode.value)
-  darkMode.value = order[(idx + 1) % order.length]
+  darkMode.value = cycleAppearanceMode(darkMode.value)
   window.localStorage.setItem(DARK_MODE_KEY, darkMode.value)
-  applyDarkMode()
+  applyThemeState()
+}
+
+function cycleTheme(): void {
+  themeId.value = cycleThemeId(themeId.value)
+  window.localStorage.setItem(THEME_ID_KEY, themeId.value)
+  applyThemeState()
 }
 
 function cycleChatWidth(): void {
@@ -3167,16 +3186,31 @@ function normalizeToWhisperLanguage(raw: string): string {
   return ''
 }
 
-function applyDarkMode(): void {
-  const root = document.documentElement
-  if (darkMode.value === 'dark') {
-    root.classList.add('dark')
-  } else if (darkMode.value === 'light') {
-    root.classList.remove('dark')
-  } else {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    root.classList.toggle('dark', prefersDark)
+function syncBrowserThemeMetadata(root: HTMLElement, theme: ThemeId, effectiveAppearance: 'light' | 'dark'): void {
+  const fallbackThemeColor = getThemeMetaColor(theme, effectiveAppearance)
+  const themeColor = normalizeMetaThemeColor(
+    window.getComputedStyle(root).getPropertyValue('--theme-body-background'),
+    fallbackThemeColor
+  )
+  const themeColorMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+  if (themeColorMeta) {
+    themeColorMeta.setAttribute('content', themeColor)
   }
+
+  const statusBarMeta = document.querySelector<HTMLMetaElement>('meta[name="apple-mobile-web-app-status-bar-style"]')
+  if (statusBarMeta) {
+    statusBarMeta.setAttribute('content', effectiveAppearance === 'dark' ? 'black-translucent' : 'default')
+  }
+}
+
+function applyThemeState(): void {
+  const root = document.documentElement
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const effectiveAppearance = getEffectiveTheme(darkMode.value, prefersDark)
+  root.dataset.theme = themeId.value
+  root.dataset.appearance = effectiveAppearance
+  root.classList.toggle('dark', effectiveAppearance === 'dark')
+  syncBrowserThemeMetadata(root, themeId.value, effectiveAppearance)
 }
 
 function loadSidebarCollapsed(): boolean {
@@ -3523,7 +3557,9 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .content-root {
-  @apply h-full min-h-0 min-w-0 w-full flex flex-col overflow-y-hidden overflow-x-hidden bg-white;
+  @apply h-full min-h-0 min-w-0 w-full flex flex-col overflow-y-hidden overflow-x-hidden;
+  background: var(--theme-main-bg);
+  color: var(--theme-text-primary);
 }
 
 .content-root.is-virtual-keyboard-open {
@@ -3537,11 +3573,20 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-search-toggle {
-  @apply h-6.75 w-6.75 rounded-md border border-transparent bg-transparent text-zinc-600 flex items-center justify-center transition hover:border-zinc-200 hover:bg-zinc-50;
+  @apply h-6.75 w-6.75 rounded-md border border-transparent bg-transparent flex items-center justify-center transition;
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-search-toggle:hover {
+  border-color: var(--theme-border);
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .sidebar-search-toggle[aria-pressed='true'] {
-  @apply border-zinc-300 bg-zinc-100 text-zinc-700;
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
 }
 
 .sidebar-search-toggle-icon {
@@ -3549,19 +3594,32 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-search-bar {
-  @apply flex items-center gap-1.5 mx-2 px-2 py-1 rounded-md border border-zinc-200 bg-white transition-colors focus-within:border-zinc-400;
+  @apply flex items-center gap-1.5 mx-2 px-2 py-1 rounded-md border transition-colors;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
 }
 
 .sidebar-search-bar-icon {
-  @apply w-3.5 h-3.5 text-zinc-400 shrink-0;
+  @apply w-3.5 h-3.5 shrink-0;
+  color: var(--theme-text-muted);
 }
 
 .sidebar-search-input {
-  @apply flex-1 min-w-0 bg-transparent text-sm text-zinc-800 placeholder-zinc-400 outline-none border-none p-0;
+  @apply flex-1 min-w-0 bg-transparent text-sm outline-none border-none p-0;
+  color: var(--theme-text-primary);
+}
+
+.sidebar-search-input::placeholder {
+  color: var(--theme-text-muted);
 }
 
 .sidebar-search-clear {
-  @apply w-4 h-4 rounded text-zinc-400 flex items-center justify-center transition hover:text-zinc-600;
+  @apply w-4 h-4 rounded flex items-center justify-center transition;
+  color: var(--theme-text-muted);
+}
+
+.sidebar-search-clear:hover {
+  color: var(--theme-text-primary);
 }
 
 .sidebar-search-clear-icon {
@@ -3648,7 +3706,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 
 .content-error {
-  @apply m-0 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700;
+  @apply m-0 rounded-lg border px-3 py-2 text-sm;
 }
 
 .content-grid {
@@ -3672,11 +3730,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .content-header-terminal-toggle {
-  @apply flex h-8 items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 text-xs text-zinc-700 transition hover:bg-zinc-50;
-}
-
-.content-header-terminal-toggle[aria-pressed='true'] {
-  @apply border-zinc-300 bg-zinc-100 text-zinc-950;
+  @apply flex h-8 items-center gap-1.5 rounded-full border px-2.5 text-xs transition;
 }
 
 .content-header-terminal-toggle-icon {
@@ -3684,11 +3738,11 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .content-header-terminal-shortcut {
-  @apply hidden text-[11px] text-zinc-500 sm:inline;
+  @apply hidden text-[11px] sm:inline;
 }
 
 .content-header-branch-dropdown :deep(.composer-dropdown-trigger) {
-  @apply rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs text-zinc-700 transition hover:bg-zinc-50;
+  @apply rounded-full border px-3 py-1.5 text-xs transition;
 }
 
 .content-header-branch-dropdown :deep(.composer-dropdown-value) {
@@ -3700,24 +3754,16 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   right: 0;
 }
 
-.content-header-branch-dropdown.is-review-open :deep(.composer-dropdown-trigger) {
-  @apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;
-}
-
-.content-header-branch-dropdown.is-review-open :deep(.composer-dropdown-chevron) {
-  @apply text-white;
-}
-
 .new-thread-empty {
   @apply flex-1 min-h-0 flex flex-col items-center justify-center gap-0.5 px-3 sm:px-6;
 }
 
 .new-thread-hero {
-  @apply m-0 text-2xl sm:text-[2.5rem] font-normal leading-[1.05] text-zinc-900;
+  @apply m-0 text-2xl sm:text-[2.5rem] font-normal leading-[1.05];
 }
 
 .new-thread-folder-dropdown {
-  @apply text-2xl sm:text-[2.5rem] text-zinc-500;
+  @apply text-2xl sm:text-[2.5rem];
 }
 
 .new-thread-folder-dropdown :deep(.composer-dropdown-trigger) {
@@ -3733,7 +3779,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-folder-selected {
-  @apply mt-2 mb-0 max-w-3xl text-center text-xs text-zinc-500 break-all;
+  @apply mt-2 mb-0 max-w-3xl text-center text-xs break-all;
 }
 
 .new-thread-folder-actions {
@@ -3825,19 +3871,15 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-folder-action {
-  @apply inline-flex h-9 items-center justify-center rounded-full border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-default disabled:opacity-60;
-}
-
-.new-thread-folder-action-primary {
-  @apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;
+  @apply inline-flex h-9 items-center justify-center rounded-full border px-4 text-sm font-medium transition disabled:cursor-default disabled:opacity-60;
 }
 
 .new-thread-open-folder-overlay {
-  @apply fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4;
+  @apply fixed inset-0 z-50 flex items-center justify-center p-4;
 }
 
 .new-thread-open-folder {
-  @apply flex w-full max-w-3xl max-h-[90vh] flex-col gap-2 overflow-y-auto rounded-2xl border border-zinc-200 bg-white px-4 py-4 text-left shadow-xl;
+  @apply flex w-full max-w-3xl max-h-[90vh] flex-col gap-2 overflow-y-auto rounded-2xl border px-4 py-4 text-left;
 }
 
 .new-thread-open-folder-header {
@@ -3845,15 +3887,18 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-title {
-  @apply m-0 text-sm font-semibold text-zinc-900;
+  @apply m-0 text-sm font-semibold;
+  color: var(--theme-text-primary);
 }
 
 .new-thread-open-folder-close {
-  @apply border-0 bg-transparent p-0 text-sm text-zinc-500 transition hover:text-zinc-800;
+  @apply border-0 bg-transparent p-0 text-sm transition;
+  color: var(--theme-text-secondary);
 }
 
 .new-thread-open-folder-label {
-  @apply m-0 text-xs font-medium uppercase tracking-wide text-zinc-500;
+  @apply m-0 text-xs font-medium uppercase tracking-wide;
+  color: var(--theme-text-muted);
 }
 
 .new-thread-open-folder-current {
@@ -3861,7 +3906,14 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-path {
-  @apply min-w-0 flex-1 rounded-xl border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-700 outline-none transition focus:border-zinc-400;
+  @apply min-w-0 flex-1 rounded-xl border px-3 py-2 font-mono text-xs outline-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-path:focus {
+  border-color: var(--theme-border-strong);
 }
 
 .new-thread-open-folder-actions {
@@ -3869,20 +3921,14 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-toggle {
-  @apply inline-flex items-center gap-2 text-sm text-zinc-600;
+  @apply inline-flex items-center gap-2 text-sm;
+  color: var(--theme-text-secondary);
 }
 
 .new-thread-open-folder-toggle-input {
-  @apply relative h-4 w-4 shrink-0 appearance-none rounded-[4px] border border-zinc-300 bg-white outline-none transition;
-}
-
-.new-thread-open-folder-toggle-input:focus-visible {
-  box-shadow: 0 0 0 3px rgb(228 228 231);
-}
-
-.new-thread-open-folder-toggle-input:checked {
-  border-color: rgb(24 24 27);
-  background-color: rgb(255 255 255);
+  @apply relative h-4 w-4 shrink-0 appearance-none rounded-[4px] border outline-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
 }
 
 .new-thread-open-folder-toggle-input::after {
@@ -3892,8 +3938,8 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   top: 1px;
   width: 4px;
   height: 8px;
-  border-right: 2px solid rgb(24 24 27);
-  border-bottom: 2px solid rgb(24 24 27);
+  border-right: 2px solid var(--theme-accent);
+  border-bottom: 2px solid var(--theme-accent);
   transform: rotate(45deg);
   opacity: 0;
 }
@@ -3903,7 +3949,10 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-filter {
-  @apply w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none transition focus:border-zinc-400;
+  @apply w-full rounded-xl border px-3 py-2 text-sm outline-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
 }
 
 .new-thread-open-folder-create {
@@ -3915,23 +3964,28 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-create-input {
-  @apply w-full min-w-0 flex-1 rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none transition focus:border-zinc-400;
+  @apply w-full min-w-0 flex-1 rounded-xl border px-3 py-2 text-sm outline-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
 }
 
 .new-thread-open-folder-create-submit {
   @apply shrink-0;
 }
 
-.new-thread-folder-action[aria-pressed='true'] {
-  @apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;
-}
-
 .new-thread-open-folder-status {
-  @apply m-0 rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-600;
+  @apply m-0 rounded-xl border px-3 py-2 text-sm;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+  color: var(--theme-text-secondary);
 }
 
 .new-thread-open-folder-error {
-  @apply m-0 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700;
+  @apply m-0 rounded-xl border px-3 py-2 text-sm;
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
 }
 
 .new-thread-open-folder-error-actions {
@@ -3941,7 +3995,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 .new-thread-open-folder-list {
   @apply m-0 flex max-h-72 list-none flex-col gap-1 overflow-y-auto p-0 pr-3;
   scrollbar-gutter: stable;
-  scrollbar-color: rgb(161 161 170) rgb(244 244 245);
+  scrollbar-color: var(--theme-border-strong) var(--theme-control-bg);
   scrollbar-width: thin;
 }
 
@@ -3950,18 +4004,18 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-list::-webkit-scrollbar-track {
-  background: rgb(244 244 245);
+  background: var(--theme-control-bg);
   border-radius: 9999px;
 }
 
 .new-thread-open-folder-list::-webkit-scrollbar-thumb {
-  background: rgb(161 161 170);
+  background: var(--theme-border-strong);
   border-radius: 9999px;
-  border: 2px solid rgb(244 244 245);
+  border: 2px solid var(--theme-control-bg);
 }
 
 .new-thread-open-folder-list::-webkit-scrollbar-thumb:hover {
-  background: rgb(113 113 122);
+  background: var(--theme-control-active-bg);
 }
 
 .new-thread-open-folder-item {
@@ -3969,7 +4023,10 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-item-main {
-  @apply min-w-0 truncate rounded-xl border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-left text-sm font-medium leading-5 text-zinc-900 transition hover:border-zinc-300 hover:bg-zinc-100;
+  @apply min-w-0 truncate rounded-xl border px-2.5 py-1 text-left text-sm font-medium leading-5 transition;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+  color: var(--theme-text-primary);
 }
 
 .new-thread-open-folder-item-main:disabled,
@@ -3982,7 +4039,10 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-item-open {
-  @apply inline-flex h-7 items-center justify-center rounded-xl border border-zinc-200 bg-white px-2.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-50;
+  @apply inline-flex h-7 items-center justify-center rounded-xl border px-2.5 text-xs font-medium transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .new-thread-runtime-dropdown {
@@ -3994,19 +4054,25 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-branch-select-label {
-  @apply m-0 mb-1 text-xs font-medium uppercase tracking-wide text-zinc-500;
+  @apply m-0 mb-1 text-xs font-medium uppercase tracking-wide;
+  color: var(--theme-text-muted);
 }
 
 .new-thread-branch-dropdown :deep(.composer-dropdown-trigger) {
-  @apply h-9 rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-700;
+  @apply h-9 rounded-xl border px-3 text-sm;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .new-thread-branch-select-help {
-  @apply mt-1 mb-0 text-xs text-zinc-500;
+  @apply mt-1 mb-0 text-xs;
+  color: var(--theme-text-muted);
 }
 
 .new-thread-runtime-help {
-  @apply mt-2 mb-0 max-w-3xl text-center text-xs text-zinc-500;
+  @apply mt-2 mb-0 max-w-3xl text-center text-xs;
+  color: var(--theme-text-muted);
 }
 
 .worktree-init-status {
@@ -4014,7 +4080,9 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .worktree-init-status.is-running {
-  @apply border-zinc-300 bg-zinc-50 text-zinc-700;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+  color: var(--theme-text-secondary);
 }
 
 .worktree-init-status.is-error {
@@ -4030,7 +4098,9 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-area {
-  @apply shrink-0 bg-slate-100 pt-2 px-2 pb-2 border-t border-zinc-200;
+  @apply shrink-0 pt-2 px-2 pb-2 border-t;
+  border-color: var(--theme-border);
+  background: var(--theme-sidebar-bg);
 }
 
 .sidebar-settings-button {
@@ -4038,7 +4108,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-button-version {
-  @apply ml-auto min-w-0 truncate text-right text-xs;
+  @apply ml-auto min-w-0 truncate text-right text-xs text-zinc-500;
 }
 
 .sidebar-settings-icon {
@@ -4257,43 +4327,74 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-key-input {
-  @apply flex-1 min-w-0 text-xs rounded border border-zinc-200 bg-white px-2 py-1 outline-none transition-colors placeholder:text-zinc-400;
+  @apply flex-1 min-w-0 text-xs rounded border px-2 py-1 outline-none transition-colors;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-key-input::placeholder {
+  color: var(--theme-text-muted);
 }
 
 .sidebar-settings-key-input:focus {
-  @apply border-zinc-400;
+  border-color: var(--theme-selection-border);
 }
 
 .sidebar-settings-key-save {
-  @apply shrink-0 rounded border border-zinc-200 bg-white px-2.5 py-1 text-xs text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-40 disabled:cursor-default;
+  @apply shrink-0 rounded border px-2.5 py-1 text-xs transition-colors disabled:opacity-40 disabled:cursor-default;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-settings-key-save:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .sidebar-settings-key-masked {
-  @apply flex-1 min-w-0 text-xs text-zinc-500 font-mono truncate;
+  @apply flex-1 min-w-0 text-xs font-mono truncate;
+  color: var(--theme-text-muted);
 }
 
 .sidebar-settings-key-clear {
-  @apply shrink-0 w-6 h-6 flex items-center justify-center rounded-full border border-zinc-200 text-xs text-zinc-400 transition-colors hover:text-zinc-600 hover:border-zinc-300 disabled:opacity-40;
+  @apply shrink-0 w-6 h-6 flex items-center justify-center rounded-full border text-xs transition-colors disabled:opacity-40;
+  border-color: var(--theme-border);
+  color: var(--theme-text-muted);
+}
+
+.sidebar-settings-key-clear:hover {
+  border-color: var(--theme-border-strong);
+  color: var(--theme-text-primary);
 }
 
 .sidebar-settings-provider-select {
-  @apply min-w-0 max-w-40 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700 outline-none transition-colors cursor-pointer;
+  @apply min-w-0 max-w-40 rounded-md border px-2 py-1 text-xs outline-none transition-colors cursor-pointer;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .sidebar-settings-provider-select:focus {
-  @apply border-zinc-400 ring-2 ring-zinc-200;
+  border-color: var(--theme-selection-border);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-selection-border) 28%, transparent);
 }
 
 .sidebar-settings-segmented {
-  @apply inline-flex items-center rounded-md border border-zinc-200 bg-white p-0.5;
+  @apply inline-flex items-center rounded-md border p-0.5;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
 }
 
 .sidebar-settings-segmented-option {
-  @apply rounded px-2 py-1 text-xs text-zinc-600 transition-colors;
+  @apply rounded px-2 py-1 text-xs transition-colors;
+  color: var(--theme-text-secondary);
 }
 
 .sidebar-settings-segmented-option.is-active {
-  @apply bg-zinc-800 text-white;
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
 }
 
 .sidebar-settings-provider-info {
@@ -4301,51 +4402,12 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-provider-link {
-  @apply text-xs text-blue-600 hover:text-blue-700 underline shrink-0;
+  @apply text-xs underline shrink-0;
+  color: var(--theme-link);
 }
 
-:root.dark .sidebar-settings-provider-select {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200;
-}
-
-:root.dark .sidebar-settings-provider-select:focus {
-  @apply border-zinc-500 ring-zinc-700;
-}
-
-:root.dark .sidebar-settings-segmented {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .sidebar-settings-segmented-option {
-  @apply text-zinc-300;
-}
-
-:root.dark .sidebar-settings-segmented-option.is-active {
-  @apply bg-zinc-100 text-zinc-900;
-}
-
-:root.dark .sidebar-settings-provider-link {
-  @apply text-blue-400 hover:text-blue-300;
-}
-
-:root.dark .sidebar-settings-key-input {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200 placeholder:text-zinc-500;
-}
-
-:root.dark .sidebar-settings-key-input:focus {
-  @apply border-zinc-500;
-}
-
-:root.dark .sidebar-settings-key-save {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-200 hover:bg-zinc-600;
-}
-
-:root.dark .sidebar-settings-key-masked {
-  @apply text-zinc-400;
-}
-
-:root.dark .sidebar-settings-key-clear {
-  @apply border-zinc-600 text-zinc-500 hover:text-zinc-300 hover:border-zinc-500;
+.sidebar-settings-provider-link:hover {
+  color: var(--theme-link-hover);
 }
 
 .settings-panel-enter-active,
@@ -4364,7 +4426,8 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-context-value {
-  @apply text-xs font-semibold text-zinc-700 text-right;
+  @apply text-xs font-semibold text-right;
+  color: var(--theme-text-secondary);
 }
 
 .sidebar-settings-context-value[data-state='ok'] {
@@ -4380,15 +4443,19 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .sidebar-settings-context-meta {
-  @apply block text-[11px] font-normal text-zinc-500;
+  @apply block text-[11px] font-normal;
+  color: var(--theme-text-muted);
 }
 
 .sidebar-settings-rate-limits {
-  @apply border-t border-zinc-200 px-2 pt-2;
+  @apply border-t px-2 pt-2;
+  border-color: var(--theme-border);
 }
 
 .sidebar-settings-build-label {
-  @apply border-t border-zinc-100 px-3 py-2 text-[11px] text-zinc-500;
+  @apply border-t px-3 py-2 text-[11px];
+  border-color: var(--theme-border);
+  color: var(--theme-text-muted);
 }
 
 </style>

--- a/src/components/content/ApiMethodsPanel.vue
+++ b/src/components/content/ApiMethodsPanel.vue
@@ -26,23 +26,29 @@ defineProps<{
 @reference "tailwindcss";
 
 .api-panel-root {
-  @apply h-full min-h-0 rounded-2xl border border-slate-200 bg-white p-4 flex flex-col;
+  @apply h-full min-h-0 rounded-2xl border p-4 flex flex-col;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
 }
 
 .api-panel-header {
-  @apply pb-3 border-b border-slate-200;
+  @apply pb-3 border-b;
+  border-color: var(--theme-border);
 }
 
 .api-panel-title {
-  @apply m-0 text-lg font-semibold text-slate-900;
+  @apply m-0 text-lg font-semibold;
+  color: var(--theme-text-primary);
 }
 
 .api-panel-count {
-  @apply m-0 mt-1 text-xs text-slate-500;
+  @apply m-0 mt-1 text-xs;
+  color: var(--theme-text-muted);
 }
 
 .api-panel-loading {
-  @apply mt-3 mb-0 text-sm text-slate-500;
+  @apply mt-3 mb-0 text-sm;
+  color: var(--theme-text-muted);
 }
 
 .api-method-list {
@@ -54,6 +60,8 @@ defineProps<{
 }
 
 .api-method-code {
-  @apply block rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-700;
+  @apply block rounded-md px-2 py-1 text-xs;
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 </style>

--- a/src/components/content/ComposerRuntimeDropdown.vue
+++ b/src/components/content/ComposerRuntimeDropdown.vue
@@ -46,31 +46,40 @@ function onSelect(value: RuntimeMode): void {
 @reference "tailwindcss";
 
 .runtime-toggle {
-  @apply inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-zinc-100 p-1;
+  @apply inline-flex items-center gap-1 rounded-full border p-1;
+  border-color: var(--theme-border);
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
 }
 
 .runtime-toggle-option {
-  @apply inline-flex h-8 items-center gap-1.5 rounded-full border border-transparent bg-transparent px-3 text-sm text-zinc-600 transition;
+  @apply inline-flex h-8 items-center gap-1.5 rounded-full border border-transparent bg-transparent px-3 text-sm transition;
+  color: var(--theme-text-secondary);
 }
 
 .runtime-toggle-option:hover {
-  @apply bg-zinc-200/70 text-zinc-900;
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .runtime-toggle-option.is-selected {
-  @apply border-zinc-200 bg-white text-zinc-900 shadow-sm;
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+  box-shadow: var(--theme-shadow-sm);
 }
 
 .runtime-toggle-option:focus-visible {
-  @apply outline-none ring-2 ring-zinc-300 ring-offset-1 ring-offset-white;
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-selection-border) 82%, transparent);
 }
 
 .runtime-toggle-option-icon {
-  @apply h-3.5 w-3.5 shrink-0 text-zinc-500;
+  @apply h-3.5 w-3.5 shrink-0;
+  color: var(--theme-text-muted);
 }
 
 .runtime-toggle-option.is-selected .runtime-toggle-option-icon {
-  @apply text-zinc-700;
+  color: inherit;
 }
 
 .runtime-toggle-option-label {

--- a/src/components/content/ComposerRuntimeDropdown.vue
+++ b/src/components/content/ComposerRuntimeDropdown.vue
@@ -48,7 +48,7 @@ function onSelect(value: RuntimeMode): void {
 .runtime-toggle {
   @apply inline-flex items-center gap-1 rounded-full border p-1;
   border-color: var(--theme-border);
-  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+  background: var(--theme-runtime-bg, color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg)));
 }
 
 .runtime-toggle-option {
@@ -62,9 +62,9 @@ function onSelect(value: RuntimeMode): void {
 }
 
 .runtime-toggle-option.is-selected {
-  border-color: var(--theme-selection-border);
-  background: var(--theme-selection-bg);
-  color: var(--theme-selection-text);
+  border-color: var(--theme-runtime-selected-border, var(--theme-selection-border));
+  background: var(--theme-runtime-selected-bg, var(--theme-selection-bg));
+  color: var(--theme-runtime-selected-text, var(--theme-selection-text));
   box-shadow: var(--theme-shadow-sm);
 }
 

--- a/src/components/content/ComposerSearchDropdown.vue
+++ b/src/components/content/ComposerSearchDropdown.vue
@@ -21,74 +21,76 @@
         }"
         :style="menuStyle"
       >
-        <div class="search-dropdown-search-wrap">
-          <div class="search-dropdown-search-row">
-            <input
-              ref="searchRef"
-              v-model="searchQuery"
-              class="search-dropdown-search"
-              type="text"
-              :placeholder="searchPlaceholder"
-              @keydown.escape.prevent="isOpen = false"
-              @keydown.enter.prevent="selectHighlighted"
-              @keydown.arrow-down.prevent="moveHighlight(1)"
-              @keydown.arrow-up.prevent="moveHighlight(-1)"
-            />
-            <button
-              v-if="createLabel"
-              class="search-dropdown-create-icon"
-              type="button"
-              :aria-label="createLabel"
-              :title="createLabel"
-              @click="emit('create')"
-            >
-              +
-            </button>
-          </div>
-          <button
-            v-if="createLabel"
-            class="search-dropdown-create"
-            type="button"
-            @click="emit('create')"
-          >
-            {{ createLabel }}
-          </button>
-        </div>
-        <ul v-if="filtered.length > 0" class="search-dropdown-list" role="listbox">
-          <li v-for="(opt, idx) in filtered" :key="opt.value">
-            <div
-              class="search-dropdown-option"
-              :class="{
-                'is-selected': selected.has(opt.value),
-                'is-highlighted': idx === highlightIdx,
-              }"
-              @pointerenter="highlightIdx = idx"
-            >
+        <div class="search-dropdown-menu">
+          <div class="search-dropdown-search-wrap">
+            <div class="search-dropdown-search-row">
+              <input
+                ref="searchRef"
+                v-model="searchQuery"
+                class="search-dropdown-search"
+                type="text"
+                :placeholder="searchPlaceholder"
+                @keydown.escape.prevent="isOpen = false"
+                @keydown.enter.prevent="selectHighlighted"
+                @keydown.arrow-down.prevent="moveHighlight(1)"
+                @keydown.arrow-up.prevent="moveHighlight(-1)"
+              />
               <button
-                class="search-dropdown-option-main"
+                v-if="createLabel"
+                class="search-dropdown-create-icon"
                 type="button"
-                @click="onSelect(opt)"
+                :aria-label="createLabel"
+                :title="createLabel"
+                @click="emit('create')"
               >
-                <span class="search-dropdown-option-check">{{ selected.has(opt.value) ? '✓' : '' }}</span>
-                <span class="search-dropdown-option-copy">
-                  <span class="search-dropdown-option-label">{{ opt.label }}</span>
-                  <span v-if="opt.description" class="search-dropdown-option-desc">{{ opt.description }}</span>
-                </span>
-              </button>
-              <button
-                v-if="allowRemove"
-                class="search-dropdown-option-remove"
-                type="button"
-                :aria-label="`${removeLabel} ${opt.label}`"
-                :title="`${removeLabel} ${opt.label}`"
-                @click.stop="emit('remove', opt.value)"
-              >
-                ×
+                +
               </button>
             </div>
-          </li>
-        </ul>
-        <div v-else class="search-dropdown-empty">{{ t('No results') }}</div>
+            <button
+              v-if="createLabel"
+              class="search-dropdown-create"
+              type="button"
+              @click="emit('create')"
+            >
+              {{ createLabel }}
+            </button>
+          </div>
+          <ul v-if="filtered.length > 0" class="search-dropdown-list" role="listbox">
+            <li v-for="(opt, idx) in filtered" :key="opt.value">
+              <div
+                class="search-dropdown-option"
+                :class="{
+                  'is-selected': selected.has(opt.value),
+                  'is-highlighted': idx === highlightIdx,
+                }"
+                @pointerenter="highlightIdx = idx"
+              >
+                <button
+                  class="search-dropdown-option-main"
+                  type="button"
+                  @click="onSelect(opt)"
+                >
+                  <span class="search-dropdown-option-check">{{ selected.has(opt.value) ? '✓' : '' }}</span>
+                  <span class="search-dropdown-option-copy">
+                    <span class="search-dropdown-option-label">{{ opt.label }}</span>
+                    <span v-if="opt.description" class="search-dropdown-option-desc">{{ opt.description }}</span>
+                  </span>
+                </button>
+                <button
+                  v-if="allowRemove"
+                  class="search-dropdown-option-remove"
+                  type="button"
+                  :aria-label="`${removeLabel} ${opt.label}`"
+                  :title="`${removeLabel} ${opt.label}`"
+                  @click.stop="emit('remove', opt.value)"
+                >
+                  ×
+                </button>
+              </div>
+            </li>
+          </ul>
+          <div v-else class="search-dropdown-empty">{{ t('No results') }}</div>
+        </div>
       </div>
     </Teleport>
   </div>
@@ -243,6 +245,7 @@ onMounted(() => {
   window.addEventListener('resize', onWindowLayoutChange)
   window.addEventListener('scroll', onWindowLayoutChange, true)
 })
+
 onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onDocumentPointerDown)
   window.removeEventListener('resize', onWindowLayoutChange)
@@ -258,11 +261,13 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-trigger {
-  @apply inline-flex min-h-7 min-w-0 items-center gap-1 border-0 bg-transparent px-0 py-0.5 text-sm leading-tight text-zinc-500 outline-none transition;
+  @apply inline-flex min-h-7 min-w-0 items-center gap-1 border-0 bg-transparent px-0 py-0.5 text-sm leading-tight outline-none transition;
+  color: var(--theme-text-secondary);
 }
 
 .search-dropdown-trigger:disabled {
-  @apply cursor-not-allowed text-zinc-500;
+  @apply cursor-not-allowed;
+  color: var(--theme-text-muted);
 }
 
 .search-dropdown-value {
@@ -270,11 +275,19 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-chevron {
-  @apply mt-px h-3.5 w-3.5 shrink-0 text-zinc-500;
+  @apply mt-px h-3.5 w-3.5 shrink-0;
+  color: var(--theme-text-muted);
 }
 
 .search-dropdown-menu-wrap {
   @apply z-[120];
+}
+
+.search-dropdown-menu {
+  @apply m-0 min-w-56 rounded-xl border p-1;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  box-shadow: var(--theme-shadow-md);
 }
 
 @media (max-width: 639px) {
@@ -284,7 +297,8 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-search-wrap {
-  @apply p-2 border-b border-zinc-100;
+  @apply border-b p-2;
+  border-color: var(--theme-border);
 }
 
 .search-dropdown-search-row {
@@ -296,11 +310,31 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-create-icon {
-  @apply inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-zinc-200 bg-white text-lg leading-none text-zinc-700 transition hover:bg-zinc-50;
+  @apply inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border text-lg leading-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.search-dropdown-create-icon:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .search-dropdown-search {
-  @apply min-w-0 flex-1 rounded-lg border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-sm text-zinc-800 outline-none placeholder-zinc-400 transition focus:border-zinc-300 focus:bg-white;
+  @apply min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none transition;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.search-dropdown-search::placeholder {
+  color: var(--theme-text-muted);
+}
+
+.search-dropdown-search:focus {
+  border-color: var(--theme-border-strong);
+  background: var(--theme-control-hover-bg);
 }
 
 .search-dropdown-list {
@@ -308,23 +342,33 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-option {
-  @apply relative flex min-w-0 items-start gap-1 rounded-lg text-zinc-700 transition;
+  @apply relative flex min-w-0 items-start gap-1 rounded-lg transition;
+  color: var(--theme-text-secondary);
 }
 
 .search-dropdown-option.is-highlighted {
-  @apply bg-zinc-100;
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .search-dropdown-option.is-selected {
-  @apply text-zinc-900;
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
 }
 
 .search-dropdown-option-main {
-  @apply flex min-w-0 flex-1 items-start gap-2 rounded-lg border-0 bg-transparent px-2.5 py-1.5 pr-8 text-left hover:bg-zinc-50;
+  @apply flex min-w-0 flex-1 items-start gap-2 rounded-lg border-0 bg-transparent px-2.5 py-1.5 pr-8 text-left;
+  color: inherit;
+}
+
+.search-dropdown-option-main:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .search-dropdown-option-check {
-  @apply mt-0.5 w-4 shrink-0 text-center text-[10px] leading-4 text-emerald-600;
+  @apply mt-0.5 w-4 shrink-0 text-center text-[10px] leading-4;
+  color: var(--theme-success-text);
 }
 
 .search-dropdown-option-copy {
@@ -332,77 +376,31 @@ onBeforeUnmount(() => {
 }
 
 .search-dropdown-option-label {
-  @apply block min-w-0 truncate text-sm font-medium text-zinc-800;
+  @apply block min-w-0 truncate text-sm font-medium;
+  color: var(--theme-text-primary);
+}
+
+.search-dropdown-option.is-selected .search-dropdown-option-label {
+  color: inherit;
 }
 
 .search-dropdown-option-desc {
-  @apply mt-0.5 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-500;
+  @apply mt-0.5 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs;
+  color: var(--theme-text-muted);
 }
 
 .search-dropdown-option-remove {
-  @apply absolute right-1 top-1 inline-flex h-6 w-6 items-center justify-center rounded-md border-0 bg-transparent text-lg font-medium leading-none text-zinc-500 transition hover:bg-zinc-200 hover:text-zinc-800;
+  @apply absolute right-1 top-1 inline-flex h-6 w-6 items-center justify-center rounded-md border-0 bg-transparent text-lg font-medium leading-none transition;
+  color: var(--theme-text-muted);
+}
+
+.search-dropdown-option-remove:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .search-dropdown-empty {
-  @apply p-3 text-center text-sm text-zinc-400;
-}
-
-.search-dropdown-menu-wrap-up,
-.search-dropdown-menu-wrap-down {
-  @apply rounded-xl border border-zinc-200 bg-white shadow-lg;
-}
-
-:global(:root.dark) .search-dropdown-trigger,
-:global(:root.dark) .search-dropdown-trigger:disabled,
-:global(:root.dark) .search-dropdown-value,
-:global(:root.dark) .search-dropdown-chevron {
-  @apply text-zinc-400;
-}
-
-:global(:root.dark) .search-dropdown-menu-wrap-up,
-:global(:root.dark) .search-dropdown-menu-wrap-down {
-  @apply border-zinc-700 bg-zinc-900 shadow-[0_18px_48px_rgba(0,0,0,0.45)];
-}
-
-:global(:root.dark) .search-dropdown-search-wrap {
-  @apply border-zinc-800;
-}
-
-:global(:root.dark) .search-dropdown-search,
-:global(:root.dark) .search-dropdown-create {
-  @apply border-zinc-700 bg-zinc-950 text-zinc-100 placeholder-zinc-500;
-}
-
-:global(:root.dark) .search-dropdown-create:hover {
-  @apply bg-zinc-900;
-}
-
-:global(:root.dark) .search-dropdown-option {
-  @apply text-zinc-200;
-}
-
-:global(:root.dark) .search-dropdown-option.is-highlighted,
-:global(:root.dark) .search-dropdown-option-main:hover {
-  @apply bg-zinc-800;
-}
-
-:global(:root.dark) .search-dropdown-option-label {
-  @apply text-zinc-100;
-}
-
-:global(:root.dark) .search-dropdown-option-desc {
-  @apply text-zinc-400;
-}
-
-:global(:root.dark) .search-dropdown-option-remove {
-  @apply text-zinc-400;
-}
-
-:global(:root.dark) .search-dropdown-option-remove:hover {
-  @apply bg-zinc-700 text-zinc-200;
-}
-
-:global(:root.dark) .search-dropdown-empty {
-  @apply text-zinc-500;
+  @apply p-3 text-center text-sm;
+  color: var(--theme-text-muted);
 }
 </style>

--- a/src/components/content/ContentHeader.vue
+++ b/src/components/content/ContentHeader.vue
@@ -21,11 +21,13 @@ defineProps<{
 @reference "tailwindcss";
 
 .content-header {
-  @apply relative z-10 w-full min-w-0 min-h-12 sm:min-h-14 flex items-center gap-2 sm:gap-3 px-2 sm:px-3 pt-3 sm:pt-4 pb-2 bg-white;
+  @apply relative z-10 w-full min-w-0 min-h-12 sm:min-h-14 flex items-center gap-2 sm:gap-3 px-2 sm:px-3 pt-3 sm:pt-4 pb-2;
+  background: var(--theme-main-bg);
 }
 
 .content-title {
-  @apply m-0 min-w-0 max-w-[min(72ch,100%)] flex-1 truncate text-sm font-medium leading-6 text-slate-900 max-sm:text-xs;
+  @apply m-0 min-w-0 max-w-[min(72ch,100%)] flex-1 truncate text-sm font-medium leading-6 max-sm:text-xs;
+  color: var(--theme-text-primary);
 }
 
 .content-title.is-accent {

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -288,43 +288,70 @@ onMounted(() => {
 }
 
 .skills-hub-title {
-  @apply text-xl sm:text-2xl font-semibold text-zinc-900 m-0;
+  @apply text-xl sm:text-2xl font-semibold m-0;
+  color: var(--theme-text-primary);
 }
 
 .skills-hub-subtitle {
-  @apply text-sm text-zinc-500 m-0;
+  @apply text-sm m-0;
+  color: var(--theme-text-muted);
 }
 
 .skills-hub-sort {
-  @apply shrink-0 rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-medium text-zinc-600 transition hover:bg-zinc-50 hover:border-zinc-300 cursor-pointer;
+  @apply shrink-0 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition cursor-pointer;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.skills-hub-sort:hover {
+  background: var(--theme-control-hover-bg);
+  border-color: var(--theme-border-strong);
+  color: var(--theme-text-primary);
 }
 
 .skills-sync-panel {
-  @apply rounded-xl border border-zinc-200 bg-zinc-50 p-3 flex flex-col gap-2;
+  @apply rounded-xl border p-3 flex flex-col gap-2;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
 }
 
 .skills-sync-header {
-  @apply flex flex-wrap items-center gap-2 text-sm text-zinc-700;
+  @apply flex flex-wrap items-center gap-2 text-sm;
+  color: var(--theme-text-primary);
 }
 
 .skills-sync-badge {
-  @apply text-xs rounded-md border border-zinc-300 bg-white px-2 py-0.5;
+  @apply text-xs rounded-md border px-2 py-0.5;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .skills-sync-badge-link {
-  @apply text-zinc-700 hover:text-zinc-900 hover:border-zinc-400;
+  color: var(--theme-text-secondary);
+}
+
+.skills-sync-badge-link:hover {
+  border-color: var(--theme-border-strong);
+  color: var(--theme-text-primary);
 }
 
 .skills-sync-device {
-  @apply text-xs text-zinc-600 flex items-center gap-2 flex-wrap;
+  @apply text-xs flex items-center gap-2 flex-wrap;
+  color: var(--theme-text-secondary);
 }
 
 .skills-sync-meta {
-  @apply text-xs text-zinc-600 flex items-center gap-3 flex-wrap;
+  @apply text-xs flex items-center gap-3 flex-wrap;
+  color: var(--theme-text-secondary);
 }
 
 .skills-sync-error {
-  @apply text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-md px-2 py-1;
+  @apply text-xs border rounded-md px-2 py-1;
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
 }
 
 .skills-sync-actions {
@@ -348,7 +375,12 @@ onMounted(() => {
 }
 
 .skills-hub-section-toggle {
-  @apply flex items-center gap-1.5 border-0 bg-transparent p-0 text-sm font-medium text-zinc-600 transition hover:text-zinc-900 cursor-pointer;
+  @apply flex items-center gap-1.5 border-0 bg-transparent p-0 text-sm font-medium transition cursor-pointer;
+  color: var(--theme-text-secondary);
+}
+
+.skills-hub-section-toggle:hover {
+  color: var(--theme-text-primary);
 }
 
 .skills-hub-section-title {
@@ -368,14 +400,19 @@ onMounted(() => {
 }
 
 .skills-hub-loading {
-  @apply text-sm text-zinc-400 py-8 text-center;
+  @apply text-sm py-8 text-center;
+  color: var(--theme-text-muted);
 }
 
 .skills-hub-error {
-  @apply text-sm text-rose-600 py-4 text-center rounded-lg border border-rose-200 bg-rose-50;
+  @apply text-sm py-4 text-center rounded-lg border;
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
 }
 
 .skills-hub-empty {
-  @apply text-sm text-zinc-400 py-8 text-center;
+  @apply text-sm py-8 text-center;
+  color: var(--theme-text-muted);
 }
 </style>

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -4512,9 +4512,9 @@ onBeforeUnmount(() => {
 
 .plan-card {
   @apply flex max-w-[min(var(--chat-card-max,76ch),100%)] flex-col gap-3 rounded-2xl border px-4 py-3;
-  border-color: var(--theme-border);
-  background: var(--theme-panel-bg);
-  color: var(--theme-text-primary);
+  border-color: var(--theme-plan-border);
+  background: var(--theme-plan-bg);
+  color: var(--theme-plan-card-text);
 }
 
 .plan-card-header {
@@ -4523,17 +4523,17 @@ onBeforeUnmount(() => {
 
 .plan-card-title {
   @apply m-0 text-sm font-semibold leading-5;
-  color: var(--theme-text-primary);
+  color: var(--theme-plan-title);
 }
 
 .plan-card-badge {
   @apply inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-4;
-  background: var(--theme-control-active-bg);
-  color: var(--theme-text-primary);
+  background: var(--theme-plan-badge-bg);
+  color: var(--theme-plan-badge-text);
 }
 
 .plan-card-explanation {
-  color: var(--theme-text-secondary);
+  color: var(--theme-plan-text);
 }
 
 .plan-card-markdown {
@@ -4552,12 +4552,12 @@ onBeforeUnmount(() => {
 
 .plan-card-markdown :deep(.message-text) {
   @apply text-sm leading-relaxed whitespace-pre-wrap;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
 }
 
 .plan-card-markdown :deep(.message-heading) {
   @apply tracking-tight;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-heading);
 }
 
 .plan-card-markdown :deep(.message-heading-h1) {
@@ -4582,19 +4582,19 @@ onBeforeUnmount(() => {
 
 .plan-card-markdown :deep(.message-heading-h6) {
   @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em];
-  color: var(--theme-text-muted);
+  color: var(--theme-message-muted);
 }
 
 .plan-card-markdown :deep(.message-blockquote) {
   @apply border-l-4 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap rounded-r-lg;
-  border-left-color: var(--theme-border-strong);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-secondary);
+  border-left-color: var(--theme-message-blockquote-border);
+  background: var(--theme-message-blockquote-bg);
+  color: var(--theme-message-blockquote-text);
 }
 
 .plan-card-markdown :deep(.message-list) {
   @apply pl-5 text-sm leading-relaxed flex flex-col gap-1.5;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
 }
 
 .plan-card-markdown :deep(.message-list-unordered) {
@@ -4627,12 +4627,12 @@ onBeforeUnmount(() => {
 
 .plan-card-markdown :deep(.message-task-checkbox) {
   @apply mt-0.5 text-sm leading-none select-none;
-  color: var(--theme-text-muted);
+  color: var(--theme-message-muted);
 }
 
 .plan-card-markdown :deep(.message-code-block) {
   @apply overflow-hidden rounded-xl border;
-  border-color: var(--theme-border);
+  border-color: var(--theme-message-inline-code-border);
   background: var(--theme-code-bg);
   color: var(--theme-code-text);
 }
@@ -4650,8 +4650,8 @@ onBeforeUnmount(() => {
 
 .plan-card-markdown :deep(.message-inline-code) {
   @apply rounded-md px-1.5 py-0.5 font-mono text-[0.9em];
-  background: var(--theme-control-bg);
-  color: var(--theme-text-primary);
+  background: var(--theme-plan-inline-code-bg);
+  color: var(--theme-plan-inline-code-text);
 }
 
 .plan-card-markdown :deep(.message-file-link) {
@@ -4661,7 +4661,7 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-table) {
-  background: var(--theme-elevated-bg);
+  background: var(--theme-plan-table-bg);
 }
 
 .plan-step-list {
@@ -4670,29 +4670,35 @@ onBeforeUnmount(() => {
 
 .plan-step-item {
   @apply flex items-start gap-2 rounded-xl border px-3 py-2 text-sm leading-relaxed;
-  border-color: var(--theme-border);
-  background: var(--theme-elevated-bg);
-  color: var(--theme-text-primary);
+  border-color: var(--theme-plan-step-border);
+  background: var(--theme-plan-step-bg);
+  color: var(--theme-plan-step-text);
 }
 
 .plan-step-item[data-status='completed'] {
-  @apply border-emerald-200 bg-emerald-50/80;
+  border-color: var(--theme-plan-step-completed-border);
+  background: var(--theme-plan-step-completed-bg);
 }
 
 .plan-step-item[data-status='inProgress'] {
-  @apply border-amber-200 bg-amber-50/80;
+  border-color: var(--theme-plan-step-in-progress-border);
+  background: var(--theme-plan-step-in-progress-bg);
 }
 
 .plan-step-status {
-  @apply mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-200 text-xs font-semibold text-slate-700;
+  @apply mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-semibold;
+  background: var(--theme-plan-step-status-bg);
+  color: var(--theme-plan-step-status-text);
 }
 
 .plan-step-status[data-status='completed'] {
-  @apply bg-emerald-200 text-emerald-900;
+  background: var(--theme-plan-step-completed-status-bg);
+  color: var(--theme-plan-step-completed-status-text);
 }
 
 .plan-step-status[data-status='inProgress'] {
-  @apply bg-amber-200 text-amber-900;
+  background: var(--theme-plan-step-in-progress-status-bg);
+  color: var(--theme-plan-step-in-progress-status-text);
 }
 
 .plan-step-text {
@@ -4709,13 +4715,13 @@ onBeforeUnmount(() => {
 
 .message-text {
   @apply m-0 text-sm leading-relaxed whitespace-pre-wrap break-words;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
   overflow-wrap: anywhere;
 }
 
 .message-heading {
   @apply m-0 tracking-tight;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-heading);
 }
 
 .message-heading-h1 {
@@ -4740,20 +4746,20 @@ onBeforeUnmount(() => {
 
 .message-heading-h6 {
   @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em];
-  color: var(--theme-text-muted);
+  color: var(--theme-message-muted);
 }
 
 .message-blockquote {
   @apply m-0 border-l-4 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap break-words rounded-r-lg;
-  border-left-color: var(--theme-border-strong);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-secondary);
+  border-left-color: var(--theme-message-blockquote-border);
+  background: var(--theme-message-blockquote-bg);
+  color: var(--theme-message-blockquote-text);
   overflow-wrap: anywhere;
 }
 
 .message-list {
   @apply m-0 pl-5 text-sm leading-relaxed flex flex-col gap-1.5;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
 }
 
 .message-list-unordered {
@@ -4791,7 +4797,7 @@ onBeforeUnmount(() => {
 
 .message-task-checkbox {
   @apply mt-0.5 text-sm leading-none select-none;
-  color: var(--theme-text-muted);
+  color: var(--theme-message-muted);
 }
 
 .message-table-wrap {
@@ -4800,15 +4806,15 @@ onBeforeUnmount(() => {
 
 .message-table {
   @apply min-w-full border-separate border-spacing-0 overflow-hidden rounded-xl border text-sm;
-  border-color: var(--theme-border);
-  background: var(--theme-elevated-bg);
-  color: var(--theme-text-primary);
+  border-color: var(--theme-message-inline-code-border);
+  background: var(--theme-message-table-bg);
+  color: var(--theme-message-text);
 }
 
 .message-table-head-cell,
 .message-table-cell {
   @apply border-b border-l px-3 py-2 align-top whitespace-pre-wrap break-words;
-  border-color: var(--theme-border);
+  border-color: var(--theme-message-inline-code-border);
   overflow-wrap: anywhere;
 }
 
@@ -4819,8 +4825,8 @@ onBeforeUnmount(() => {
 
 .message-table-head-cell {
   @apply font-semibold;
-  background: var(--theme-elevated-strong-bg);
-  color: var(--theme-text-primary);
+  background: var(--theme-message-table-head-bg);
+  color: var(--theme-message-heading);
 }
 
 .message-table-body-row:last-child .message-table-cell {
@@ -4829,7 +4835,7 @@ onBeforeUnmount(() => {
 
 .message-bold-text {
   @apply font-semibold;
-  color: var(--theme-text-primary);
+  color: var(--theme-message-heading);
 }
 
 .message-italic-text {
@@ -4838,7 +4844,7 @@ onBeforeUnmount(() => {
 
 .message-strikethrough-text {
   @apply line-through;
-  color: var(--theme-text-muted);
+  color: var(--theme-message-muted);
 }
 
 .message-markdown-image {
@@ -4847,14 +4853,14 @@ onBeforeUnmount(() => {
 
 .message-inline-code {
   @apply rounded-md border px-1.5 py-0.5 text-[0.875em] leading-[1.4] font-mono;
-  border-color: var(--theme-border);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-primary);
+  border-color: var(--theme-message-inline-code-border);
+  background: var(--theme-message-inline-code-bg);
+  color: var(--theme-message-inline-code-text);
 }
 
 .message-code-block {
   @apply overflow-hidden rounded-xl border;
-  border-color: var(--theme-border);
+  border-color: var(--theme-message-inline-code-border);
   background: var(--theme-code-bg);
   color: var(--theme-code-text);
 }
@@ -4903,7 +4909,7 @@ onBeforeUnmount(() => {
 
 .message-divider {
   @apply m-0 border-0 h-px;
-  background: var(--theme-border-soft);
+  background: var(--theme-message-divider-bg);
 }
 
 .message-stack[data-role='user'] {
@@ -4926,7 +4932,6 @@ onBeforeUnmount(() => {
 .message-card[data-role='assistant'],
 .message-card[data-role='system'] {
   @apply px-0 py-0 bg-transparent border-none rounded-none;
-  width: fit-content;
   align-self: flex-start;
 }
 

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -4264,11 +4264,14 @@ onBeforeUnmount(() => {
 }
 
 .load-more-button {
-  @apply px-4 py-1.5 text-xs rounded-full border border-slate-300 dark:border-slate-600
-         text-slate-500 dark:text-slate-400 bg-transparent
-         hover:bg-slate-100 dark:hover:bg-slate-800
-         disabled:opacity-40 disabled:cursor-not-allowed
-         transition-colors cursor-pointer;
+  @apply px-4 py-1.5 text-xs rounded-full border bg-transparent disabled:opacity-40
+         disabled:cursor-not-allowed transition-colors cursor-pointer;
+  border-color: var(--theme-border);
+  color: var(--theme-text-secondary);
+}
+
+.load-more-button:hover {
+  background: var(--theme-control-hover-bg);
 }
 
 .conversation-item {
@@ -4508,7 +4511,10 @@ onBeforeUnmount(() => {
 }
 
 .plan-card {
-  @apply flex max-w-[min(var(--chat-card-max,76ch),100%)] flex-col gap-3 rounded-2xl border border-sky-200 bg-sky-50 px-4 py-3 text-slate-900;
+  @apply flex max-w-[min(var(--chat-card-max,76ch),100%)] flex-col gap-3 rounded-2xl border px-4 py-3;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
 }
 
 .plan-card-header {
@@ -4516,15 +4522,18 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-title {
-  @apply m-0 text-sm font-semibold leading-5 text-sky-900;
+  @apply m-0 text-sm font-semibold leading-5;
+  color: var(--theme-text-primary);
 }
 
 .plan-card-badge {
-  @apply inline-flex items-center rounded-full bg-sky-200 px-2 py-0.5 text-[11px] font-medium leading-4 text-sky-900;
+  @apply inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium leading-4;
+  background: var(--theme-control-active-bg);
+  color: var(--theme-text-primary);
 }
 
 .plan-card-explanation {
-  @apply text-slate-700;
+  color: var(--theme-text-secondary);
 }
 
 .plan-card-markdown {
@@ -4542,11 +4551,13 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-text) {
-  @apply text-sm leading-relaxed whitespace-pre-wrap text-slate-800;
+  @apply text-sm leading-relaxed whitespace-pre-wrap;
+  color: var(--theme-text-primary);
 }
 
 .plan-card-markdown :deep(.message-heading) {
-  @apply text-slate-900 tracking-tight;
+  @apply tracking-tight;
+  color: var(--theme-text-primary);
 }
 
 .plan-card-markdown :deep(.message-heading-h1) {
@@ -4570,15 +4581,20 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-heading-h6) {
-  @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em] text-slate-600;
+  @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em];
+  color: var(--theme-text-muted);
 }
 
 .plan-card-markdown :deep(.message-blockquote) {
-  @apply border-l-4 border-slate-300 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap text-slate-700 bg-slate-50/70 rounded-r-lg;
+  @apply border-l-4 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap rounded-r-lg;
+  border-left-color: var(--theme-border-strong);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .plan-card-markdown :deep(.message-list) {
-  @apply pl-5 text-sm leading-relaxed text-slate-800 flex flex-col gap-1.5;
+  @apply pl-5 text-sm leading-relaxed flex flex-col gap-1.5;
+  color: var(--theme-text-primary);
 }
 
 .plan-card-markdown :deep(.message-list-unordered) {
@@ -4610,15 +4626,22 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-task-checkbox) {
-  @apply mt-0.5 text-sm leading-none text-slate-500 select-none;
+  @apply mt-0.5 text-sm leading-none select-none;
+  color: var(--theme-text-muted);
 }
 
 .plan-card-markdown :deep(.message-code-block) {
-  @apply overflow-hidden rounded-xl border border-slate-200 bg-slate-950/95 text-slate-100;
+  @apply overflow-hidden rounded-xl border;
+  border-color: var(--theme-border);
+  background: var(--theme-code-bg);
+  color: var(--theme-code-text);
 }
 
 .plan-card-markdown :deep(.message-code-language) {
-  @apply border-b border-slate-800 bg-slate-900/90 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.08em] text-slate-400;
+  @apply border-b px-3 py-2 text-[11px] font-medium uppercase tracking-[0.08em];
+  border-color: var(--theme-border-soft);
+  background: var(--theme-code-header-bg);
+  color: var(--theme-code-muted);
 }
 
 .plan-card-markdown :deep(.message-code-pre) {
@@ -4626,15 +4649,19 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-inline-code) {
-  @apply rounded-md bg-slate-200/80 px-1.5 py-0.5 font-mono text-[0.9em] text-slate-900;
+  @apply rounded-md px-1.5 py-0.5 font-mono text-[0.9em];
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
 }
 
 .plan-card-markdown :deep(.message-file-link) {
-  @apply text-sky-700 underline decoration-sky-300 underline-offset-2;
+  @apply underline underline-offset-2;
+  color: var(--theme-link);
+  text-decoration-color: var(--theme-link-decoration);
 }
 
 .plan-card-markdown :deep(.message-table) {
-  @apply bg-white/90;
+  background: var(--theme-elevated-bg);
 }
 
 .plan-step-list {
@@ -4642,7 +4669,10 @@ onBeforeUnmount(() => {
 }
 
 .plan-step-item {
-  @apply flex items-start gap-2 rounded-xl border border-white/70 bg-white/80 px-3 py-2 text-sm leading-relaxed text-slate-800;
+  @apply flex items-start gap-2 rounded-xl border px-3 py-2 text-sm leading-relaxed;
+  border-color: var(--theme-border);
+  background: var(--theme-elevated-bg);
+  color: var(--theme-text-primary);
 }
 
 .plan-step-item[data-status='completed'] {
@@ -4678,12 +4708,14 @@ onBeforeUnmount(() => {
 }
 
 .message-text {
-  @apply m-0 text-sm leading-relaxed whitespace-pre-wrap break-words text-slate-800;
+  @apply m-0 text-sm leading-relaxed whitespace-pre-wrap break-words;
+  color: var(--theme-text-primary);
   overflow-wrap: anywhere;
 }
 
 .message-heading {
-  @apply m-0 text-slate-900 tracking-tight;
+  @apply m-0 tracking-tight;
+  color: var(--theme-text-primary);
 }
 
 .message-heading-h1 {
@@ -4707,16 +4739,21 @@ onBeforeUnmount(() => {
 }
 
 .message-heading-h6 {
-  @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em] text-slate-600;
+  @apply text-xs font-semibold leading-snug uppercase tracking-[0.04em];
+  color: var(--theme-text-muted);
 }
 
 .message-blockquote {
-  @apply m-0 border-l-4 border-slate-300 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap break-words text-slate-700 bg-slate-50/70 rounded-r-lg;
+  @apply m-0 border-l-4 pl-4 py-1 text-sm leading-relaxed whitespace-pre-wrap break-words rounded-r-lg;
+  border-left-color: var(--theme-border-strong);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
   overflow-wrap: anywhere;
 }
 
 .message-list {
-  @apply m-0 pl-5 text-sm leading-relaxed text-slate-800 flex flex-col gap-1.5;
+  @apply m-0 pl-5 text-sm leading-relaxed flex flex-col gap-1.5;
+  color: var(--theme-text-primary);
 }
 
 .message-list-unordered {
@@ -4753,7 +4790,8 @@ onBeforeUnmount(() => {
 }
 
 .message-task-checkbox {
-  @apply mt-0.5 text-sm leading-none text-slate-500 select-none;
+  @apply mt-0.5 text-sm leading-none select-none;
+  color: var(--theme-text-muted);
 }
 
 .message-table-wrap {
@@ -4761,12 +4799,16 @@ onBeforeUnmount(() => {
 }
 
 .message-table {
-  @apply min-w-full border-separate border-spacing-0 overflow-hidden rounded-xl border border-slate-200 bg-white text-sm text-slate-800;
+  @apply min-w-full border-separate border-spacing-0 overflow-hidden rounded-xl border text-sm;
+  border-color: var(--theme-border);
+  background: var(--theme-elevated-bg);
+  color: var(--theme-text-primary);
 }
 
 .message-table-head-cell,
 .message-table-cell {
-  @apply border-b border-l border-slate-200 px-3 py-2 align-top whitespace-pre-wrap break-words;
+  @apply border-b border-l px-3 py-2 align-top whitespace-pre-wrap break-words;
+  border-color: var(--theme-border);
   overflow-wrap: anywhere;
 }
 
@@ -4776,7 +4818,9 @@ onBeforeUnmount(() => {
 }
 
 .message-table-head-cell {
-  @apply bg-slate-100 font-semibold text-slate-900;
+  @apply font-semibold;
+  background: var(--theme-elevated-strong-bg);
+  color: var(--theme-text-primary);
 }
 
 .message-table-body-row:last-child .message-table-cell {
@@ -4784,7 +4828,8 @@ onBeforeUnmount(() => {
 }
 
 .message-bold-text {
-  @apply font-semibold text-slate-900;
+  @apply font-semibold;
+  color: var(--theme-text-primary);
 }
 
 .message-italic-text {
@@ -4792,7 +4837,8 @@ onBeforeUnmount(() => {
 }
 
 .message-strikethrough-text {
-  @apply line-through text-slate-500;
+  @apply line-through;
+  color: var(--theme-text-muted);
 }
 
 .message-markdown-image {
@@ -4800,15 +4846,24 @@ onBeforeUnmount(() => {
 }
 
 .message-inline-code {
-  @apply rounded-md border border-slate-200 bg-slate-100/60 px-1.5 py-0.5 text-[0.875em] leading-[1.4] text-slate-900 font-mono;
+  @apply rounded-md border px-1.5 py-0.5 text-[0.875em] leading-[1.4] font-mono;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
 }
 
 .message-code-block {
-  @apply overflow-hidden rounded-xl border border-slate-200 bg-slate-950 text-slate-100;
+  @apply overflow-hidden rounded-xl border;
+  border-color: var(--theme-border);
+  background: var(--theme-code-bg);
+  color: var(--theme-code-text);
 }
 
 .message-code-language {
-  @apply border-b border-slate-800 px-3 py-2 text-[11px] font-mono uppercase tracking-[0.08em] text-slate-400;
+  @apply border-b px-3 py-2 text-[11px] font-mono uppercase tracking-[0.08em];
+  border-color: var(--theme-border-soft);
+  background: var(--theme-code-header-bg);
+  color: var(--theme-code-muted);
 }
 
 .message-code-pre {
@@ -4820,19 +4875,35 @@ onBeforeUnmount(() => {
 }
 
 .message-file-link {
-  @apply text-sm leading-relaxed text-[#0969da] no-underline hover:text-[#1f6feb] hover:underline underline-offset-2;
+  @apply text-sm leading-relaxed no-underline hover:underline underline-offset-2;
+  color: var(--theme-link);
+  text-decoration-color: var(--theme-link-decoration);
+}
+
+.message-file-link:hover {
+  color: var(--theme-link-hover);
 }
 
 .file-link-context-menu {
-  @apply fixed z-50 min-w-36 rounded-lg border border-zinc-200 bg-white p-1 shadow-xl;
+  @apply fixed z-50 min-w-36 rounded-lg border p-1 shadow-xl;
+  border-color: var(--theme-border);
+  background: var(--theme-elevated-strong-bg);
+  color: var(--theme-text-primary);
 }
 
 .file-link-context-menu-item {
-  @apply block w-full rounded-md px-2 py-1.5 text-left text-xs text-zinc-700 hover:bg-zinc-100;
+  @apply block w-full rounded-md px-2 py-1.5 text-left text-xs;
+  color: var(--theme-text-secondary);
+}
+
+.file-link-context-menu-item:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .message-divider {
-  @apply m-0 border-0 h-px bg-slate-300/80;
+  @apply m-0 border-0 h-px;
+  background: var(--theme-border-soft);
 }
 
 .message-stack[data-role='user'] {
@@ -4845,7 +4916,8 @@ onBeforeUnmount(() => {
 }
 
 .message-card[data-role='user'] {
-  @apply rounded-2xl bg-slate-200 px-4 py-3 max-w-[min(560px,100%)];
+  @apply rounded-2xl px-4 py-3 max-w-[min(560px,100%)];
+  background: var(--theme-user-bubble-bg);
   width: fit-content;
   margin-left: auto;
   align-self: flex-end;
@@ -4854,6 +4926,8 @@ onBeforeUnmount(() => {
 .message-card[data-role='assistant'],
 .message-card[data-role='system'] {
   @apply px-0 py-0 bg-transparent border-none rounded-none;
+  width: fit-content;
+  align-self: flex-start;
 }
 
 .conversation-item[data-message-type='worked'] .message-stack,
@@ -4879,11 +4953,13 @@ onBeforeUnmount(() => {
 }
 
 .worked-separator-line {
-  @apply h-px bg-zinc-300/80 flex-1;
+  @apply h-px flex-1;
+  background: var(--theme-border-soft);
 }
 
 .worked-separator-text {
-  @apply m-0 text-sm leading-relaxed font-normal text-slate-800;
+  @apply m-0 text-sm leading-relaxed font-normal;
+  color: var(--theme-text-primary);
 }
 
 .worked-details {
@@ -4903,7 +4979,10 @@ onBeforeUnmount(() => {
 }
 
 .image-modal-close {
-  @apply absolute top-2 right-2 z-10 w-10 h-10 rounded-full bg-white/90 text-slate-900 border border-slate-300 flex items-center justify-center;
+  @apply absolute top-2 right-2 z-10 w-10 h-10 rounded-full border flex items-center justify-center;
+  border-color: var(--theme-border);
+  background: var(--theme-elevated-bg);
+  color: var(--theme-text-primary);
 }
 
 .image-modal-image {
@@ -4915,11 +4994,21 @@ onBeforeUnmount(() => {
 }
 
 .cmd-row {
-  @apply w-full flex items-center gap-2 px-3 py-1.5 rounded-lg border border-zinc-200 bg-zinc-50 cursor-pointer transition text-left hover:bg-zinc-100;
+  @apply w-full flex items-center gap-2 px-3 py-1.5 rounded-lg border cursor-pointer transition text-left;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
+}
+
+.cmd-row:hover {
+  background: var(--theme-control-hover-bg);
 }
 
 .cmd-row.cmd-row-group {
-  @apply border-dashed border-zinc-300 bg-zinc-100/90 text-zinc-600;
+  @apply border-dashed;
+  border-color: var(--theme-border-strong);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
 }
 
 .cmd-row.cmd-compact {
@@ -4946,7 +5035,8 @@ onBeforeUnmount(() => {
 }
 
 .cmd-chevron {
-  @apply text-[10px] text-zinc-400 transition-transform duration-150 flex-shrink-0;
+  @apply text-[10px] transition-transform duration-150 flex-shrink-0;
+  color: var(--theme-text-muted);
 }
 
 .cmd-chevron-open {
@@ -4954,11 +5044,13 @@ onBeforeUnmount(() => {
 }
 
 .cmd-label {
-  @apply flex-1 min-w-0 truncate text-xs font-mono text-zinc-700;
+  @apply flex-1 min-w-0 truncate text-xs font-mono;
+  color: var(--theme-text-primary);
 }
 
 .cmd-group-label {
-  @apply flex-1 min-w-0 truncate text-xs font-medium text-zinc-600;
+  @apply flex-1 min-w-0 truncate text-xs font-medium;
+  color: var(--theme-text-secondary);
 }
 
 .cmd-status {
@@ -4978,17 +5070,18 @@ onBeforeUnmount(() => {
 }
 
 .cmd-output-wrap {
-  @apply rounded-b-lg bg-zinc-900;
+  @apply rounded-b-lg;
   display: grid;
   grid-template-rows: 0fr;
   transition: grid-template-rows 300ms ease-out, border-color 300ms ease-out;
   border: 1px solid transparent;
   border-top: none;
+  background: var(--theme-code-bg);
 }
 
 .cmd-output-wrap.cmd-output-visible {
   grid-template-rows: 1fr;
-  border-color: #e4e4e7;
+  border-color: var(--theme-border);
 }
 
 .cmd-group-wrap {
@@ -5011,7 +5104,8 @@ onBeforeUnmount(() => {
 }
 
 .cmd-output {
-  @apply m-0 px-3 py-2 text-xs font-mono text-zinc-200 whitespace-pre-wrap break-words max-h-60 overflow-y-auto;
+  @apply m-0 max-h-60 overflow-y-auto whitespace-pre-wrap break-words px-3 py-2 text-xs font-mono;
+  color: var(--theme-code-text);
 }
 
 .cmd-output.cmd-output-condensed {
@@ -5031,11 +5125,13 @@ onBeforeUnmount(() => {
 }
 
 .file-change-summary-label {
-  @apply flex-1 min-w-0 truncate text-xs font-medium text-zinc-700;
+  @apply flex-1 min-w-0 truncate text-xs font-medium;
+  color: var(--theme-text-primary);
 }
 
 .file-change-summary-status {
-  @apply inline-flex max-w-28 items-center justify-end gap-1.5 text-right text-[11px] font-semibold text-zinc-500 flex-shrink-0;
+  @apply inline-flex max-w-28 shrink-0 items-center justify-end gap-1.5 text-right text-[11px] font-semibold;
+  color: var(--theme-text-muted);
 }
 
 .file-change-panel-inner {
@@ -5043,11 +5139,14 @@ onBeforeUnmount(() => {
 }
 
 .file-change-list {
-  @apply m-0 flex list-none flex-col gap-0.5 rounded-xl border border-zinc-200 bg-white/80 p-1.5;
+  @apply m-0 flex list-none flex-col gap-0.5 rounded-xl border p-1.5;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
 }
 
 .file-change-item {
-  @apply flex flex-wrap items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-zinc-700;
+  @apply flex flex-wrap items-center gap-1.5 rounded-lg px-2 py-1 text-sm;
+  color: var(--theme-text-primary);
 }
 
 .file-change-badge {
@@ -5075,15 +5174,23 @@ onBeforeUnmount(() => {
 }
 
 .file-change-path-button {
-  @apply min-w-0 border-0 bg-transparent p-0 text-left font-mono text-[13px] text-[#0969da] hover:text-[#1f6feb] hover:underline underline-offset-2;
+  @apply min-w-0 border-0 bg-transparent p-0 text-left font-mono text-[13px] hover:underline underline-offset-2;
+  color: var(--theme-link);
+}
+
+.file-change-path-button:hover {
+  color: var(--theme-link-hover);
 }
 
 .file-change-arrow {
-  @apply text-zinc-400;
+  color: var(--theme-text-muted);
 }
 
 .file-change-delta {
-  @apply ml-auto inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-1 text-[11px] font-semibold text-zinc-600;
+  @apply ml-auto inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-semibold;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-muted);
 }
 
 .file-change-signed-count {
@@ -5353,5 +5460,14 @@ onBeforeUnmount(() => {
   .diff-viewer-line-code {
     @apply px-2 py-1 text-[11px] leading-5;
   }
+}
+</style>
+
+<style>
+:root[data-theme='macos'][data-appearance='light'] .message-body[data-role='assistant'] .message-card[data-role='assistant'],
+:root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='assistant'] .message-card[data-role='assistant'],
+:root[data-theme='macos'][data-appearance='light'] .message-body[data-role='system'] .message-card[data-role='system'],
+:root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='system'] .message-card[data-role='system'] {
+  padding: 0.875rem 1rem;
 }
 </style>

--- a/src/components/content/ThreadMessageTypeMenu.vue
+++ b/src/components/content/ThreadMessageTypeMenu.vue
@@ -89,7 +89,15 @@ onBeforeUnmount(() => {
 }
 
 .thread-type-menu-trigger {
-  @apply h-7 w-7 rounded-md border border-zinc-200 bg-white p-0 text-zinc-600 flex items-center justify-center hover:bg-zinc-100;
+  @apply h-7 w-7 rounded-md border p-0 flex items-center justify-center;
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.thread-type-menu-trigger:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .thread-type-menu-icon {
@@ -97,23 +105,39 @@ onBeforeUnmount(() => {
 }
 
 .thread-type-menu-panel {
-  @apply absolute right-0 top-full mt-1 z-20 min-w-64 max-h-96 overflow-auto rounded-md border border-zinc-200 bg-white p-1 shadow-md;
+  @apply absolute right-0 top-full mt-1 z-20 min-w-64 max-h-96 overflow-auto rounded-md border p-1;
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  box-shadow: var(--theme-shadow-md);
 }
 
 .thread-type-menu-actions {
-  @apply sticky top-0 z-10 flex items-center gap-1 border-b border-zinc-100 bg-white px-1 py-1;
+  @apply sticky top-0 z-10 flex items-center gap-1 border-b px-1 py-1;
+  border-color: var(--theme-border-soft);
+  background: var(--theme-panel-bg);
 }
 
 .thread-type-menu-action-button {
-  @apply rounded px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-100;
+  @apply rounded px-2 py-1 text-xs;
+  color: var(--theme-text-secondary);
+}
+
+.thread-type-menu-action-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
 }
 
 .thread-type-menu-empty {
-  @apply m-0 px-2 py-2 text-xs text-zinc-500;
+  @apply m-0 px-2 py-2 text-xs;
+  color: var(--theme-text-muted);
 }
 
 .thread-type-menu-option {
-  @apply grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded px-2 py-1 hover:bg-zinc-100;
+  @apply grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded px-2 py-1;
+}
+
+.thread-type-menu-option:hover {
+  background: var(--theme-control-hover-bg);
 }
 
 .thread-type-menu-checkbox {
@@ -121,10 +145,12 @@ onBeforeUnmount(() => {
 }
 
 .thread-type-menu-label {
-  @apply text-xs text-zinc-700 font-mono;
+  @apply text-xs font-mono;
+  color: var(--theme-text-secondary);
 }
 
 .thread-type-menu-count {
-  @apply text-xs text-zinc-500;
+  @apply text-xs;
+  color: var(--theme-text-muted);
 }
 </style>

--- a/src/components/layout/DesktopLayout.vue
+++ b/src/components/layout/DesktopLayout.vue
@@ -166,4 +166,30 @@ function onResizeHandleMouseDown(event: MouseEvent): void {
 .drawer-leave-to .mobile-drawer {
   transform: translateX(-100%);
 }
+
+.desktop-layout {
+  background: var(--theme-shell-bg);
+  color: var(--theme-text-primary);
+}
+
+.desktop-sidebar,
+.mobile-drawer {
+  background: var(--theme-sidebar-bg);
+}
+
+.desktop-main {
+  background: var(--theme-main-bg);
+}
+
+.desktop-resize-handle {
+  background: var(--theme-border-strong);
+}
+
+.desktop-resize-handle:hover {
+  background: var(--theme-control-active-bg);
+}
+
+.mobile-drawer-backdrop {
+  background: var(--theme-overlay);
+}
 </style>

--- a/src/components/sidebar/SidebarThreadControls.vue
+++ b/src/components/sidebar/SidebarThreadControls.vue
@@ -59,4 +59,14 @@ const { t } = useUiLanguage()
 .sidebar-thread-controls-icon {
   @apply w-4 h-4;
 }
+
+.sidebar-thread-controls-button {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-thread-controls-button:hover {
+  border-color: var(--theme-border);
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
 </style>

--- a/src/components/sidebar/SidebarThreadControls.vue
+++ b/src/components/sidebar/SidebarThreadControls.vue
@@ -61,7 +61,7 @@ const { t } = useUiLanguage()
 }
 
 .sidebar-thread-controls-button {
-  color: var(--theme-text-secondary);
+  color: var(--theme-sidebar-control-text, var(--theme-text-subtle));
 }
 
 .sidebar-thread-controls-button:hover {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1967,10 +1967,6 @@ onBeforeUnmount(() => {
   @apply relative z-40;
 }
 
-.thread-row {
-  @apply hover:bg-zinc-200;
-}
-
 .thread-row[data-menu-open='true'] {
   @apply relative z-30;
 }
@@ -2079,10 +2075,6 @@ onBeforeUnmount(() => {
 
 .project-header-row:hover .project-icon-chevron {
   @apply flex opacity-100;
-}
-
-.thread-row[data-active='true'] {
-  @apply bg-zinc-200;
 }
 
 .thread-row:hover .thread-pin-button,

--- a/src/style.css
+++ b/src/style.css
@@ -43,6 +43,12 @@
   --theme-text-secondary: #3f3f46;
   --theme-text-subtle: #52525b;
   --theme-text-muted: #71717a;
+  --theme-shell-text: #0f172a;
+  --theme-heading-text: #18181b;
+  --theme-runtime-bg: #f4f4f5;
+  --theme-runtime-selected-bg: #ffffff;
+  --theme-runtime-selected-border: #e4e4e7;
+  --theme-runtime-selected-text: #18181b;
   --theme-link: #0969da;
   --theme-link-hover: #1f6feb;
   --theme-link-decoration: rgba(9, 105, 218, 0.28);
@@ -144,13 +150,20 @@
   --theme-text-secondary: #d4d4d8;
   --theme-text-subtle: #d4d4d8;
   --theme-text-muted: #a1a1aa;
+  --theme-shell-text: #f4f4f5;
+  --theme-heading-text: #f4f4f5;
+  --theme-settings-button-text: #a1a1aa;
+  --theme-runtime-bg: #18181b;
+  --theme-runtime-selected-bg: #27272a;
+  --theme-runtime-selected-border: #52525b;
+  --theme-runtime-selected-text: #f4f4f5;
   --theme-link: #7dd3fc;
   --theme-link-hover: #bae6fd;
   --theme-link-decoration: rgba(125, 211, 252, 0.28);
   --theme-control-bg: #3f3f46;
   --theme-control-hover-bg: #3f3f46;
   --theme-control-active-bg: #3f3f46;
-  --theme-accent: #3f3f46;
+  --theme-accent: #18181b;
   --theme-accent-hover: #52525b;
   --theme-accent-contrast: #f4f4f5;
   --theme-success-solid-bg: #10b981;
@@ -675,7 +688,7 @@ body {
 
 .desktop-layout {
   background: var(--theme-shell-bg);
-  color: var(--theme-text-primary);
+  color: var(--theme-shell-text, var(--theme-text-primary));
 }
 
 .desktop-sidebar {
@@ -689,12 +702,12 @@ body {
 
 .desktop-main {
   background: var(--theme-main-bg);
-  color: var(--theme-text-primary);
+  color: var(--theme-shell-text, var(--theme-text-primary));
 }
 
 .content-root {
   background: var(--theme-main-bg);
-  color: var(--theme-text-primary);
+  color: var(--theme-shell-text, var(--theme-text-primary));
 }
 
 .sidebar-settings-area {
@@ -783,7 +796,7 @@ body {
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button {
-  color: var(--theme-text-secondary);
+  color: var(--theme-settings-button-text, var(--theme-text-secondary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button:hover {
@@ -1074,6 +1087,10 @@ body {
 :root[data-theme][data-appearance] .request-title,
 :root[data-theme][data-appearance] .request-reason {
   color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .new-thread-hero {
+  color: var(--theme-heading-text, var(--theme-text-primary));
 }
 
 :root[data-theme][data-appearance] .rate-limit-card-plan,
@@ -1437,6 +1454,12 @@ body {
   border-color: var(--theme-selection-border);
   background: var(--theme-selection-bg);
   color: var(--theme-selection-text);
+}
+
+:root[data-theme][data-appearance] .runtime-toggle-option.is-selected {
+  border-color: var(--theme-runtime-selected-border, var(--theme-selection-border));
+  background: var(--theme-runtime-selected-bg, var(--theme-selection-bg));
+  color: var(--theme-runtime-selected-text, var(--theme-selection-text));
 }
 
 :root[data-theme][data-appearance] .thread-composer-attach-switch::after {

--- a/src/style.css
+++ b/src/style.css
@@ -1,1459 +1,3113 @@
 @import "tailwindcss";
+@import "tailwindcss-uikit-colors/v4/macos.css";
 @import "highlight.js/styles/github-dark.css";
+@import "./theme/app-shell-theme.css";
 
-:root.dark {
+/*
+ * Align Tailwind v4's dark variant with the app's explicit appearance
+ * toggle. Without this, `dark:*` utilities fall back to
+ * `prefers-color-scheme: dark` and ignore the user's choice. Keeping
+ * `.dark` as the Tailwind compatibility switch lets `dark:*` utilities
+ * follow the selected appearance while the app itself is themed by tokens.
+ */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/*
+ * Theme token layer
+ *
+ * Theme identity and effective appearance are separate concerns:
+ * `data-theme` selects a named theme, while `data-appearance` resolves the
+ * light/dark presentation after applying the system preference.
+ */
+
+:root[data-theme='default'][data-appearance='light'] {
+  color-scheme: light;
+  --theme-body-background: #f1f5f9;
+  --theme-body-text: #0f172a;
+  --theme-shell-bg: #f1f5f9;
+  --theme-sidebar-bg: #f1f5f9;
+  --theme-main-bg: #ffffff;
+  --theme-panel-bg: rgba(255, 255, 255, 0.94);
+  --theme-panel-subtle-bg: rgba(248, 250, 252, 0.9);
+  --theme-elevated-bg: rgba(255, 255, 255, 0.96);
+  --theme-elevated-strong-bg: #ffffff;
+  --theme-user-bubble-bg: #e2e8f0;
+  --theme-code-bg: #09090b;
+  --theme-code-header-bg: rgba(24, 24, 27, 0.92);
+  --theme-code-text: #f8fafc;
+  --theme-code-muted: #94a3b8;
+  --theme-border: #e4e4e7;
+  --theme-border-strong: #d4d4d8;
+  --theme-border-soft: rgba(228, 228, 231, 0.72);
+  --theme-text-primary: #0f172a;
+  --theme-text-secondary: #3f3f46;
+  --theme-text-muted: #71717a;
+  --theme-link: #0969da;
+  --theme-link-hover: #1f6feb;
+  --theme-link-decoration: rgba(9, 105, 218, 0.28);
+  --theme-control-bg: rgba(255, 255, 255, 0.94);
+  --theme-control-hover-bg: #f4f4f5;
+  --theme-control-active-bg: #e4e4e7;
+  --theme-accent: #18181b;
+  --theme-accent-hover: #27272a;
+  --theme-accent-contrast: #ffffff;
+  --theme-success-solid-bg: #10b981;
+  --theme-success-solid-hover-bg: #059669;
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: rgba(16, 185, 129, 0.12);
+  --theme-success-border: rgba(16, 185, 129, 0.35);
+  --theme-success-text: #047857;
+  --theme-warning-solid-bg: #d97706;
+  --theme-warning-solid-hover-bg: #b45309;
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: rgba(245, 158, 11, 0.12);
+  --theme-warning-border: rgba(245, 158, 11, 0.35);
+  --theme-warning-text: #b45309;
+  --theme-danger-solid-bg: #f43f5e;
+  --theme-danger-solid-hover-bg: #e11d48;
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: rgba(244, 63, 94, 0.1);
+  --theme-danger-border: rgba(244, 63, 94, 0.35);
+  --theme-danger-text: #be123c;
+  --theme-info-solid-bg: #0284c7;
+  --theme-info-solid-hover-bg: #0369a1;
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: rgba(14, 165, 233, 0.1);
+  --theme-info-border: rgba(14, 165, 233, 0.35);
+  --theme-info-text: #0369a1;
+  --theme-selection-bg: rgba(228, 228, 231, 0.88);
+  --theme-selection-border: rgba(212, 212, 216, 0.9);
+  --theme-selection-text: #0f172a;
+  --theme-overlay: rgba(15, 23, 42, 0.4);
+  --theme-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --theme-shadow-md: 0 14px 36px rgba(15, 23, 42, 0.1);
+  --theme-shadow-lg: 0 24px 64px rgba(15, 23, 42, 0.18);
+  --theme-backdrop-blur: 0px;
+}
+
+:root[data-theme='default'][data-appearance='dark'] {
   color-scheme: dark;
-}
-
-:root.dark body {
-  @apply bg-zinc-900 text-zinc-100;
-}
-
-:root.dark .desktop-layout {
-  @apply bg-zinc-900 text-zinc-100;
-}
-
-:root.dark .desktop-sidebar {
-  @apply bg-zinc-900;
-}
-
-:root.dark .desktop-resize-handle {
-  @apply bg-zinc-700 hover:bg-zinc-600;
-}
-
-:root.dark .desktop-main {
-  @apply bg-zinc-950;
-}
-
-:root.dark .mobile-drawer {
-  @apply bg-zinc-900;
-}
-
-:root.dark .sidebar-root {
-  @apply bg-zinc-900;
-}
-
-:root.dark .content-root {
-  @apply bg-zinc-950;
-}
-
-:root.dark .sidebar-scrollable {
-  @apply bg-zinc-900;
-}
-
-:root.dark .sidebar-settings-area {
-  @apply bg-zinc-900 border-zinc-700;
-}
-
-:root.dark .sidebar-settings-button {
-  @apply text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200;
-}
-
-:root.dark .sidebar-settings-panel {
-  @apply border-zinc-700 bg-zinc-800;
-}
-
-:root.dark .sidebar-settings-row {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .sidebar-settings-row + .sidebar-settings-row {
-  @apply border-zinc-700;
-}
-
-:root.dark .sidebar-settings-context-value {
-  @apply text-zinc-300;
-}
-
-:root.dark .sidebar-settings-context-value[data-state='ok'] {
-  @apply text-emerald-300;
-}
-
-:root.dark .sidebar-settings-context-value[data-state='warning'] {
-  @apply text-amber-300;
-}
-
-:root.dark .sidebar-settings-context-value[data-state='danger'] {
-  @apply text-rose-300;
-}
-
-:root.dark .sidebar-settings-context-meta {
-  @apply text-zinc-400;
-}
-
-:root.dark .sidebar-settings-rate-limits {
-  @apply border-zinc-700;
-}
-
-:root.dark .sidebar-settings-account-section {
-  @apply border-zinc-700 bg-zinc-800/70;
-}
-
-:root.dark .sidebar-settings-account-title {
-  @apply text-zinc-200;
-}
-
-:root.dark .sidebar-settings-account-count {
-  @apply bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .sidebar-settings-account-error {
-  @apply bg-rose-950/40 text-rose-200;
-}
-
-:root.dark .sidebar-settings-account-refresh,
-:root.dark .sidebar-settings-account-switch {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-200 hover:bg-zinc-600;
-}
-
-:root.dark .sidebar-settings-account-empty {
-  @apply text-zinc-400;
-}
-
-:root.dark .sidebar-settings-account-item {
-  @apply border-zinc-700 bg-zinc-900/70;
-}
-
-:root.dark .sidebar-settings-account-item.is-active {
-  @apply border-emerald-500/35 bg-emerald-500/10;
-}
-
-:root.dark .sidebar-settings-account-item.is-unavailable {
-  @apply border-rose-500/35 bg-rose-500/10;
-}
-
-:root.dark .sidebar-settings-account-email {
-  @apply text-zinc-100;
-}
-
-:root.dark .sidebar-settings-account-meta {
-  @apply text-zinc-400;
-}
-
-:root.dark .sidebar-settings-account-quota {
-  @apply text-zinc-300;
-}
-
-:root.dark .sidebar-settings-account-id {
-  @apply bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .sidebar-settings-account-item.is-active .sidebar-settings-account-id {
-  @apply bg-emerald-500/15 text-emerald-200;
-}
-
-:root.dark .sidebar-settings-account-item.is-unavailable .sidebar-settings-account-id {
-  @apply bg-rose-500/15 text-rose-200;
-}
-
-:root.dark .sidebar-settings-account-remove {
-  @apply border-amber-500/35 bg-zinc-700 text-zinc-400 hover:bg-amber-500/10;
-}
-
-:root.dark .sidebar-settings-account-remove.is-confirming {
-  @apply border-amber-400/50 bg-amber-500/10 text-amber-200;
-}
-
-:root.dark .sidebar-settings-value {
-  @apply text-zinc-400 bg-zinc-700;
-}
-
-:root.dark .sidebar-settings-toggle {
-  @apply bg-zinc-600;
-}
-
-:root.dark .sidebar-settings-toggle.is-on {
-  @apply bg-zinc-300;
-}
-
-:root.dark .sidebar-settings-toggle::after {
-  @apply bg-zinc-900;
-}
-
-:root.dark .sidebar-skills-link {
-  @apply border-emerald-900/70 bg-[linear-gradient(135deg,_rgba(6,78,59,0.42),_rgba(24,24,27,0.96))] text-zinc-100 hover:border-emerald-700 hover:bg-emerald-950;
-}
-
-:root.dark .sidebar-skills-link.is-active {
-  @apply border-emerald-700 bg-emerald-950/80 text-zinc-50;
-}
-
-:root.dark .sidebar-search-toggle {
-  @apply text-zinc-400 hover:border-zinc-600 hover:bg-zinc-800;
-}
-
-:root.dark .sidebar-search-toggle[aria-pressed='true'] {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .sidebar-search-bar {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .sidebar-search-input {
-  @apply text-zinc-200 placeholder-zinc-500;
-}
-
-:root.dark .thread-tree-header {
-  @apply text-zinc-500;
-}
-
-:root.dark .thread-row {
-  @apply hover:bg-zinc-800;
-}
-
-:root.dark .thread-row[data-active='true'] {
-  @apply bg-zinc-800;
-}
-
-:root.dark .thread-row-title {
-  @apply text-zinc-200;
-}
-
-:root.dark .thread-row-time {
-  @apply text-zinc-500;
-}
-
-:root.dark .project-header-row {
-  @apply hover:bg-zinc-800;
-}
-
-:root.dark .project-title {
-  @apply text-zinc-300;
-}
-
-:root.dark .thread-composer-shell {
-  @apply border-zinc-700 bg-zinc-800;
-}
-
-:root.dark .thread-composer-shell--drag-active {
-  @apply border-zinc-400 shadow-zinc-950/60;
-}
-
-:root.dark .thread-composer-input {
-  @apply text-zinc-100;
-}
-
-:root.dark .thread-composer-input:disabled {
-  @apply bg-zinc-700 text-zinc-500;
-}
-
-:root.dark .thread-composer-input-wrap--drag-active {
-  @apply bg-zinc-900/70;
-}
-
-:root.dark .thread-composer-drop-overlay {
-  @apply border-zinc-500 bg-zinc-900/92;
-}
-
-:root.dark .thread-composer-drop-overlay-copy {
-  @apply bg-zinc-100 text-zinc-900;
-}
-
-:root.dark .thread-composer-attach-trigger {
-  @apply text-zinc-400 hover:text-zinc-200;
-}
-
-:root.dark .thread-composer-submit {
-  @apply bg-zinc-200 text-zinc-900 hover:bg-white;
-}
-
-:root.dark .thread-composer-submit:disabled {
-  @apply bg-zinc-700 text-zinc-500;
-}
-
-:root.dark .thread-composer-mic {
-  @apply bg-zinc-700 text-zinc-400 hover:bg-zinc-600 hover:text-zinc-200;
-}
-
-:root.dark .thread-composer-stop {
-  @apply bg-zinc-200 text-zinc-900 hover:bg-white;
-}
-
-:root.dark .composer-dropdown-trigger {
-  @apply text-zinc-400;
-}
-
-
-:root.dark .composer-dropdown-menu {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .composer-dropdown-option {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .composer-dropdown-option.is-selected {
-  @apply bg-zinc-700;
-}
-
-:root.dark .content-header {
-  @apply border-zinc-800 bg-zinc-950;
-}
-
-:root.dark .content-header .content-title,
-:root.dark .content-title {
-  @apply text-zinc-200;
-}
-
-:root.dark .sidebar-thread-controls-button {
-  @apply text-zinc-400 hover:border-zinc-600 hover:bg-zinc-800;
-}
-
-:root.dark .new-thread-hero {
-  @apply text-zinc-100;
-}
-
-:root.dark .build-badge {
-  @apply border-zinc-700 bg-zinc-800/95 text-zinc-400;
-}
-
-:root.dark .rate-limit-card {
-  @apply border-zinc-700 bg-zinc-800/95;
-}
-
-:root.dark .rate-limit-card-title {
-  @apply text-zinc-500;
-}
-
-:root.dark .rate-limit-card-plan {
-  @apply bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .rate-limit-card-metric {
-  @apply bg-amber-900/40 text-amber-200;
-}
-
-:root.dark .rate-limit-card-footer {
-  @apply text-zinc-400;
-}
-
-:root.dark .thread-composer-attach-menu {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .thread-composer-attach-item {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .thread-composer-attach-separator {
-  @apply bg-zinc-700;
-}
-
-:root.dark .thread-composer-attach-setting {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .thread-composer-attach-setting-label {
-  @apply text-zinc-100;
-}
-
-:root.dark .thread-composer-attach-setting-description {
-  @apply text-zinc-400;
-}
-
-:root.dark .thread-composer-attach-mode-label {
-  @apply text-zinc-100;
-}
-
-:root.dark .thread-composer-attach-mode-buttons {
-  @apply border-zinc-600 bg-zinc-900;
-}
-
-:root.dark .thread-composer-attach-mode-button {
-  @apply text-zinc-300 hover:text-zinc-100;
-}
-
-:root.dark .thread-composer-attach-mode-button.is-active {
-  @apply bg-zinc-200 text-zinc-900 hover:text-zinc-900;
-}
-
-:root.dark .thread-composer-attach-switch {
-  @apply bg-zinc-600;
-}
-
-:root.dark .thread-composer-attach-switch::after {
-  @apply bg-zinc-100;
-}
-
-:root.dark .thread-composer-attach-switch.is-on {
-  @apply bg-emerald-500;
-}
-
-:root.dark .thread-composer-file-mentions {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .thread-composer-file-mention-row {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .thread-composer-file-chip {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .organize-menu-panel {
-  @apply border-zinc-600 bg-zinc-800/95;
-}
-
-:root.dark .organize-menu-item {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .organize-menu-item[data-active='true'] {
-  @apply bg-zinc-700 text-zinc-100;
-}
-
-:root.dark .project-menu-panel {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .project-menu-item {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .thread-menu-panel {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .thread-menu-item {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .thread-menu-item-danger {
-  @apply text-rose-300 hover:bg-rose-900/40;
-}
-
-:root.dark .thread-menu-trigger {
-  @apply text-zinc-400;
-}
-
-:root.dark .rename-thread-panel {
-  @apply bg-zinc-800;
-}
-
-:root.dark .rename-thread-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .rename-thread-subtitle {
-  @apply text-zinc-400;
-}
-
-:root.dark .rename-thread-input {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-100;
-}
-
-:root.dark .rename-thread-button {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .rename-thread-button-primary {
-  @apply bg-zinc-200 text-zinc-900 hover:bg-white;
-}
-
-:root.dark .rename-thread-button-danger {
-  @apply bg-rose-500 text-white hover:bg-rose-400;
-}
-
-:root.dark .thread-pin-button {
-  @apply text-zinc-400;
-}
-
-:root.dark .message-bubble {
-  @apply bg-zinc-800 text-zinc-200;
-}
-
-:root.dark .message-bubble-user {
-  @apply bg-zinc-700;
-}
-
-:root.dark .composer-search-dropdown-menu {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .composer-search-dropdown-option {
-  @apply text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .message-text {
-  @apply text-zinc-200;
-}
-
-:root.dark .message-heading {
-  @apply text-zinc-100;
-}
-
-:root.dark .message-heading-h6 {
-  @apply text-zinc-400;
-}
-
-:root.dark .message-bold-text {
-  @apply text-zinc-100;
-}
-
-:root.dark .message-italic-text {
-  @apply text-zinc-200;
-}
-
-:root.dark .message-strikethrough-text {
-  @apply text-zinc-400;
-}
-
-:root.dark .message-blockquote {
-  @apply border-zinc-600 bg-zinc-800/70 text-zinc-300;
-}
-
-:root.dark .message-list {
-  @apply text-zinc-200;
-}
-
-:root.dark .message-task-checkbox {
-  @apply text-zinc-400;
-}
-
-:root.dark .message-card[data-role='user'] {
-  @apply bg-zinc-700;
-}
-
-:root.dark .message-copy-button {
-  @apply border-zinc-700 bg-zinc-800/90 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-100;
-}
-
-:root.dark .message-copy-button[data-copied='true'] {
-  @apply border-emerald-500/40 bg-emerald-500/10 text-emerald-200;
-}
-
-:root.dark .message-rollback-button {
-  @apply text-amber-400/70 hover:text-amber-300;
-}
-
-:root.dark .message-inline-code {
-  @apply border-zinc-600 bg-zinc-700/60 text-zinc-200;
-}
-
-:root.dark .message-table {
-  @apply border-zinc-700 bg-zinc-900/90 text-zinc-100;
-}
-
-:root.dark .message-table-head-cell,
-:root.dark .message-table-cell {
-  @apply border-zinc-700;
-}
-
-:root.dark .message-table-head-cell {
-  @apply bg-zinc-800 text-zinc-100;
-}
-
-:root.dark .message-code-block {
-  @apply border-zinc-700 bg-zinc-950 text-zinc-100;
-}
-
-:root.dark .message-code-language {
-  @apply border-zinc-800 text-zinc-400;
-}
-
-:root.dark .message-divider {
-  @apply bg-zinc-700/80;
-}
-
-:root.dark .message-file-chip {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .conversation-loading,
-:root.dark .conversation-empty {
-  @apply text-zinc-500;
-}
-
-:root.dark .live-overlay-label {
-  @apply text-zinc-400;
-}
-
-:root.dark .live-overlay-reasoning {
-  @apply text-zinc-500;
-}
-
-:root.dark .cmd-row {
-  @apply border-zinc-700 bg-zinc-800 hover:bg-zinc-700;
-}
-
-:root.dark .cmd-row.cmd-row-group {
-  @apply border-zinc-700 bg-zinc-800 text-zinc-300 hover:bg-zinc-700;
-}
-
-:root.dark .cmd-chevron {
-  @apply text-zinc-300;
-}
-
-:root.dark .cmd-label {
-  @apply text-zinc-300;
-}
-
-:root.dark .cmd-group-label {
-  @apply text-zinc-300;
-}
-
-:root.dark .cmd-status {
-  @apply text-zinc-400;
-}
-
-:root.dark .cmd-status-running .cmd-status {
-  @apply text-amber-300;
-}
-
-:root.dark .cmd-status-ok .cmd-status {
-  @apply text-emerald-300;
-}
-
-:root.dark .cmd-status-error .cmd-status {
-  @apply text-rose-300;
-}
-
-:root.dark .cmd-output-wrap.cmd-output-visible {
-  @apply border-zinc-700;
-}
-
-:root.dark .file-change-summary-label {
-  @apply text-zinc-200;
-}
-
-:root.dark .file-change-path-button {
-  @apply text-sky-300 hover:text-sky-200;
-}
-
-:root.dark .file-change-summary-status {
-  @apply text-zinc-400;
-}
-
-:root.dark .file-change-list {
-  @apply border-zinc-700 bg-zinc-900/70;
-}
-
-:root.dark .file-change-item {
-  @apply text-zinc-200;
-}
-
-:root.dark .file-change-badge[data-operation='add'] {
-  @apply bg-emerald-950/70 text-emerald-300;
-}
-
-:root.dark .file-change-badge[data-operation='update'] {
-  @apply bg-sky-950/70 text-sky-300;
-}
-
-:root.dark .file-change-badge[data-operation='delete'] {
-  @apply bg-rose-950/70 text-rose-300;
-}
-
-:root.dark .file-change-badge[data-operation='move'] {
-  @apply bg-amber-950/70 text-amber-300;
-}
-
-:root.dark .file-change-arrow {
-  @apply text-zinc-500;
-}
-
-:root.dark .file-change-delta {
-  @apply bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .file-change-signed-count[data-tone='add'] {
-  @apply text-emerald-300;
-}
-
-:root.dark .file-change-signed-count[data-tone='remove'] {
-  @apply text-rose-300;
-}
-
-:root.dark .diff-viewer-shell {
-  @apply border-zinc-700 bg-zinc-900;
-}
-
-:root.dark .diff-viewer-sidebar {
-  @apply border-zinc-700 bg-zinc-950;
-}
-
-:root.dark .diff-viewer-sidebar-header {
-  @apply border-zinc-700;
-}
-
-:root.dark .diff-viewer-sidebar-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .diff-viewer-sidebar-count {
-  @apply text-zinc-400;
-}
-
-:root.dark .diff-viewer-file-button {
-  @apply hover:border-zinc-700 hover:bg-zinc-900;
-}
-
-:root.dark .diff-viewer-file-button[data-active='true'] {
-  @apply border-sky-800 bg-zinc-900;
-}
-
-:root.dark .diff-viewer-file-label {
-  @apply text-zinc-200;
-}
-
-:root.dark .diff-viewer-file-delta {
-  @apply bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .diff-viewer-main {
-  @apply bg-zinc-900;
-}
-
-:root.dark .diff-viewer-toolbar {
-  @apply border-zinc-700 bg-zinc-900;
-}
-
-:root.dark .diff-viewer-mobile-files-button {
-  @apply border-zinc-700 bg-zinc-800 text-zinc-200;
-}
-
-:root.dark .diff-viewer-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .diff-viewer-subtitle {
-  @apply text-zinc-400;
-}
-
-:root.dark .diff-viewer-empty-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .diff-viewer-empty-text {
-  @apply text-zinc-400;
-}
-
-:root.dark .diff-viewer-meta {
-  @apply border-zinc-700 bg-zinc-950;
-}
-
-:root.dark .diff-viewer-language {
-  @apply bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .diff-viewer-mobile-sheet {
-  @apply border-zinc-700 bg-zinc-900;
-}
-
-:root.dark .diff-viewer-mobile-sheet-handle {
-  @apply bg-zinc-700;
-}
-
-:root.dark .diff-viewer-mobile-sheet-header {
-  @apply border-zinc-700;
-}
-
-:root.dark .diff-viewer-close {
-  @apply border-zinc-700 bg-zinc-800 text-zinc-100;
-}
-
-:root.dark .content-header-branch-dropdown .composer-dropdown-trigger {
-  @apply border-zinc-700 bg-zinc-900 text-zinc-300 hover:bg-zinc-800;
-}
-
-:root.dark .content-header-branch-dropdown.is-review-open .composer-dropdown-trigger {
-  @apply border-zinc-200 bg-zinc-200 text-zinc-900 hover:bg-white;
-}
-
-:root.dark .content-header-branch-dropdown.is-review-open .composer-dropdown-chevron {
-  @apply text-zinc-900;
-}
-
-:root.dark .review-pane {
-  @apply border-zinc-700 bg-zinc-900;
-}
-
-:root.dark .review-pane-header,
-:root.dark .review-pane-toolbar,
-:root.dark .review-pane-bulk-actions,
-:root.dark .review-pane-hunk-header {
-  @apply border-zinc-700;
-}
-
-:root.dark .review-pane-header,
-:root.dark .review-pane-toolbar,
-:root.dark .review-pane-hunk-header,
-:root.dark .review-pane-summary-card,
-:root.dark .review-pane-file-header,
-:root.dark .review-pane-hunk,
-:root.dark .review-pane-finding,
-:root.dark .review-pane-sheet {
-  @apply bg-zinc-900;
-}
-
-:root.dark .review-pane-eyebrow {
-  @apply text-zinc-500;
-}
-
-:root.dark .review-pane-title,
-:root.dark .review-pane-empty-title,
-:root.dark .review-pane-file-title,
-:root.dark .review-pane-summary-title,
-:root.dark .review-pane-finding-title,
-:root.dark .review-pane-sheet-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .review-pane-empty-text,
-:root.dark .review-pane-file-subtitle,
-:root.dark .review-pane-hunk-meta,
-:root.dark .review-pane-finding-location,
-:root.dark .review-pane-finding-body {
-  @apply text-zinc-400;
-}
-
-:root.dark .review-pane-close,
-:root.dark .review-pane-mobile-files-button,
-:root.dark .review-pane-refresh,
-:root.dark .review-pane-bulk-button,
-:root.dark .review-pane-row-button,
-:root.dark .review-pane-primary-cta {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200 hover:bg-zinc-700;
-}
-
-:root.dark .review-pane-control-label {
-  @apply text-zinc-500;
-}
-
-:root.dark .review-pane-branch-select-wrap {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .review-pane-branch-select {
-  @apply text-zinc-200;
-}
-
-:root.dark .review-pane-segmented {
-  @apply bg-zinc-800;
-}
-
-:root.dark .review-pane-segmented-button {
-  @apply text-zinc-400;
-}
-
-:root.dark .review-pane-segmented-button::before {
-  @apply bg-zinc-600;
-}
-
-:root.dark .review-pane-segmented-button[data-active='true'] {
-  @apply border-sky-400/40 bg-sky-500 text-white;
-}
-
-:root.dark .review-pane-segmented-button[data-active='true']::before {
-  @apply bg-white;
-}
-
-:root.dark .review-pane-run,
-:root.dark .review-pane-primary-cta {
-  @apply border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-400;
-}
-
-:root.dark .review-pane-refresh {
-  @apply border-amber-500/35 bg-amber-500/12 text-amber-200 hover:bg-amber-500/20;
-}
-
-:root.dark .review-pane-meta span,
-:root.dark .review-pane-sheet-count {
-  @apply bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .review-pane-summary-pill.review-pane-summary-pill-add {
-  @apply bg-emerald-500/15 text-emerald-300;
-}
-
-:root.dark .review-pane-summary-pill.review-pane-summary-pill-remove {
-  @apply bg-rose-500/15 text-rose-300;
-}
-
-:root.dark .review-pane-file-list {
-  @apply border-zinc-700 bg-zinc-950/70;
-}
-
-:root.dark .review-pane-tree-folder {
-  @apply text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100;
-}
-
-:root.dark .review-pane-tree-folder-sheet {
-  @apply bg-zinc-800/80;
-}
-
-:root.dark .review-pane-tree-folder-count {
-  @apply bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .review-pane-resizer {
-  @apply bg-zinc-800;
-}
-
-:root.dark .review-pane-resizer::before {
-  @apply bg-zinc-600;
-}
-
-:root.dark .review-pane-resizer:hover::before {
-  @apply bg-sky-400;
-}
-
-:root.dark .review-pane-file {
-  @apply hover:border-zinc-600 hover:bg-zinc-800;
-}
-
-:root.dark .review-pane-file[data-active='true'] {
-  @apply border-zinc-500 bg-zinc-800;
-}
-
-:root.dark .review-pane-file-path {
-  @apply text-zinc-100;
-}
-
-:root.dark .review-pane-file-op[data-operation='update'] {
-  @apply bg-amber-500/15 text-amber-200;
-}
-
-:root.dark .review-pane-file-op[data-operation='add'] {
-  @apply bg-emerald-500/15 text-emerald-200;
-}
-
-:root.dark .review-pane-file-op[data-operation='delete'] {
-  @apply bg-rose-500/15 text-rose-200;
-}
-
-:root.dark .review-pane-file-op[data-operation='rename'] {
-  @apply bg-sky-500/15 text-sky-200;
-}
-
-:root.dark .review-pane-file-delta,
-:root.dark .review-pane-meta {
-  @apply text-zinc-500;
-}
-
-:root.dark .review-pane-delta-add {
-  @apply text-emerald-300;
-}
-
-:root.dark .review-pane-delta-remove {
-  @apply text-rose-300;
-}
-
-:root.dark .review-pane-delta-separator {
-  @apply text-zinc-500;
-}
-
-:root.dark .review-pane-file-header,
-:root.dark .review-pane-hunk,
-:root.dark .review-pane-summary-card,
-:root.dark .review-pane-finding {
-  @apply border-zinc-700;
-}
-
-:root.dark .review-pane-hunk[data-active='true'] {
-  box-shadow: 0 0 0 1px rgba(244, 244, 245, 0.12);
-  @apply border-zinc-400;
-}
-
-:root.dark .review-pane-lines,
-:root.dark .review-pane-raw-diff {
-  @apply border-zinc-700 bg-zinc-950;
-}
-
-:root.dark .review-pane-line-number,
-:root.dark .review-pane-line-marker {
-  @apply text-zinc-600;
-}
-
-:root.dark .review-pane-line[data-kind='add'] .review-pane-line-marker,
-:root.dark .review-pane-line[data-kind='add'] .review-pane-line-code {
-  @apply text-emerald-300;
-}
-
-:root.dark .review-pane-line[data-kind='remove'] .review-pane-line-marker,
-:root.dark .review-pane-line[data-kind='remove'] .review-pane-line-code {
-  @apply text-rose-300;
-}
-
-:root.dark .review-pane-sheet-handle {
-  @apply bg-zinc-700;
-}
-
-:root.dark .review-pane-sheet-backdrop {
-  @apply bg-black/55;
-}
-
-:root.dark .worked-separator-text {
-  @apply text-zinc-300;
-}
-
-:root.dark .worked-separator-line {
-  @apply bg-zinc-700;
-}
-
-:root.dark .request-card {
-  @apply border-amber-700 bg-amber-900/30;
-}
-
-:root.dark .request-title {
-  @apply text-amber-200;
-}
-
-:root.dark .request-meta {
-  @apply text-amber-400;
-}
-
-:root.dark .request-reason {
-  @apply text-amber-200;
-}
-
-:root.dark .request-button {
-  @apply border-amber-700 bg-zinc-800 text-amber-200 hover:bg-zinc-700;
-}
-
-:root.dark .request-button-primary {
-  @apply border-amber-600 bg-amber-600 text-white hover:bg-amber-700;
-}
-
-:root.dark .request-question-option-description {
-  @apply text-amber-400;
-}
-
-:root.dark .plan-card {
-  @apply border-sky-700/70 bg-slate-900/78;
-}
-
-:root.dark .plan-card-title {
-  @apply text-sky-200;
-}
-
-:root.dark .plan-card-badge {
-  @apply bg-sky-800 text-sky-100;
-}
-
-:root.dark .plan-card-explanation {
-  @apply text-zinc-200;
-}
-
-:root.dark .plan-card-markdown .message-text,
-:root.dark .plan-card-markdown .message-heading,
-:root.dark .plan-card-markdown .message-list,
-:root.dark .plan-card-markdown .message-list-item-text {
-  @apply text-zinc-200;
-}
-
-:root.dark .plan-card-markdown .message-heading-h6 {
-  @apply text-zinc-400;
-}
-
-:root.dark .plan-card-markdown .message-blockquote {
-  @apply border-zinc-600 bg-zinc-800/70 text-zinc-300;
-}
-
-:root.dark .plan-card-markdown .message-inline-code {
-  @apply bg-zinc-800 text-zinc-100;
-}
-
-:root.dark .plan-card-markdown .message-file-link {
-  @apply text-sky-300 decoration-sky-500;
-}
-
-:root.dark .plan-card-markdown .message-table {
-  @apply bg-zinc-900/90;
-}
-
-:root.dark .plan-step-item {
-  @apply border-zinc-700 bg-zinc-800/72 text-zinc-100;
-}
-
-:root.dark .plan-step-item[data-status='completed'] {
-  @apply border-emerald-900 bg-emerald-950/40;
-}
-
-:root.dark .plan-step-item[data-status='inProgress'] {
-  @apply border-amber-900 bg-amber-950/40;
-}
-
-:root.dark .plan-step-status {
-  @apply bg-zinc-700 text-zinc-200;
-}
-
-:root.dark .plan-step-status[data-status='completed'] {
-  @apply bg-emerald-900 text-emerald-200;
-}
-
-:root.dark .plan-step-status[data-status='inProgress'] {
-  @apply bg-amber-900 text-amber-200;
-}
-
-:root.dark .plan-card-implement-button {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-100 hover:border-zinc-500 hover:bg-zinc-700;
-}
-
-:root.dark .message-image-button {
-  @apply border-zinc-600 bg-zinc-800;
-}
-
-:root.dark .message-file-link {
-  @apply text-blue-400 hover:text-blue-300;
-}
-
-:root.dark .composer-dropdown-search-input {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-200;
-}
-
-:root.dark .composer-dropdown-chevron {
-  @apply text-zinc-500;
-}
-
-:root.dark .composer-dropdown-empty {
-  @apply text-zinc-500;
-}
-
-:root.dark .search-dropdown-trigger,
-:root.dark .search-dropdown-trigger:disabled,
-:root.dark .search-dropdown-value,
-:root.dark .search-dropdown-chevron {
-  @apply text-zinc-400;
-}
-
-:root.dark .search-dropdown-menu-wrap-up,
-:root.dark .search-dropdown-menu-wrap-down {
-  @apply border-zinc-700 bg-zinc-900 shadow-[0_18px_48px_rgba(0,0,0,0.45)];
-}
-
-:root.dark .search-dropdown-search-wrap {
-  @apply border-zinc-800;
-}
-
-:root.dark .search-dropdown-search,
-:root.dark .search-dropdown-create,
-:root.dark .search-dropdown-create-icon {
-  @apply border-zinc-700 bg-zinc-950 text-zinc-100 placeholder-zinc-500;
-}
-
-:root.dark .search-dropdown-create:hover,
-:root.dark .search-dropdown-create-icon:hover {
-  @apply bg-zinc-900;
-}
-
-:root.dark .search-dropdown-option {
-  @apply text-zinc-200;
-}
-
-:root.dark .search-dropdown-option.is-highlighted,
-:root.dark .search-dropdown-option-main:hover {
-  @apply bg-zinc-800;
-}
-
-:root.dark .search-dropdown-option-label {
-  @apply text-zinc-100;
-}
-
-:root.dark .search-dropdown-option-desc {
-  @apply text-zinc-400;
-}
-
-:root.dark .search-dropdown-option-remove {
-  @apply text-zinc-300;
-}
-
-:root.dark .search-dropdown-option-remove:hover {
-  @apply bg-zinc-700 text-zinc-100;
-}
-
-:root.dark .search-dropdown-empty {
-  @apply text-zinc-500;
-}
-
-:root.dark .thread-composer-skill-chip {
-  @apply border-emerald-800 bg-emerald-900/40 text-emerald-300;
-}
-
-:root.dark .thread-composer-input::placeholder {
-  @apply text-zinc-500;
-}
-
-:root.dark .new-thread-folder-dropdown {
-  @apply text-zinc-400;
-}
-
-:root.dark .new-thread-folder-dropdown .composer-dropdown-trigger {
-  @apply text-zinc-300;
-}
-
-:root.dark .new-thread-folder-dropdown .composer-dropdown-value {
-  @apply text-zinc-200;
-}
-
-:root.dark .runtime-toggle {
-  @apply border-zinc-700 bg-zinc-900;
-}
-
-:root.dark .runtime-toggle-option {
-  @apply text-zinc-300;
-}
-
-:root.dark .runtime-toggle-option:hover {
-  @apply bg-zinc-800 text-zinc-100;
-}
-
-:root.dark .runtime-toggle-option.is-selected {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-100 shadow-none;
-}
-
-:root.dark .runtime-toggle-option:focus-visible {
-  @apply ring-zinc-600 ring-offset-zinc-900;
-}
-
-:root.dark .runtime-toggle-option-icon {
-  @apply text-zinc-400;
-}
-
-:root.dark .runtime-toggle-option.is-selected .runtime-toggle-option-icon {
-  @apply text-zinc-200;
-}
-
-:root.dark .worktree-init-status.is-running {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-300;
-}
-
-:root.dark .worktree-init-status.is-error {
-  @apply border-rose-700 bg-rose-950/40 text-rose-200;
-}
-
-:root.dark .skills-hub-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .skills-hub-subtitle {
-  @apply text-zinc-400;
-}
-
-:root.dark .skills-hub-search-wrap {
-  @apply border-zinc-700 bg-zinc-800 focus-within:border-zinc-500;
-}
-
-:root.dark .skills-hub-search-icon {
-  @apply text-zinc-500;
-}
-
-:root.dark .skills-hub-search {
-  @apply text-zinc-200 placeholder-zinc-500;
-}
-
-:root.dark .skills-hub-search-btn,
-:root.dark .skills-hub-sort {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200 hover:bg-zinc-700 hover:border-zinc-500;
-}
-
-:root.dark .skills-hub-count {
-  @apply text-zinc-500;
-}
-
-:root.dark .skills-sync-panel {
-  @apply border-zinc-700 bg-zinc-800;
-}
-
-:root.dark .skills-sync-header {
-  @apply text-zinc-300;
-}
-
-:root.dark .skills-sync-badge {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-200;
-}
-
-:root.dark .skills-sync-badge-link {
-  @apply text-zinc-200 hover:text-white hover:border-zinc-500;
-}
-
-:root.dark .skills-sync-device,
-:root.dark .skills-sync-meta {
-  @apply text-zinc-400;
-}
-
-:root.dark .skills-sync-device a {
-  @apply text-blue-400 hover:text-blue-300;
-}
-
-:root.dark .skills-sync-device code {
-  @apply border border-zinc-600 bg-zinc-700 px-1.5 py-0.5 rounded text-zinc-200;
-}
-
-:root.dark .skills-sync-error {
-  @apply border-rose-800 bg-rose-950/40 text-rose-200;
-}
-
-:root.dark .skills-hub-section-toggle {
-  @apply text-zinc-300 hover:text-zinc-100;
-}
-
-:root.dark .skills-hub-loading,
-:root.dark .skills-hub-empty {
-  @apply text-zinc-400;
-}
-
-:root.dark .skills-hub-error {
-  @apply border-rose-800 bg-rose-950/40 text-rose-200;
-}
-
-:root.dark .directory-title,
-:root.dark .directory-card-title,
-:root.dark .directory-modal-title,
-:root.dark .directory-mini-heading,
-:root.dark .directory-detail-heading {
-  @apply text-zinc-100;
-}
-
-:root.dark .directory-subtitle,
-:root.dark .directory-card-meta,
-:root.dark .directory-card-description,
-:root.dark .directory-mini-list,
-:root.dark .directory-detail-description {
-  @apply text-zinc-400;
-}
-
-:root.dark .directory-tabs,
-:root.dark .directory-search,
-:root.dark .directory-card,
-:root.dark .directory-loading,
-:root.dark .directory-empty,
-:root.dark .directory-modal,
-:root.dark .directory-refresh,
-:root.dark .directory-action,
-:root.dark .directory-action-link,
-:root.dark .directory-modal-close {
-  @apply border-zinc-700 bg-zinc-900 text-zinc-100;
-}
-
-:root.dark .directory-tab,
-:root.dark .directory-sort-button {
-  @apply text-zinc-400 hover:text-zinc-100;
-}
-
-:root.dark .directory-search {
-  @apply text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500;
-}
-
-:root.dark .directory-tab.is-active,
-:root.dark .directory-sort-button.is-active,
-:root.dark .directory-detail-block,
-:root.dark .directory-auth-panel,
-:root.dark .directory-chip {
-  @apply border-zinc-700 bg-zinc-800 text-zinc-100;
-}
-
-:root.dark .directory-sort-group {
-  @apply border-zinc-700 bg-zinc-950;
-}
-
-:root.dark .directory-badge.is-muted,
-:root.dark .directory-auth-status.is-muted {
-  @apply border-zinc-700 bg-zinc-900 text-zinc-400;
-}
-
-:root.dark .skill-card {
-  @apply border-zinc-700 bg-zinc-800 hover:border-zinc-600 hover:bg-zinc-700/70;
-}
-
-:root.dark .skill-card-avatar {
-  @apply bg-zinc-700;
-}
-
-:root.dark .skill-card-avatar-fallback {
-  @apply bg-zinc-600 text-zinc-300;
-}
-
-:root.dark .skill-card-name {
-  @apply text-zinc-100;
-}
-
-:root.dark .skill-card-badge-disabled {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .skill-card-owner {
-  @apply text-zinc-400;
-}
-
-:root.dark .skill-card-browse {
-  @apply text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200;
-}
-
-:root.dark .skill-card-desc {
-  @apply text-zinc-300;
-}
-
-:root.dark .skill-card-date {
-  @apply text-zinc-500;
-}
-
-:root.dark .sdm-panel {
-  @apply bg-zinc-800;
-}
-
-:root.dark .sdm-title {
-  @apply text-zinc-100;
-}
-
-:root.dark .sdm-badge-disabled {
-  @apply border-zinc-600 bg-zinc-700 text-zinc-300;
-}
-
-:root.dark .sdm-owner {
-  @apply text-zinc-400;
-}
-
-:root.dark .sdm-close {
-  @apply text-zinc-400 hover:bg-zinc-700 hover:text-zinc-100;
-}
-
-:root.dark .sdm-desc {
-  @apply text-zinc-300;
-}
-
-:root.dark .sdm-readme-loading {
-  @apply text-zinc-400;
-}
-
-:root.dark .sdm-readme {
-  @apply text-zinc-300 border-zinc-700;
-}
-
-:root.dark .sdm-readme h2 {
-  @apply text-zinc-100;
-}
-
-:root.dark .sdm-readme h3 {
-  @apply text-zinc-200;
-}
-
-:root.dark .sdm-readme h4 {
-  @apply text-zinc-300;
-}
-
-:root.dark .sdm-readme code {
-  @apply bg-zinc-700 text-zinc-200;
-}
-
-:root.dark .sdm-footer {
-  @apply border-zinc-700;
-}
-
-:root.dark .sdm-btn-primary {
-  @apply bg-zinc-200 text-zinc-900 hover:bg-white;
-}
-
-:root.dark .sdm-btn-secondary {
-  @apply bg-zinc-700 text-zinc-200 hover:bg-zinc-600;
+  --theme-body-background: #18181b;
+  --theme-body-text: #f4f4f5;
+  --theme-shell-bg: #18181b;
+  --theme-sidebar-bg: #18181b;
+  --theme-main-bg: #09090b;
+  --theme-panel-bg: rgba(39, 39, 42, 0.96);
+  --theme-panel-subtle-bg: rgba(39, 39, 42, 0.84);
+  --theme-elevated-bg: rgba(39, 39, 42, 0.96);
+  --theme-elevated-strong-bg: #27272a;
+  --theme-user-bubble-bg: #3f3f46;
+  --theme-code-bg: #09090b;
+  --theme-code-header-bg: rgba(24, 24, 27, 0.96);
+  --theme-code-text: #f4f4f5;
+  --theme-code-muted: #a1a1aa;
+  --theme-border: #3f3f46;
+  --theme-border-strong: #52525b;
+  --theme-border-soft: rgba(63, 63, 70, 0.82);
+  --theme-text-primary: #f4f4f5;
+  --theme-text-secondary: #d4d4d8;
+  --theme-text-muted: #a1a1aa;
+  --theme-link: #7dd3fc;
+  --theme-link-hover: #bae6fd;
+  --theme-link-decoration: rgba(125, 211, 252, 0.28);
+  --theme-control-bg: rgba(39, 39, 42, 0.94);
+  --theme-control-hover-bg: #3f3f46;
+  --theme-control-active-bg: #52525b;
+  --theme-accent: #3f3f46;
+  --theme-accent-hover: #52525b;
+  --theme-accent-contrast: #f4f4f5;
+  --theme-success-solid-bg: #10b981;
+  --theme-success-solid-hover-bg: #34d399;
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: rgba(16, 185, 129, 0.1);
+  --theme-success-border: rgba(16, 185, 129, 0.35);
+  --theme-success-text: #a7f3d0;
+  --theme-warning-solid-bg: #d97706;
+  --theme-warning-solid-hover-bg: #f59e0b;
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: rgba(245, 158, 11, 0.12);
+  --theme-warning-border: rgba(245, 158, 11, 0.35);
+  --theme-warning-text: #fde68a;
+  --theme-danger-solid-bg: #f43f5e;
+  --theme-danger-solid-hover-bg: #fb7185;
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: rgba(244, 63, 94, 0.1);
+  --theme-danger-border: rgba(244, 63, 94, 0.35);
+  --theme-danger-text: #fecdd3;
+  --theme-info-solid-bg: #0ea5e9;
+  --theme-info-solid-hover-bg: #38bdf8;
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: rgba(14, 165, 233, 0.12);
+  --theme-info-border: rgba(14, 165, 233, 0.35);
+  --theme-info-text: #bae6fd;
+  --theme-selection-bg: rgba(63, 63, 70, 0.92);
+  --theme-selection-border: rgba(82, 82, 91, 0.92);
+  --theme-selection-text: #f4f4f5;
+  --theme-overlay: rgba(0, 0, 0, 0.42);
+  --theme-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --theme-shadow-md: 0 14px 36px rgba(0, 0, 0, 0.32);
+  --theme-shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.42);
+  --theme-backdrop-blur: 0px;
+}
+
+:root[data-theme='graphite'][data-appearance='light'] {
+  color-scheme: light;
+  --theme-body-background: #eef2f7;
+  --theme-body-text: #111827;
+  --theme-shell-bg: #e7edf5;
+  --theme-sidebar-bg: #e7edf5;
+  --theme-main-bg: #fbfdff;
+  --theme-panel-bg: rgba(255, 255, 255, 0.92);
+  --theme-panel-subtle-bg: rgba(239, 244, 250, 0.92);
+  --theme-elevated-bg: rgba(255, 255, 255, 0.97);
+  --theme-elevated-strong-bg: #ffffff;
+  --theme-user-bubble-bg: #dbe4ef;
+  --theme-code-bg: #0f172a;
+  --theme-code-header-bg: rgba(15, 23, 42, 0.94);
+  --theme-code-text: #e5eefb;
+  --theme-code-muted: #94a3b8;
+  --theme-border: #d5dde8;
+  --theme-border-strong: #c1ccda;
+  --theme-border-soft: rgba(213, 221, 232, 0.8);
+  --theme-text-primary: #111827;
+  --theme-text-secondary: #374151;
+  --theme-text-muted: #6b7280;
+  --theme-link: #2563eb;
+  --theme-link-hover: #1d4ed8;
+  --theme-link-decoration: rgba(37, 99, 235, 0.26);
+  --theme-control-bg: rgba(248, 250, 252, 0.96);
+  --theme-control-hover-bg: #e8eef6;
+  --theme-control-active-bg: #dbe4ef;
+  --theme-accent: #1f2937;
+  --theme-accent-hover: #111827;
+  --theme-accent-contrast: #f9fafb;
+  --theme-success-solid-bg: #10b981;
+  --theme-success-solid-hover-bg: #059669;
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: rgba(16, 185, 129, 0.12);
+  --theme-success-border: rgba(16, 185, 129, 0.35);
+  --theme-success-text: #047857;
+  --theme-warning-solid-bg: #d97706;
+  --theme-warning-solid-hover-bg: #b45309;
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: rgba(245, 158, 11, 0.12);
+  --theme-warning-border: rgba(245, 158, 11, 0.35);
+  --theme-warning-text: #b45309;
+  --theme-danger-solid-bg: #f43f5e;
+  --theme-danger-solid-hover-bg: #e11d48;
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: rgba(244, 63, 94, 0.1);
+  --theme-danger-border: rgba(244, 63, 94, 0.35);
+  --theme-danger-text: #be123c;
+  --theme-info-solid-bg: #2563eb;
+  --theme-info-solid-hover-bg: #1d4ed8;
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: rgba(37, 99, 235, 0.1);
+  --theme-info-border: rgba(37, 99, 235, 0.35);
+  --theme-info-text: #1d4ed8;
+  --theme-selection-bg: rgba(219, 228, 239, 0.9);
+  --theme-selection-border: rgba(193, 204, 218, 0.9);
+  --theme-selection-text: #111827;
+  --theme-overlay: rgba(15, 23, 42, 0.42);
+  --theme-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.07);
+  --theme-shadow-md: 0 16px 36px rgba(15, 23, 42, 0.11);
+  --theme-shadow-lg: 0 28px 72px rgba(15, 23, 42, 0.18);
+  --theme-backdrop-blur: 0px;
+}
+
+:root[data-theme='graphite'][data-appearance='dark'] {
+  color-scheme: dark;
+  --theme-body-background: #111827;
+  --theme-body-text: #e5e7eb;
+  --theme-shell-bg: #111827;
+  --theme-sidebar-bg: #111827;
+  --theme-main-bg: #030712;
+  --theme-panel-bg: rgba(31, 41, 55, 0.96);
+  --theme-panel-subtle-bg: rgba(31, 41, 55, 0.84);
+  --theme-elevated-bg: rgba(31, 41, 55, 0.96);
+  --theme-elevated-strong-bg: #1f2937;
+  --theme-user-bubble-bg: #374151;
+  --theme-code-bg: #030712;
+  --theme-code-header-bg: rgba(3, 7, 18, 0.96);
+  --theme-code-text: #e5e7eb;
+  --theme-code-muted: #9ca3af;
+  --theme-border: #374151;
+  --theme-border-strong: #4b5563;
+  --theme-border-soft: rgba(55, 65, 81, 0.82);
+  --theme-text-primary: #e5e7eb;
+  --theme-text-secondary: #cbd5e1;
+  --theme-text-muted: #9ca3af;
+  --theme-link: #93c5fd;
+  --theme-link-hover: #bfdbfe;
+  --theme-link-decoration: rgba(147, 197, 253, 0.3);
+  --theme-control-bg: rgba(31, 41, 55, 0.94);
+  --theme-control-hover-bg: #374151;
+  --theme-control-active-bg: #4b5563;
+  --theme-accent: #374151;
+  --theme-accent-hover: #4b5563;
+  --theme-accent-contrast: #e5e7eb;
+  --theme-success-solid-bg: #10b981;
+  --theme-success-solid-hover-bg: #34d399;
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: rgba(16, 185, 129, 0.1);
+  --theme-success-border: rgba(16, 185, 129, 0.35);
+  --theme-success-text: #a7f3d0;
+  --theme-warning-solid-bg: #d97706;
+  --theme-warning-solid-hover-bg: #f59e0b;
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: rgba(245, 158, 11, 0.12);
+  --theme-warning-border: rgba(245, 158, 11, 0.35);
+  --theme-warning-text: #fde68a;
+  --theme-danger-solid-bg: #f43f5e;
+  --theme-danger-solid-hover-bg: #fb7185;
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: rgba(244, 63, 94, 0.1);
+  --theme-danger-border: rgba(244, 63, 94, 0.35);
+  --theme-danger-text: #fecdd3;
+  --theme-info-solid-bg: #3b82f6;
+  --theme-info-solid-hover-bg: #60a5fa;
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: rgba(59, 130, 246, 0.12);
+  --theme-info-border: rgba(59, 130, 246, 0.35);
+  --theme-info-text: #bfdbfe;
+  --theme-selection-bg: rgba(55, 65, 81, 0.92);
+  --theme-selection-border: rgba(75, 85, 99, 0.92);
+  --theme-selection-text: #e5e7eb;
+  --theme-overlay: rgba(0, 0, 0, 0.46);
+  --theme-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --theme-shadow-md: 0 14px 36px rgba(0, 0, 0, 0.34);
+  --theme-shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.44);
+  --theme-backdrop-blur: 0px;
+}
+
+:root[data-theme='macos'][data-appearance='light'] {
+  color-scheme: light;
+  --theme-font-sans:
+    "SF Pro Display",
+    "SF Pro Text",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Helvetica Neue",
+    sans-serif;
+  --theme-font-mono:
+    "SF Mono",
+    "SFMono-Regular",
+    ui-monospace,
+    "Cascadia Code",
+    "Source Code Pro",
+    Menlo,
+    Monaco,
+    monospace;
+  --theme-body-background: rgb(var(--color-materialThick-light));
+  --theme-body-text: rgb(var(--color-text-light));
+  --theme-shell-bg: rgb(var(--color-materialThick-light));
+  --theme-sidebar-bg: rgb(var(--color-sidebar-light));
+  --theme-macos-sidebar-surface-bg: color-mix(in srgb, rgb(var(--color-sidebar-light)) 94%, rgb(var(--color-materialThin-light)));
+  --theme-main-bg: rgb(var(--color-materialThin-light));
+  --theme-panel-bg: rgb(var(--color-materialMedium-light));
+  --theme-panel-subtle-bg: rgb(var(--color-materialThin-light));
+  --theme-elevated-bg: rgb(var(--color-materialThick-light));
+  --theme-elevated-strong-bg: rgb(var(--color-materialOpaque-light));
+  --theme-floating-panel-bg: rgb(var(--color-materialOpaque-light));
+  --theme-user-bubble-bg: rgb(var(--color-selectionUnfocusedFill-light));
+  --theme-code-bg: rgba(17, 24, 39, 0.92);
+  --theme-code-header-bg: rgba(30, 41, 59, 0.92);
+  --theme-code-text: #f8fafc;
+  --theme-code-muted: #cbd5e1;
+  --theme-border: rgb(var(--color-fill-light));
+  --theme-border-strong: rgb(var(--color-fillSecondary-light));
+  --theme-border-soft: rgb(var(--color-textQuinary-light));
+  --theme-text-primary: rgb(var(--color-text-light));
+  --theme-text-secondary: rgb(var(--color-textSecondary-light));
+  --theme-text-muted: rgb(var(--color-textTertiary-light));
+  --theme-link: rgb(var(--color-blue-light));
+  --theme-link-hover: rgb(var(--color-blue-dark));
+  --theme-link-decoration: rgb(var(--color-selectionFocused-light));
+  --theme-control-bg: rgb(var(--color-controlEnabled-light));
+  --theme-control-hover-bg: rgb(var(--color-fillQuinary-light));
+  --theme-control-active-bg: rgb(var(--color-selectionUnfocusedFill-light));
+  --theme-accent: rgb(var(--color-blue-light));
+  --theme-accent-hover: rgb(var(--color-blue-dark));
+  --theme-accent-contrast: #ffffff;
+  --theme-success-solid-bg: rgb(var(--color-green-light));
+  --theme-success-solid-hover-bg: rgb(var(--color-green-dark));
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: color-mix(in srgb, rgb(var(--color-green-light)) 14%, transparent);
+  --theme-success-border: color-mix(in srgb, rgb(var(--color-green-light)) 30%, transparent);
+  --theme-success-text: rgb(var(--color-green-dark));
+  --theme-warning-solid-bg: rgb(var(--color-orange-light));
+  --theme-warning-solid-hover-bg: rgb(var(--color-orange-dark));
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: color-mix(in srgb, rgb(var(--color-orange-light)) 14%, transparent);
+  --theme-warning-border: color-mix(in srgb, rgb(var(--color-orange-light)) 30%, transparent);
+  --theme-warning-text: rgb(var(--color-orange-dark));
+  --theme-danger-solid-bg: rgb(var(--color-red-light));
+  --theme-danger-solid-hover-bg: rgb(var(--color-red-dark));
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: color-mix(in srgb, rgb(var(--color-red-light)) 12%, transparent);
+  --theme-danger-border: color-mix(in srgb, rgb(var(--color-red-light)) 28%, transparent);
+  --theme-danger-text: rgb(var(--color-red-dark));
+  --theme-info-solid-bg: rgb(var(--color-blue-dark));
+  --theme-info-solid-hover-bg: rgb(var(--color-blue-light));
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: color-mix(in srgb, rgb(var(--color-blue-light)) 12%, transparent);
+  --theme-info-border: color-mix(in srgb, rgb(var(--color-blue-light)) 28%, transparent);
+  --theme-info-text: rgb(var(--color-blue-dark));
+  --theme-selection-bg: rgb(var(--color-selectionFocused-light));
+  --theme-selection-border: color-mix(in srgb, rgb(var(--color-selectionFocusedFill-light)) 32%, transparent);
+  --theme-selection-text: #12304f;
+  --theme-overlay: rgb(var(--color-popover-light));
+  --theme-shadow-sm: 0 1px 3px rgba(29, 29, 31, 0.08);
+  --theme-shadow-md: 0 12px 28px rgba(29, 29, 31, 0.09);
+  --theme-shadow-lg: 0 20px 48px rgba(29, 29, 31, 0.14);
+  --theme-backdrop-blur: 18px;
+  --theme-macos-control-radius: 12px;
+  --theme-macos-panel-radius: 18px;
+  --theme-macos-row-radius: 10px;
+}
+
+:root[data-theme='macos'][data-appearance='dark'] {
+  color-scheme: dark;
+  --theme-font-sans:
+    "SF Pro Display",
+    "SF Pro Text",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Helvetica Neue",
+    sans-serif;
+  --theme-font-mono:
+    "SF Mono",
+    "SFMono-Regular",
+    ui-monospace,
+    "Cascadia Code",
+    "Source Code Pro",
+    Menlo,
+    Monaco,
+    monospace;
+  --theme-body-background: rgb(var(--color-materialThick-dark));
+  --theme-body-text: rgb(var(--color-text-dark));
+  --theme-shell-bg: rgb(var(--color-materialThick-dark));
+  --theme-sidebar-bg: rgb(var(--color-sidebar-dark));
+  --theme-macos-sidebar-surface-bg: color-mix(in srgb, rgb(var(--color-sidebar-dark)) 94%, rgb(var(--color-materialThin-dark)));
+  --theme-main-bg: rgb(var(--color-materialThin-dark));
+  --theme-panel-bg: rgb(var(--color-materialMedium-dark));
+  --theme-panel-subtle-bg: rgb(var(--color-materialThin-dark));
+  --theme-elevated-bg: rgb(var(--color-materialThick-dark));
+  --theme-elevated-strong-bg: rgb(var(--color-materialOpaque-dark));
+  --theme-floating-panel-bg: rgb(var(--color-materialOpaque-dark));
+  --theme-user-bubble-bg: rgb(var(--color-selectionUnfocusedFill-dark));
+  --theme-code-bg: rgba(2, 6, 23, 0.96);
+  --theme-code-header-bg: rgba(15, 23, 42, 0.96);
+  --theme-code-text: #e2e8f0;
+  --theme-code-muted: #94a3b8;
+  --theme-border: rgb(var(--color-fill-dark));
+  --theme-border-strong: rgb(var(--color-fillSecondary-dark));
+  --theme-border-soft: rgb(var(--color-textQuinary-dark));
+  --theme-text-primary: rgb(var(--color-text-dark));
+  --theme-text-secondary: rgb(var(--color-textSecondary-dark));
+  --theme-text-muted: rgb(var(--color-textTertiary-dark));
+  --theme-link: rgb(var(--color-blue-dark));
+  --theme-link-hover: rgb(var(--color-blue-light));
+  --theme-link-decoration: rgb(var(--color-selectionFocused-dark));
+  --theme-control-bg: color-mix(in srgb, rgb(var(--color-controlEnabled-dark)) 58%, rgb(var(--color-materialOpaque-dark)));
+  --theme-control-hover-bg: color-mix(in srgb, rgb(var(--color-fillQuinary-dark)) 58%, rgb(var(--color-materialOpaque-dark)));
+  --theme-control-active-bg: rgb(var(--color-selectionUnfocusedFill-dark));
+  --theme-accent: rgb(var(--color-blue-dark));
+  --theme-accent-hover: rgb(var(--color-blue-light));
+  --theme-accent-contrast: #ffffff;
+  --theme-success-solid-bg: rgb(var(--color-green-dark));
+  --theme-success-solid-hover-bg: rgb(var(--color-green-light));
+  --theme-success-solid-text: #ffffff;
+  --theme-success-soft-bg: color-mix(in srgb, rgb(var(--color-green-dark)) 12%, transparent);
+  --theme-success-border: color-mix(in srgb, rgb(var(--color-green-dark)) 28%, transparent);
+  --theme-success-text: rgb(var(--color-green-dark));
+  --theme-warning-solid-bg: rgb(var(--color-orange-dark));
+  --theme-warning-solid-hover-bg: rgb(var(--color-orange-light));
+  --theme-warning-solid-text: #ffffff;
+  --theme-warning-soft-bg: color-mix(in srgb, rgb(var(--color-orange-dark)) 14%, transparent);
+  --theme-warning-border: color-mix(in srgb, rgb(var(--color-orange-dark)) 30%, transparent);
+  --theme-warning-text: rgb(var(--color-orange-light));
+  --theme-danger-solid-bg: rgb(var(--color-red-dark));
+  --theme-danger-solid-hover-bg: rgb(var(--color-red-light));
+  --theme-danger-solid-text: #ffffff;
+  --theme-danger-soft-bg: color-mix(in srgb, rgb(var(--color-red-dark)) 12%, transparent);
+  --theme-danger-border: color-mix(in srgb, rgb(var(--color-red-dark)) 30%, transparent);
+  --theme-danger-text: rgb(var(--color-red-light));
+  --theme-info-solid-bg: rgb(var(--color-blue-dark));
+  --theme-info-solid-hover-bg: rgb(var(--color-blue-light));
+  --theme-info-solid-text: #ffffff;
+  --theme-info-soft-bg: color-mix(in srgb, rgb(var(--color-blue-dark)) 14%, transparent);
+  --theme-info-border: color-mix(in srgb, rgb(var(--color-blue-dark)) 30%, transparent);
+  --theme-info-text: rgb(var(--color-blue-light));
+  --theme-selection-bg: rgb(var(--color-selectionFocused-dark));
+  --theme-selection-border: color-mix(in srgb, rgb(var(--color-selectionFocusedFill-dark)) 32%, transparent);
+  --theme-selection-text: #f5f5f7;
+  --theme-overlay: rgb(var(--color-popover-dark));
+  --theme-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.22);
+  --theme-shadow-md: 0 12px 28px rgba(0, 0, 0, 0.24);
+  --theme-shadow-lg: 0 20px 48px rgba(0, 0, 0, 0.3);
+  --theme-backdrop-blur: 20px;
+  --theme-macos-control-radius: 12px;
+  --theme-macos-panel-radius: 18px;
+  --theme-macos-row-radius: 10px;
+}
+
+body {
+  background: var(--theme-body-background);
+  color: var(--theme-body-text);
+}
+
+.desktop-layout {
+  background: var(--theme-shell-bg);
+  color: var(--theme-text-primary);
+}
+
+.desktop-sidebar {
+  background: var(--theme-sidebar-bg);
+}
+
+.sidebar-root,
+.sidebar-scrollable {
+  background: var(--theme-sidebar-bg);
+}
+
+.desktop-main {
+  background: var(--theme-main-bg);
+  color: var(--theme-text-primary);
+}
+
+.content-root {
+  background: var(--theme-main-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-area {
+  background: var(--theme-sidebar-bg);
+  border-color: var(--theme-border);
+}
+
+.composer-dropdown-trigger {
+  color: var(--theme-text-secondary);
+}
+
+.composer-dropdown-menu {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+.message-bubble {
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
+}
+
+.message-bubble-user,
+.message-card[data-role='user'] {
+  background: var(--theme-user-bubble-bg);
+}
+
+.message-text {
+  color: var(--theme-text-primary);
+}
+
+.message-list,
+.message-italic-text {
+  color: var(--theme-text-primary);
+}
+
+.message-heading,
+.message-bold-text {
+  color: var(--theme-text-primary);
+}
+
+.message-inline-code {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.message-code-block {
+  border-color: var(--theme-border);
+  background: var(--theme-code-bg);
+  color: var(--theme-code-text);
+}
+
+.message-code-language {
+  border-color: var(--theme-border-soft);
+  color: var(--theme-code-muted);
+}
+
+.conversation-loading,
+.conversation-empty {
+  color: var(--theme-text-muted);
+}
+
+.cmd-row {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+.cmd-row:hover,
+.cmd-row.cmd-row-group:hover {
+  background: var(--theme-control-hover-bg);
+}
+
+.cmd-row.cmd-row-group,
+.cmd-chevron,
+.cmd-label,
+.cmd-group-label {
+  color: var(--theme-text-secondary);
+}
+
+.cmd-status {
+  color: var(--theme-text-muted);
+}
+
+.cmd-output-wrap.cmd-output-visible {
+  border-color: var(--theme-border);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button-version {
+  color: var(--theme-text-muted);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-panel {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row {
+  color: var(--theme-text-primary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row:hover {
+  background: var(--theme-control-hover-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-language-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row + .sidebar-settings-row {
+  border-color: var(--theme-border);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-telegram-panel,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-section {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-field-label,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-title,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-email {
+  color: var(--theme-text-primary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-input,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-textarea {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-input:focus,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-textarea:focus {
+  border-color: var(--theme-selection-border);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-selection-border) 28%, transparent);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-field-help,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-empty,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-meta,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-quota {
+  color: var(--theme-text-muted);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-collapse,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-refresh,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-switch {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-collapse:hover,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-refresh:hover,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-switch:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-count,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-id,
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-value {
+  background: var(--theme-control-active-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-item {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-remove {
+  border-color: var(--theme-warning-border);
+  background: var(--theme-warning-soft-bg);
+  color: var(--theme-warning-text);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-remove:hover {
+  background: color-mix(in srgb, var(--theme-warning-soft-bg) 88%, var(--theme-warning-solid-bg));
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-toggle {
+  background: var(--theme-border-strong);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-toggle::after {
+  background: var(--theme-elevated-strong-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-toggle.is-on {
+  background: var(--theme-selection-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-error {
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .desktop-resize-handle,
+:root[data-theme][data-appearance] .thread-composer-attach-switch,
+:root[data-theme][data-appearance] .review-pane-segmented-button::before,
+:root[data-theme][data-appearance] .review-pane-resizer::before,
+:root[data-theme][data-appearance] .diff-viewer-mobile-sheet-handle,
+:root[data-theme][data-appearance] .review-pane-sheet-handle {
+  background: var(--theme-border-strong);
+}
+
+:root[data-theme][data-appearance] .desktop-resize-handle:hover,
+:root[data-theme][data-appearance] .review-pane-resizer:hover::before {
+  background: var(--theme-control-active-bg);
+}
+
+:root[data-theme][data-appearance] .mobile-drawer,
+:root[data-theme][data-appearance] .content-header,
+:root[data-theme][data-appearance] .diff-viewer-main,
+:root[data-theme][data-appearance] .review-pane-header,
+:root[data-theme][data-appearance] .review-pane-toolbar,
+:root[data-theme][data-appearance] .review-pane-bulk-actions,
+:root[data-theme][data-appearance] .review-pane-hunk-header,
+:root[data-theme][data-appearance] .review-pane-summary-card,
+:root[data-theme][data-appearance] .review-pane-file-header,
+:root[data-theme][data-appearance] .review-pane-hunk,
+:root[data-theme][data-appearance] .review-pane-finding,
+:root[data-theme][data-appearance] .review-pane-sheet,
+:root[data-theme][data-appearance] .sdm-panel,
+:root[data-theme][data-appearance] .rename-thread-panel {
+  background: var(--theme-main-bg);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-context-value,
+:root[data-theme][data-appearance] .sidebar-settings-account-quota,
+:root[data-theme][data-appearance] .sidebar-search-toggle,
+:root[data-theme][data-appearance] .sidebar-skills-link,
+:root[data-theme][data-appearance] .project-title,
+:root[data-theme][data-appearance] .thread-composer-attach-trigger,
+:root[data-theme][data-appearance] .thread-menu-trigger,
+:root[data-theme][data-appearance] .live-overlay-label,
+:root[data-theme][data-appearance] .skills-sync-device,
+:root[data-theme][data-appearance] .skills-sync-meta,
+:root[data-theme][data-appearance] .skills-hub-subtitle,
+:root[data-theme][data-appearance] .skills-hub-section-toggle,
+:root[data-theme][data-appearance] .skill-card-owner,
+:root[data-theme][data-appearance] .sdm-owner,
+:root[data-theme][data-appearance] .thread-composer-attach-setting-description,
+:root[data-theme][data-appearance] .rate-limit-card-footer,
+:root[data-theme][data-appearance] .rate-limit-card-title,
+:root[data-theme][data-appearance] .request-meta,
+:root[data-theme][data-appearance] .request-question-option-description,
+:root[data-theme][data-appearance] .review-pane-control-label,
+:root[data-theme][data-appearance] .review-pane-file-delta,
+:root[data-theme][data-appearance] .review-pane-meta,
+:root[data-theme][data-appearance] .review-pane-delta-separator,
+:root[data-theme][data-appearance] .diff-viewer-subtitle,
+:root[data-theme][data-appearance] .diff-viewer-empty-text,
+:root[data-theme][data-appearance] .thread-row-time,
+:root[data-theme][data-appearance] .thread-tree-header,
+:root[data-theme][data-appearance] .thread-pin-button,
+:root[data-theme][data-appearance] .composer-dropdown-chevron,
+:root[data-theme][data-appearance] .composer-dropdown-empty,
+:root[data-theme][data-appearance] .conversation-loading,
+:root[data-theme][data-appearance] .conversation-empty,
+:root[data-theme][data-appearance] .worktree-init-status.is-running {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-context-value[data-state='ok'],
+:root[data-theme][data-appearance] .cmd-status-ok .cmd-status,
+:root[data-theme][data-appearance] .file-change-signed-count[data-tone='add'],
+:root[data-theme][data-appearance] .review-pane-delta-add {
+  color: var(--theme-success-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-context-value[data-state='warning'],
+:root[data-theme][data-appearance] .cmd-status-running .cmd-status {
+  color: var(--theme-warning-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-context-value[data-state='danger'],
+:root[data-theme][data-appearance] .cmd-status-error .cmd-status,
+:root[data-theme][data-appearance] .file-change-signed-count[data-tone='remove'],
+:root[data-theme][data-appearance] .review-pane-delta-remove {
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-context-meta,
+:root[data-theme][data-appearance] .sidebar-settings-account-meta,
+:root[data-theme][data-appearance] .sidebar-settings-account-empty,
+:root[data-theme][data-appearance] .sidebar-settings-key-masked,
+:root[data-theme][data-appearance] .sidebar-search-input::placeholder,
+:root[data-theme][data-appearance] .thread-composer-input::placeholder,
+:root[data-theme][data-appearance] .live-overlay-reasoning,
+:root[data-theme][data-appearance] .file-change-summary-status,
+:root[data-theme][data-appearance] .file-change-arrow,
+:root[data-theme][data-appearance] .review-pane-eyebrow,
+:root[data-theme][data-appearance] .review-pane-empty-text,
+:root[data-theme][data-appearance] .review-pane-file-subtitle,
+:root[data-theme][data-appearance] .review-pane-hunk-meta,
+:root[data-theme][data-appearance] .review-pane-finding-location,
+:root[data-theme][data-appearance] .review-pane-finding-body,
+:root[data-theme][data-appearance] .review-pane-line-number,
+:root[data-theme][data-appearance] .review-pane-line-marker,
+:root[data-theme][data-appearance] .review-pane-file-delta,
+:root[data-theme][data-appearance] .skills-hub-count,
+:root[data-theme][data-appearance] .skills-hub-loading,
+:root[data-theme][data-appearance] .skills-hub-empty,
+:root[data-theme][data-appearance] .skill-card-date,
+:root[data-theme][data-appearance] .sdm-readme-loading,
+:root[data-theme][data-appearance] .request-meta,
+:root[data-theme][data-appearance] .request-question-option-description {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .rate-limit-card,
+:root[data-theme][data-appearance] .skills-sync-panel,
+:root[data-theme][data-appearance] .skill-card,
+:root[data-theme][data-appearance] .thread-composer-shell,
+:root[data-theme][data-appearance] .thread-composer-file-mentions,
+:root[data-theme][data-appearance] .review-pane-file-list,
+:root[data-theme][data-appearance] .file-change-list,
+:root[data-theme][data-appearance] .diff-viewer-shell,
+:root[data-theme][data-appearance] .diff-viewer-toolbar,
+:root[data-theme][data-appearance] .diff-viewer-mobile-sheet,
+:root[data-theme][data-appearance] .review-pane,
+:root[data-theme][data-appearance] .review-pane-file-header,
+:root[data-theme][data-appearance] .review-pane-hunk,
+:root[data-theme][data-appearance] .review-pane-summary-card,
+:root[data-theme][data-appearance] .review-pane-finding,
+:root[data-theme][data-appearance] .request-card,
+:root[data-theme][data-appearance] .build-badge {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+:root[data-theme][data-appearance] .file-change-list,
+:root[data-theme][data-appearance] .request-card,
+:root[data-theme][data-appearance] .build-badge,
+:root[data-theme][data-appearance] .rate-limit-card,
+:root[data-theme][data-appearance] .skills-sync-panel,
+:root[data-theme][data-appearance] .skill-card {
+  background: var(--theme-panel-subtle-bg);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-title,
+:root[data-theme][data-appearance] .sidebar-settings-account-email,
+:root[data-theme][data-appearance] .thread-row-title,
+:root[data-theme][data-appearance] .thread-composer-input,
+:root[data-theme][data-appearance] .thread-composer-attach-setting-label,
+:root[data-theme][data-appearance] .thread-composer-attach-mode-label,
+:root[data-theme][data-appearance] .rename-thread-title,
+:root[data-theme][data-appearance] .new-thread-hero,
+:root[data-theme][data-appearance] .file-change-summary-label,
+:root[data-theme][data-appearance] .file-change-item,
+:root[data-theme][data-appearance] .diff-viewer-sidebar-title,
+:root[data-theme][data-appearance] .diff-viewer-file-label,
+:root[data-theme][data-appearance] .diff-viewer-title,
+:root[data-theme][data-appearance] .diff-viewer-empty-title,
+:root[data-theme][data-appearance] .review-pane-title,
+:root[data-theme][data-appearance] .review-pane-empty-title,
+:root[data-theme][data-appearance] .review-pane-file-title,
+:root[data-theme][data-appearance] .review-pane-summary-title,
+:root[data-theme][data-appearance] .review-pane-finding-title,
+:root[data-theme][data-appearance] .review-pane-sheet-title,
+:root[data-theme][data-appearance] .skills-hub-title,
+:root[data-theme][data-appearance] .skill-card-name,
+:root[data-theme][data-appearance] .sdm-title,
+:root[data-theme][data-appearance] .request-title,
+:root[data-theme][data-appearance] .request-reason {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .rate-limit-card-plan,
+:root[data-theme][data-appearance] .thread-composer-file-chip,
+:root[data-theme][data-appearance] .message-file-chip,
+:root[data-theme][data-appearance] .file-change-delta,
+:root[data-theme][data-appearance] .diff-viewer-file-delta,
+:root[data-theme][data-appearance] .diff-viewer-language,
+:root[data-theme][data-appearance] .review-pane-meta span,
+:root[data-theme][data-appearance] .review-pane-sheet-count,
+:root[data-theme][data-appearance] .review-pane-tree-folder-count,
+:root[data-theme][data-appearance] .skills-sync-badge,
+:root[data-theme][data-appearance] .skill-card-badge-disabled,
+:root[data-theme][data-appearance] .sdm-badge-disabled {
+  background: var(--theme-control-active-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-error,
+:root[data-theme][data-appearance] .skills-sync-error,
+:root[data-theme][data-appearance] .skills-hub-error,
+:root[data-theme][data-appearance] .worktree-init-status.is-error {
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .thread-composer-mic,
+:root[data-theme][data-appearance] .diff-viewer-mobile-files-button,
+:root[data-theme][data-appearance] .diff-viewer-close,
+:root[data-theme][data-appearance] .review-pane-close,
+:root[data-theme][data-appearance] .review-pane-mobile-files-button,
+:root[data-theme][data-appearance] .review-pane-bulk-button,
+:root[data-theme][data-appearance] .review-pane-row-button,
+:root[data-theme][data-appearance] .message-copy-button,
+:root[data-theme][data-appearance] .message-image-button,
+:root[data-theme][data-appearance] .request-button,
+:root[data-theme][data-appearance] .skills-hub-search-btn,
+:root[data-theme][data-appearance] .skills-hub-sort,
+:root[data-theme][data-appearance] .sdm-btn-secondary {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .thread-composer-mic:hover,
+:root[data-theme][data-appearance] .diff-viewer-mobile-files-button:hover,
+:root[data-theme][data-appearance] .diff-viewer-close:hover,
+:root[data-theme][data-appearance] .review-pane-close:hover,
+:root[data-theme][data-appearance] .review-pane-mobile-files-button:hover,
+:root[data-theme][data-appearance] .review-pane-bulk-button:hover,
+:root[data-theme][data-appearance] .review-pane-row-button:hover,
+:root[data-theme][data-appearance] .message-copy-button:hover,
+:root[data-theme][data-appearance] .request-button:hover,
+:root[data-theme][data-appearance] .skills-hub-search-btn:hover,
+:root[data-theme][data-appearance] .skills-hub-sort:hover,
+:root[data-theme][data-appearance] .sdm-btn-secondary:hover,
+:root[data-theme][data-appearance] .sidebar-skills-link:hover,
+:root[data-theme][data-appearance] .sidebar-thread-controls-button:hover,
+:root[data-theme][data-appearance] .sidebar-search-toggle:hover,
+:root[data-theme][data-appearance] .thread-composer-attach-trigger:hover,
+:root[data-theme][data-appearance] .thread-menu-trigger:hover,
+:root[data-theme][data-appearance] .review-pane-tree-folder:hover,
+:root[data-theme][data-appearance] .skill-card-browse:hover,
+:root[data-theme][data-appearance] .sdm-close:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-item,
+:root[data-theme][data-appearance] .review-pane-tree-folder-sheet,
+:root[data-theme][data-appearance] .review-pane-branch-select-wrap,
+:root[data-theme][data-appearance] .review-pane-segmented,
+:root[data-theme][data-appearance] .sidebar-search-bar,
+:root[data-theme][data-appearance] .composer-search-dropdown-menu,
+:root[data-theme][data-appearance] .thread-composer-attach-menu,
+:root[data-theme][data-appearance] .organize-menu-panel,
+:root[data-theme][data-appearance] .project-menu-panel,
+:root[data-theme][data-appearance] .thread-menu-panel {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+:root[data-theme][data-appearance] .queued-messages-inner {
+  border-color: var(--theme-border);
+  background: color-mix(in srgb, var(--theme-panel-subtle-bg) 92%, transparent);
+}
+
+:root[data-theme][data-appearance] .queued-row-icon,
+:root[data-theme][data-appearance] .queued-row-delete {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .queued-row-text {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .queued-row-edit,
+:root[data-theme][data-appearance] .queued-row-steer {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .queued-row-edit:hover,
+:root[data-theme][data-appearance] .queued-row-steer:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .queued-row-delete:hover {
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-shell {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
+  box-shadow: var(--theme-shadow-lg);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-eyebrow,
+:root[data-theme][data-appearance] .thread-pending-request-select-label {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-title,
+:root[data-theme][data-appearance] .thread-pending-request-option-label,
+:root[data-theme][data-appearance] .thread-pending-request-question-title,
+:root[data-theme][data-appearance] .thread-pending-request-link,
+:root[data-theme][data-appearance] .thread-pending-request-checkbox-row {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-counter,
+:root[data-theme][data-appearance] .thread-pending-request-command-line,
+:root[data-theme][data-appearance] .thread-pending-request-preview,
+:root[data-theme][data-appearance] .thread-pending-request-question {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-counter,
+:root[data-theme][data-appearance] .thread-pending-request-option-index,
+:root[data-theme][data-appearance] .thread-pending-request-question-text,
+:root[data-theme][data-appearance] .thread-pending-request-question-description,
+:root[data-theme][data-appearance] .thread-pending-request-input::placeholder {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-option,
+:root[data-theme][data-appearance] .thread-pending-request-inline-input,
+:root[data-theme][data-appearance] .thread-pending-request-link,
+:root[data-theme][data-appearance] .thread-pending-request-select,
+:root[data-theme][data-appearance] .thread-pending-request-input,
+:root[data-theme][data-appearance] .thread-pending-request-secondary {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-option:hover,
+:root[data-theme][data-appearance] .thread-pending-request-inline-input:hover,
+:root[data-theme][data-appearance] .thread-pending-request-link:hover,
+:root[data-theme][data-appearance] .thread-pending-request-secondary:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-option.is-selected {
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--theme-selection-border) 22%, transparent);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-inline-input.is-active {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-inline-input:focus-within,
+:root[data-theme][data-appearance] .thread-pending-request-select:focus,
+:root[data-theme][data-appearance] .thread-pending-request-input:focus {
+  border-color: var(--theme-border-strong);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-selection-border) 28%, transparent);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-inline-control {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-validation-error {
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-checkbox {
+  accent-color: var(--theme-accent);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-primary {
+  border-color: var(--theme-accent);
+  background: var(--theme-accent);
+  color: var(--theme-accent-contrast);
+}
+
+:root[data-theme][data-appearance] .thread-pending-request-primary:hover {
+  border-color: var(--theme-accent-hover);
+  background: var(--theme-accent-hover);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-item.is-active,
+:root[data-theme][data-appearance] .sidebar-settings-account-item.is-active .sidebar-settings-account-id,
+:root[data-theme][data-appearance] .message-copy-button[data-copied='true'],
+:root[data-theme][data-appearance] .review-pane-summary-pill.review-pane-summary-pill-add,
+:root[data-theme][data-appearance] .review-pane-file-op[data-operation='add'],
+:root[data-theme][data-appearance] .file-change-badge[data-operation='add'],
+:root[data-theme][data-appearance] .plan-step-item[data-status='completed'],
+:root[data-theme][data-appearance] .thread-composer-skill-chip {
+  border-color: var(--theme-success-border);
+  background: var(--theme-success-soft-bg);
+  color: var(--theme-success-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-item.is-unavailable,
+:root[data-theme][data-appearance] .sidebar-settings-account-item.is-unavailable .sidebar-settings-account-id,
+:root[data-theme][data-appearance] .review-pane-summary-pill.review-pane-summary-pill-remove,
+:root[data-theme][data-appearance] .review-pane-file-op[data-operation='delete'],
+:root[data-theme][data-appearance] .file-change-badge[data-operation='delete'] {
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-remove,
+:root[data-theme][data-appearance] .review-pane-refresh,
+:root[data-theme][data-appearance] .file-change-badge[data-operation='move'],
+:root[data-theme][data-appearance] .review-pane-file-op[data-operation='update'],
+:root[data-theme][data-appearance] .plan-step-item[data-status='inProgress'] {
+  border-color: var(--theme-warning-border);
+  background: var(--theme-warning-soft-bg);
+  color: var(--theme-warning-text);
+}
+
+:root[data-theme][data-appearance] .sidebar-settings-account-remove:hover,
+:root[data-theme][data-appearance] .review-pane-refresh:hover,
+:root[data-theme][data-appearance] .sidebar-settings-account-remove.is-confirming {
+  background: var(--theme-warning-soft-bg);
+  color: var(--theme-warning-text);
+}
+
+:root[data-theme][data-appearance] .review-pane-file-op[data-operation='rename'],
+:root[data-theme][data-appearance] .file-change-badge[data-operation='update'],
+:root[data-theme][data-appearance] .content-header-branch-dropdown.is-review-open .composer-dropdown-trigger,
+:root[data-theme][data-appearance] .review-pane-segmented-button[data-active='true'] {
+  border-color: var(--theme-info-border);
+  background: var(--theme-info-soft-bg);
+  color: var(--theme-info-text);
+}
+
+:root[data-theme][data-appearance] .content-header-branch-dropdown.is-review-open .composer-dropdown-chevron,
+:root[data-theme][data-appearance] .review-pane-segmented-button[data-active='true']::before {
+  color: var(--theme-info-solid-text);
+  background: var(--theme-info-solid-text);
+}
+
+:root[data-theme][data-appearance] .review-pane-run,
+:root[data-theme][data-appearance] .review-pane-primary-cta {
+  border-color: var(--theme-success-solid-bg);
+  background: var(--theme-success-solid-bg);
+  color: var(--theme-success-solid-text);
+}
+
+:root[data-theme][data-appearance] .review-pane-run:hover,
+:root[data-theme][data-appearance] .review-pane-primary-cta:hover {
+  background: var(--theme-success-solid-hover-bg);
+}
+
+:root[data-theme][data-appearance] .thread-composer-submit,
+:root[data-theme][data-appearance] .thread-composer-stop,
+:root[data-theme][data-appearance] .rename-thread-button-primary,
+:root[data-theme][data-appearance] .sdm-btn-primary {
+  background: var(--theme-accent);
+  color: var(--theme-accent-contrast);
+}
+
+:root[data-theme][data-appearance] .thread-composer-submit:hover,
+:root[data-theme][data-appearance] .thread-composer-stop:hover,
+:root[data-theme][data-appearance] .rename-thread-button-primary:hover,
+:root[data-theme][data-appearance] .sdm-btn-primary:hover {
+  background: var(--theme-accent-hover);
+}
+
+:root[data-theme][data-appearance] .thread-composer-submit:disabled,
+:root[data-theme][data-appearance] .thread-composer-input:disabled {
+  background: var(--theme-control-active-bg);
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .rename-thread-button-danger,
+:root[data-theme][data-appearance] .request-button-primary {
+  border-color: var(--theme-danger-solid-bg);
+  background: var(--theme-danger-solid-bg);
+  color: var(--theme-danger-solid-text);
+}
+
+:root[data-theme][data-appearance] .rename-thread-button-danger:hover,
+:root[data-theme][data-appearance] .request-button-primary:hover {
+  background: var(--theme-danger-solid-hover-bg);
+}
+
+:root[data-theme][data-appearance] .request-button-primary {
+  border-color: var(--theme-warning-solid-bg);
+  background: var(--theme-warning-solid-bg);
+  color: var(--theme-warning-solid-text);
+}
+
+:root[data-theme][data-appearance] .request-button-primary:hover {
+  background: var(--theme-warning-solid-hover-bg);
+}
+
+:root[data-theme][data-appearance] .runtime-toggle-option.is-selected,
+:root[data-theme][data-appearance] .composer-dropdown-option.is-selected,
+:root[data-theme][data-appearance] .organize-menu-item[data-active='true'],
+:root[data-theme][data-appearance] .thread-row[data-active='true'],
+:root[data-theme][data-appearance] .review-pane-file[data-active='true'],
+:root[data-theme][data-appearance] .diff-viewer-file-button[data-active='true'] {
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+}
+
+:root[data-theme][data-appearance] .thread-composer-attach-switch::after {
+  background: var(--theme-elevated-strong-bg);
+}
+
+:root[data-theme][data-appearance] .thread-composer-attach-switch.is-on {
+  background: var(--theme-success-solid-bg);
+}
+
+:root[data-theme][data-appearance] .sidebar-search-input,
+:root[data-theme][data-appearance] .rename-thread-input,
+:root[data-theme][data-appearance] .composer-dropdown-search-input,
+:root[data-theme][data-appearance] .review-pane-branch-select,
+:root[data-theme][data-appearance] .skills-hub-search,
+:root[data-theme][data-appearance] .thread-composer-input {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .rename-thread-input,
+:root[data-theme][data-appearance] .composer-dropdown-search-input,
+:root[data-theme][data-appearance] .review-pane-branch-select-wrap,
+:root[data-theme][data-appearance] .content-header-branch-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+}
+
+:root[data-theme][data-appearance] .review-pane-lines,
+:root[data-theme][data-appearance] .review-pane-raw-diff,
+:root[data-theme][data-appearance] .diff-viewer-sidebar,
+:root[data-theme][data-appearance] .diff-viewer-meta {
+  border-color: var(--theme-border);
+  background: var(--theme-code-bg);
+}
+
+:root[data-theme][data-appearance] .review-pane-header,
+:root[data-theme][data-appearance] .review-pane-toolbar,
+:root[data-theme][data-appearance] .review-pane-bulk-actions,
+:root[data-theme][data-appearance] .review-pane-hunk-header,
+:root[data-theme][data-appearance] .review-pane-file-header,
+:root[data-theme][data-appearance] .review-pane-hunk,
+:root[data-theme][data-appearance] .review-pane-summary-card,
+:root[data-theme][data-appearance] .review-pane-finding,
+:root[data-theme][data-appearance] .review-pane-sheet,
+:root[data-theme][data-appearance] .review-pane-file-list,
+:root[data-theme][data-appearance] .review-pane-sidebar,
+:root[data-theme][data-appearance] .review-pane-resizer,
+:root[data-theme][data-appearance] .diff-viewer-sidebar-header,
+:root[data-theme][data-appearance] .diff-viewer-toolbar,
+:root[data-theme][data-appearance] .diff-viewer-mobile-sheet-header,
+:root[data-theme][data-appearance] .sdm-footer {
+  border-color: var(--theme-border);
+}
+
+:root[data-theme][data-appearance] .review-pane-file,
+:root[data-theme][data-appearance] .diff-viewer-file-button,
+:root[data-theme][data-appearance] .project-menu-item,
+:root[data-theme][data-appearance] .thread-menu-item,
+:root[data-theme][data-appearance] .thread-composer-attach-item,
+:root[data-theme][data-appearance] .thread-composer-attach-setting,
+:root[data-theme][data-appearance] .thread-composer-file-mention-row,
+:root[data-theme][data-appearance] .composer-search-dropdown-option,
+:root[data-theme][data-appearance] .organize-menu-item,
+:root[data-theme][data-appearance] .rename-thread-button,
+:root[data-theme][data-appearance] .project-header-row,
+:root[data-theme][data-appearance] .thread-row,
+:root[data-theme][data-appearance] .runtime-toggle-option,
+:root[data-theme][data-appearance] .skill-card,
+:root[data-theme][data-appearance] .thread-composer-attach-mode-button {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .review-pane-file:hover,
+:root[data-theme][data-appearance] .diff-viewer-file-button:hover,
+:root[data-theme][data-appearance] .project-menu-item:hover,
+:root[data-theme][data-appearance] .thread-menu-item:hover,
+:root[data-theme][data-appearance] .thread-composer-attach-item:hover,
+:root[data-theme][data-appearance] .thread-composer-attach-setting:hover,
+:root[data-theme][data-appearance] .thread-composer-file-mention-row:hover,
+:root[data-theme][data-appearance] .composer-search-dropdown-option:hover,
+:root[data-theme][data-appearance] .organize-menu-item:hover,
+:root[data-theme][data-appearance] .rename-thread-button:hover,
+:root[data-theme][data-appearance] .project-header-row:hover,
+:root[data-theme][data-appearance] .thread-row:hover,
+:root[data-theme][data-appearance] .runtime-toggle-option:hover,
+:root[data-theme][data-appearance] .thread-composer-attach-mode-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-menu-item-danger {
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .thread-menu-item-danger:hover {
+  background: var(--theme-danger-soft-bg);
+}
+
+:root[data-theme][data-appearance] .file-change-path-button,
+:root[data-theme][data-appearance] .message-file-link,
+:root[data-theme][data-appearance] .skills-sync-device a {
+  color: var(--theme-link);
+}
+
+:root[data-theme][data-appearance] .file-change-path-button:hover,
+:root[data-theme][data-appearance] .message-file-link:hover,
+:root[data-theme][data-appearance] .skills-sync-device a:hover {
+  color: var(--theme-link-hover);
+}
+
+:root[data-theme][data-appearance] .request-card,
+:root[data-theme][data-appearance] .request-button {
+  border-color: var(--theme-warning-border);
+  background: var(--theme-warning-soft-bg);
+  color: var(--theme-warning-text);
+}
+
+:root[data-theme][data-appearance] .review-pane-sheet-backdrop {
+  background: var(--theme-overlay);
+}
+
+:root[data-theme][data-appearance] .thread-composer-shell--drag-active,
+:root[data-theme][data-appearance] .review-pane-hunk[data-active='true'] {
+  border-color: var(--theme-selection-border);
+  box-shadow: var(--theme-shadow-sm);
+}
+
+:root[data-theme='macos'][data-appearance='light'] body,
+:root[data-theme='macos'][data-appearance='dark'] body {
+  background-attachment: fixed;
+  font-family: var(--theme-font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='macos'][data-appearance='light'] code,
+:root[data-theme='macos'][data-appearance='light'] pre,
+:root[data-theme='macos'][data-appearance='light'] kbd,
+:root[data-theme='macos'][data-appearance='light'] samp,
+:root[data-theme='macos'][data-appearance='dark'] code,
+:root[data-theme='macos'][data-appearance='dark'] pre,
+:root[data-theme='macos'][data-appearance='dark'] kbd,
+:root[data-theme='macos'][data-appearance='dark'] samp {
+  font-family: var(--theme-font-mono);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .desktop-layout,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-layout {
+  background: var(--theme-shell-bg);
+  gap: 0;
+  backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(150%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .desktop-sidebar,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-sidebar,
+:root[data-theme='macos'][data-appearance='light'] .desktop-main,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-main,
+:root[data-theme='macos'][data-appearance='light'] .mobile-drawer,
+:root[data-theme='macos'][data-appearance='dark'] .mobile-drawer,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-area,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-area,
+:root[data-theme='macos'][data-appearance='light'] .content-header,
+:root[data-theme='macos'][data-appearance='dark'] .content-header,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-shell,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-shell,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-shell,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-shell,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-mobile-sheet,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-mobile-sheet {
+  backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(150%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .desktop-sidebar,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-sidebar {
+  background: var(--theme-macos-sidebar-surface-bg);
+  border-right: 1px solid var(--theme-border-soft);
+  box-shadow: inset -1px 0 0 var(--theme-border);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .desktop-sidebar,
+:root[data-theme='macos'][data-appearance='light'] .desktop-main,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-sidebar,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-main {
+  min-height: 0;
+  border-radius: 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .desktop-main,
+:root[data-theme='macos'][data-appearance='dark'] .desktop-main {
+  overflow: hidden;
+  border: 0;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--theme-main-bg) 94%, var(--theme-elevated-bg)) 0%,
+    var(--theme-main-bg) 100%
+  );
+  box-shadow:
+    inset 1px 0 0 color-mix(in srgb, var(--theme-border) 52%, transparent),
+    inset 0 1px 0 var(--theme-border-soft);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-scrollable,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-scrollable {
+  padding: 0.75rem 0.5rem 0.625rem;
+  gap: 0.75rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-host,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-host,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-header-host,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-header-host {
+  margin-top: 0;
+  padding-inline: 0.25rem;
+  padding-bottom: 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-primary-nav,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-primary-nav {
+  gap: 0.25rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-area,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-area {
+  background: color-mix(
+    in srgb,
+    var(--theme-panel-subtle-bg) 96%,
+    var(--theme-macos-sidebar-surface-bg)
+  );
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-panel,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-panel {
+  overflow: clip;
+  border-color: color-mix(in srgb, var(--theme-border) 64%, transparent);
+  background: color-mix(in srgb, var(--theme-panel-bg) 94%, var(--theme-main-bg));
+  padding-block: 0.4375rem;
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.42)) saturate(155%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.42)) saturate(155%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-section,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-section,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-telegram-panel,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-telegram-panel {
+  margin: 0.375rem 0.375rem 0.25rem;
+  border: 1px solid color-mix(in srgb, var(--theme-border) 48%, transparent);
+  border-radius: calc(var(--theme-macos-panel-radius) - 4px);
+  background: color-mix(in srgb, var(--theme-panel-subtle-bg) 74%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 86%, transparent),
+    0 1px 0 rgba(15, 23, 42, 0.04);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-section,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-section {
+  padding: 0.75rem 0.75rem 0.8125rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-telegram-panel,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-telegram-panel {
+  padding: 0.75rem 0.75rem 0.8125rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-header,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-header {
+  margin-bottom: 0.625rem;
+  gap: 0.5rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-list,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-list {
+  gap: 0.5rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-item,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-item {
+  border-radius: calc(var(--theme-macos-panel-radius) - 6px);
+  border-color: color-mix(in srgb, var(--theme-border) 58%, transparent);
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 84%, transparent),
+    0 1px 0 rgba(15, 23, 42, 0.03);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-actions,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-actions {
+  width: auto;
+  min-width: 5.125rem;
+  gap: 0.5rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--select,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--select {
+  gap: 0.75rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--input,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--input {
+  margin: 0.25rem 0.375rem 0;
+  border-top: 0;
+  border-radius: calc(var(--theme-macos-panel-radius) - 4px);
+  padding: 0.75rem 0.875rem 0.8125rem;
+  background: color-mix(in srgb, var(--theme-panel-subtle-bg) 74%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-provider-info,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-provider-info,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-group,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-group {
+  gap: 0.5rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-field-help,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-field-help {
+  margin-top: 0.25rem;
+  line-height: 1.35;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-telegram-actions,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-telegram-actions {
+  margin-top: 0.875rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-rate-limits,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-rate-limits {
+  margin: 0.375rem 0.375rem 0;
+  padding: 0.625rem 0.75rem 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-build-label,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-build-label {
+  margin: 0.125rem 0.375rem 0;
+  padding: 0.625rem 0.75rem 0.75rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  border-radius: calc(var(--theme-macos-control-radius) + 2px);
+  min-height: 2.5rem;
+  gap: 0.625rem;
+  padding-inline: 0.75rem;
+  background: transparent;
+  box-shadow: none;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 44%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row + .sidebar-settings-row,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row + .sidebar-settings-row {
+  border-top-color: color-mix(in srgb, var(--theme-border) 56%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-label,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--theme-text-primary);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-value,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-value,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-provider-select,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-provider-select,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-language-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-language-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-input,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-input,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-save,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-save,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-clear,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-clear,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-refresh,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-refresh,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-collapse,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-collapse,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-switch,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-switch,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-remove,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-remove,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-telegram-save,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-telegram-save {
+  min-height: 1.875rem;
+  border-radius: 999px;
+  padding-inline: 0.625rem;
+  font-size: 0.8125rem;
+  background: color-mix(in srgb, var(--theme-control-bg) 72%, var(--theme-main-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 72%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 88%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--theme-border) 18%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-value,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-value {
+  font-weight: 500;
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-toggle {
+  background: color-mix(in srgb, var(--theme-control-bg) 82%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    inset 0 0 0 1px color-mix(in srgb, var(--theme-border) 86%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-segmented,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-segmented {
+  min-height: 1.75rem;
+  border-color: color-mix(in srgb, var(--theme-border) 70%, transparent);
+  background: color-mix(in srgb, var(--theme-control-bg) 68%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 82%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--theme-border) 16%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-segmented-option,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-segmented-option {
+  min-height: 1.5rem;
+  padding-inline: 0.625rem;
+  font-weight: 500;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-count,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-count {
+  min-width: 1.375rem;
+  justify-content: center;
+  border: 0;
+  background: color-mix(in srgb, var(--theme-control-bg) 44%, transparent);
+  color: var(--theme-text-muted);
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .content-header,
+:root[data-theme='macos'][data-appearance='dark'] .content-header {
+  background: color-mix(in srgb, var(--theme-sidebar-bg) 84%, var(--theme-main-bg));
+  border-bottom: 1px solid var(--theme-border-soft);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .content-header .content-title,
+:root[data-theme='macos'][data-appearance='dark'] .content-header .content-title {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-shell,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-shell {
+  border-radius: var(--theme-macos-panel-radius);
+  background: color-mix(in srgb, var(--theme-elevated-bg) 96%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-input-wrap,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-input-wrap {
+  border-radius: calc(var(--theme-macos-panel-radius) - 4px);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-bar,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-bar {
+  border-radius: 999px;
+  padding: 0.3125rem 0.5rem;
+  background: color-mix(in srgb, var(--theme-control-bg) 82%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 0 0 1px var(--theme-border),
+    inset 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-bar:focus-within,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-bar:focus-within {
+  border-color: color-mix(in srgb, var(--theme-accent) 38%, var(--theme-border));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--theme-accent) 44%, var(--theme-border)),
+    0 0 0 3px color-mix(in srgb, var(--theme-accent) 14%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-button,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-skills-link,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-skills-link,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row,
+:root[data-theme='macos'][data-appearance='light'] .thread-row,
+:root[data-theme='macos'][data-appearance='dark'] .thread-row,
+:root[data-theme='macos'][data-appearance='light'] .project-header-row,
+:root[data-theme='macos'][data-appearance='dark'] .project-header-row,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option {
+  border-radius: var(--theme-macos-row-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-button,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-skills-link,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-skills-link,
+:root[data-theme='macos'][data-appearance='light'] .thread-row,
+:root[data-theme='macos'][data-appearance='dark'] .thread-row,
+:root[data-theme='macos'][data-appearance='light'] .project-header-row,
+:root[data-theme='macos'][data-appearance='dark'] .project-header-row {
+  min-height: 2rem;
+  padding-inline: 0.75rem;
+  border: 1px solid transparent;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-bar,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-bar,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-provider-select,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-provider-select,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-input,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-input,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-key-save,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-key-save,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-item,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-item,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-refresh,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-refresh,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-switch,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-switch,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-collapse,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-collapse,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-id,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-id,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-value,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-value,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-chip,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-chip,
+:root[data-theme='macos'][data-appearance='light'] .message-file-chip,
+:root[data-theme='macos'][data-appearance='dark'] .message-file-chip,
+:root[data-theme='macos'][data-appearance='light'] .file-change-delta,
+:root[data-theme='macos'][data-appearance='dark'] .file-change-delta,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-file-delta,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-file-delta,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-language,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-language,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-submit,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-submit,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-mic,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-mic,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-close,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-close,
+:root[data-theme='macos'][data-appearance='light'] .diff-viewer-mobile-files-button,
+:root[data-theme='macos'][data-appearance='dark'] .diff-viewer-mobile-files-button,
+:root[data-theme='macos'][data-appearance='light'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='dark'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='light'] .review-pane-segmented-button,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-segmented-button {
+  border-radius: var(--theme-macos-control-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-trigger {
+  border-radius: var(--theme-macos-control-radius);
+  background: color-mix(in srgb, var(--theme-control-bg) 58%, transparent);
+  border: 1px solid color-mix(in srgb, var(--theme-border) 44%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 84%, transparent),
+    0 1px 1px rgba(29, 29, 31, 0.06);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.3)) saturate(150%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.3)) saturate(150%);
+  transition:
+    background-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-trigger:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 78%, var(--theme-floating-panel-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button {
+  background: transparent;
+  border: 1px solid transparent;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle:hover,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 82%, transparent);
+  border-color: var(--theme-border);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-skills-link:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-skills-link:hover,
+:root[data-theme='macos'][data-appearance='light'] .project-header-row:hover,
+:root[data-theme='macos'][data-appearance='dark'] .project-header-row:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-row:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-row:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 72%, transparent);
+  border-color: color-mix(in srgb, var(--theme-border) 56%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle[aria-pressed='true'],
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle[aria-pressed='true'],
+:root[data-theme='macos'][data-appearance='light'] .sidebar-skills-link.is-active,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-skills-link.is-active,
+:root[data-theme='macos'][data-appearance='light'] .thread-row[data-active='true'],
+:root[data-theme='macos'][data-appearance='dark'] .thread-row[data-active='true'] {
+  background: color-mix(in srgb, var(--theme-selection-bg) 78%, var(--theme-floating-panel-bg));
+  border-color: color-mix(in srgb, var(--theme-selection-border) 68%, transparent);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    0 1px 2px rgba(29, 29, 31, 0.08);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .content-header-terminal-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-terminal-toggle,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop {
+  background: transparent;
+  color: var(--theme-text-secondary);
+  border: 0;
+  box-shadow: none;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown.is-review-open .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown.is-review-open .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .content-header-terminal-toggle[aria-pressed='true'],
+:root[data-theme='macos'][data-appearance='dark'] .content-header-terminal-toggle[aria-pressed='true'] {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 92%, transparent);
+  color: var(--theme-text-primary);
+  border: 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger:hover,
+:root[data-theme='macos'][data-appearance='light'] .content-header-terminal-toggle:hover,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-terminal-toggle:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 92%, transparent);
+  border: 0;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .thread-start-button,
+:root[data-theme='macos'][data-appearance='dark'] .thread-start-button,
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop {
+  background: color-mix(in srgb, var(--theme-control-bg) 58%, transparent);
+  border: 1px solid color-mix(in srgb, var(--theme-border) 44%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 84%, transparent),
+    0 1px 1px rgba(29, 29, 31, 0.06);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.3)) saturate(150%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.3)) saturate(150%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger,
+:root[data-theme='macos'][data-appearance='light'] .thread-start-button,
+:root[data-theme='macos'][data-appearance='dark'] .thread-start-button,
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mention-row,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mention-row,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-item,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-item,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-setting,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-setting {
+  transition:
+    background-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-option,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-option,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-action-button,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-action-button,
+:root[data-theme='macos'][data-appearance='light'] .file-link-context-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu-item {
+  min-height: 1.875rem;
+  border-radius: var(--theme-macos-row-radius);
+  padding-inline: 0.625rem;
+  font-size: 0.8125rem;
+  transition:
+    background-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 140ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-option:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-option:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-action-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-action-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .file-link-context-menu-item:hover,
+:root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu-item:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 72%, transparent);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle:hover,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-start-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-start-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 78%, var(--theme-floating-panel-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-item,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mention-row,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mention-row,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-item,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-item,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-setting,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-setting {
+  min-height: 1.875rem;
+  padding-inline: 0.625rem;
+  font-size: 0.8125rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-start-button:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-start-button:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-action-button:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-action-button:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mention-row:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mention-row:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-item:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-item:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-setting:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-setting:focus-visible,
+:root[data-theme='macos'][data-appearance='light'] .file-link-context-menu-item:focus-visible,
+:root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--theme-accent) 54%, transparent);
+  outline-offset: 0;
+  border-color: color-mix(in srgb, var(--theme-accent) 34%, var(--theme-border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-accent) 16%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle:disabled,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button:disabled,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger:disabled,
+:root[data-theme='macos'][data-appearance='light'] .thread-start-button:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .thread-start-button:disabled,
+:root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger:disabled,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-stop:disabled,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop:disabled,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .project-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mention-row[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mention-row[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-item[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-setting[aria-disabled='true'],
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-setting[aria-disabled='true'] {
+  background: color-mix(in srgb, var(--theme-control-bg) 34%, transparent);
+  border-color: color-mix(in srgb, var(--theme-border) 28%, transparent);
+  color: var(--theme-text-muted);
+  opacity: 0.55;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-tree-header,
+:root[data-theme='macos'][data-appearance='dark'] .thread-tree-header,
+:root[data-theme='macos'][data-appearance='light'] .thread-row-time,
+:root[data-theme='macos'][data-appearance='dark'] .thread-row-time,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-button-version,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-button-version,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-meta,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-meta,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-context-meta,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-context-meta,
+:root[data-theme='macos'][data-appearance='light'] .sidebar-settings-build-label,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-build-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.01em;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-menu,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-menu,
+:root[data-theme='macos'][data-appearance='light'] .composer-search-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .composer-search-dropdown-menu,
+:root[data-theme='macos'][data-appearance='light'] .account-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .account-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .skill-picker,
+:root[data-theme='macos'][data-appearance='dark'] .skill-picker,
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .rename-thread-panel,
+:root[data-theme='macos'][data-appearance='dark'] .rename-thread-panel,
+:root[data-theme='macos'][data-appearance='light'] .file-link-context-menu,
+:root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mentions,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mentions {
+  background: var(--theme-floating-panel-bg);
+  border: 1px solid var(--theme-border);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-lg);
+  backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(170%);
+  -webkit-backdrop-filter: blur(var(--theme-backdrop-blur)) saturate(170%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .queued-messages-inner,
+:root[data-theme='macos'][data-appearance='dark'] .queued-messages-inner,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-shell,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-shell {
+  border-radius: var(--theme-macos-panel-radius);
+  background: color-mix(in srgb, var(--theme-elevated-bg) 96%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .queued-row-edit,
+:root[data-theme='macos'][data-appearance='dark'] .queued-row-edit,
+:root[data-theme='macos'][data-appearance='light'] .queued-row-steer,
+:root[data-theme='macos'][data-appearance='dark'] .queued-row-steer,
+:root[data-theme='macos'][data-appearance='light'] .queued-row-delete,
+:root[data-theme='macos'][data-appearance='dark'] .queued-row-delete,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-option,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-option,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-inline-input,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-inline-input,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-link,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-link,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-select,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-select,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-input,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-input,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-primary,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-primary,
+:root[data-theme='macos'][data-appearance='light'] .thread-pending-request-secondary,
+:root[data-theme='macos'][data-appearance='dark'] .thread-pending-request-secondary {
+  border-radius: var(--theme-macos-control-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .directory-card,
+:root[data-theme='macos'][data-appearance='dark'] .directory-card,
+:root[data-theme='macos'][data-appearance='light'] .directory-modal,
+:root[data-theme='macos'][data-appearance='dark'] .directory-modal {
+  border-radius: var(--theme-macos-panel-radius);
+  border-color: color-mix(in srgb, var(--theme-border) 74%, transparent);
+  background: color-mix(in srgb, var(--theme-floating-panel-bg) 98%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.55)) saturate(160%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.55)) saturate(160%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .directory-tabs,
+:root[data-theme='macos'][data-appearance='dark'] .directory-tabs,
+:root[data-theme='macos'][data-appearance='light'] .directory-sort-group,
+:root[data-theme='macos'][data-appearance='dark'] .directory-sort-group,
+:root[data-theme='macos'][data-appearance='light'] .directory-refresh,
+:root[data-theme='macos'][data-appearance='dark'] .directory-refresh,
+:root[data-theme='macos'][data-appearance='light'] .directory-action,
+:root[data-theme='macos'][data-appearance='dark'] .directory-action,
+:root[data-theme='macos'][data-appearance='light'] .directory-action-link,
+:root[data-theme='macos'][data-appearance='dark'] .directory-action-link,
+:root[data-theme='macos'][data-appearance='light'] .directory-modal-close,
+:root[data-theme='macos'][data-appearance='dark'] .directory-modal-close,
+:root[data-theme='macos'][data-appearance='light'] .directory-search,
+:root[data-theme='macos'][data-appearance='dark'] .directory-search {
+  border-radius: var(--theme-macos-control-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-panel,
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-header,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-header {
+  border-radius: var(--theme-macos-panel-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-panel {
+  border-color: color-mix(in srgb, var(--theme-border) 74%, transparent);
+  background: color-mix(in srgb, var(--theme-floating-panel-bg) 96%, var(--theme-code-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(155%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(155%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-header,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-header,
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-tab,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-tab,
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-quick-command,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-quick-command,
+:root[data-theme='macos'][data-appearance='light'] .thread-terminal-action,
+:root[data-theme='macos'][data-appearance='dark'] .thread-terminal-action {
+  border-radius: var(--theme-macos-control-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-scrollable,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-scrollable,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mentions,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mentions,
+:root[data-theme='macos'][data-appearance='light'] .review-pane-file-list,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-file-list,
+:root[data-theme='macos'][data-appearance='light'] .file-change-list,
+:root[data-theme='macos'][data-appearance='dark'] .file-change-list,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='light'] .skill-picker,
+:root[data-theme='macos'][data-appearance='dark'] .skill-picker {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--theme-text-muted) 42%, transparent) transparent;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-scrollable::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-scrollable::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mentions::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mentions::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .review-pane-file-list::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-file-list::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .file-change-list::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .file-change-list::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='light'] .skill-picker::-webkit-scrollbar,
+:root[data-theme='macos'][data-appearance='dark'] .skill-picker::-webkit-scrollbar {
+  width: 0.625rem;
+  height: 0.625rem;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .sidebar-scrollable::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .sidebar-scrollable::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mentions::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mentions::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .review-pane-file-list::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-file-list::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .file-change-list::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .file-change-list::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='light'] .skill-picker::-webkit-scrollbar-thumb,
+:root[data-theme='macos'][data-appearance='dark'] .skill-picker::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--theme-text-muted) 36%, transparent);
+  background-clip: padding-box;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .review-pane-segmented,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-segmented,
+:root[data-theme='macos'][data-appearance='light'] .runtime-toggle,
+:root[data-theme='macos'][data-appearance='dark'] .runtime-toggle,
+:root[data-theme='macos'][data-appearance='light'] .review-pane-branch-select-wrap,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-branch-select-wrap {
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+  border: 1px solid color-mix(in srgb, var(--theme-border) 88%, transparent);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    inset 0 -1px 0 color-mix(in srgb, var(--theme-border) 32%, transparent);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.35)) saturate(150%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.35)) saturate(150%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .review-pane-segmented-button,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-segmented-button,
+:root[data-theme='macos'][data-appearance='light'] .runtime-toggle-option,
+:root[data-theme='macos'][data-appearance='dark'] .runtime-toggle-option {
+  min-height: 26px;
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .review-pane-segmented-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-segmented-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .runtime-toggle-option:hover,
+:root[data-theme='macos'][data-appearance='dark'] .runtime-toggle-option:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 90%, transparent);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .review-pane-segmented-button[data-active='true'] {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(243, 247, 252, 0.96) 100%);
+  border-color: color-mix(in srgb, var(--theme-selection-border) 76%, var(--theme-border));
+  color: var(--theme-selection-text);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 1px 2px rgba(29, 29, 31, 0.08);
+}
+
+:root[data-theme='macos'][data-appearance='dark'] .review-pane-segmented-button[data-active='true'] {
+  background: linear-gradient(180deg, rgba(76, 80, 92, 0.92) 0%, rgba(52, 56, 66, 0.96) 100%);
+  border-color: color-mix(in srgb, var(--theme-selection-border) 82%, var(--theme-border));
+  color: var(--theme-selection-text);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-search-toggle,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-search-toggle,
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-thread-controls-button,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-thread-controls-button,
+  :root[data-theme='macos'][data-appearance='light'] .thread-menu-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-menu-trigger,
+  :root[data-theme='macos'][data-appearance='light'] .project-menu-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .project-menu-trigger,
+  :root[data-theme='macos'][data-appearance='light'] .organize-menu-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .organize-menu-trigger,
+  :root[data-theme='macos'][data-appearance='light'] .thread-start-button,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-start-button,
+  :root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop,
+  :root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-menu,
+  :root[data-theme='macos'][data-appearance='light'] .composer-search-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .composer-search-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='light'] .account-menu-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .account-menu-panel,
+  :root[data-theme='macos'][data-appearance='light'] .skill-picker,
+  :root[data-theme='macos'][data-appearance='dark'] .skill-picker,
+  :root[data-theme='macos'][data-appearance='light'] .organize-menu-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .organize-menu-panel,
+  :root[data-theme='macos'][data-appearance='light'] .project-menu-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .project-menu-panel,
+  :root[data-theme='macos'][data-appearance='light'] .thread-menu-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-menu-panel,
+  :root[data-theme='macos'][data-appearance='light'] .rename-thread-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .rename-thread-panel,
+  :root[data-theme='macos'][data-appearance='light'] .file-link-context-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-file-mentions,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-file-mentions {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+:root[data-theme='macos'][data-appearance='light'] .request-card,
+:root[data-theme='macos'][data-appearance='light'] .message-card,
+:root[data-theme='macos'][data-appearance='light'] .plan-card {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--theme-floating-panel-bg) 94%, transparent) 0%,
+      color-mix(in srgb, var(--theme-elevated-bg) 86%, transparent) 100%
+    );
+}
+
+:root[data-theme='macos'][data-appearance='dark'] .request-card,
+:root[data-theme='macos'][data-appearance='dark'] .message-card,
+:root[data-theme='macos'][data-appearance='dark'] .plan-card {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--theme-floating-panel-bg) 92%, transparent) 0%,
+      color-mix(in srgb, var(--theme-elevated-bg) 88%, transparent) 100%
+    );
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-card,
+:root[data-theme='macos'][data-appearance='dark'] .message-card,
+:root[data-theme='macos'][data-appearance='light'] .plan-card,
+:root[data-theme='macos'][data-appearance='dark'] .plan-card,
+:root[data-theme='macos'][data-appearance='light'] .request-card,
+:root[data-theme='macos'][data-appearance='dark'] .request-card {
+  border-radius: var(--theme-macos-panel-radius);
+  border: 1px solid color-mix(in srgb, var(--theme-border) 74%, transparent);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-sm);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(160%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(160%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-card:has(> .plan-card),
+:root[data-theme='macos'][data-appearance='dark'] .message-card:has(> .plan-card) {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-body[data-role='user'] .message-card,
+:root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='user'] .message-card {
+  background: color-mix(in srgb, var(--theme-user-bubble-bg) 94%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .cmd-row,
+:root[data-theme='macos'][data-appearance='dark'] .cmd-row {
+  border-radius: calc(var(--theme-macos-panel-radius) - 2px);
+  border: 1px solid color-mix(in srgb, var(--theme-border) 68%, transparent);
+  background: color-mix(in srgb, var(--theme-control-bg) 80%, var(--theme-floating-panel-bg));
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-sm);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.35)) saturate(150%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.35)) saturate(150%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .cmd-row.cmd-expanded,
+:root[data-theme='macos'][data-appearance='dark'] .cmd-row.cmd-expanded {
+  border-bottom-color: transparent;
+  box-shadow: inset 0 1px 0 var(--theme-border-soft);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .cmd-output-wrap,
+:root[data-theme='macos'][data-appearance='dark'] .cmd-output-wrap {
+  background: transparent;
+}
+
+:root[data-theme='macos'][data-appearance='light'] .cmd-output-wrap.cmd-output-visible,
+:root[data-theme='macos'][data-appearance='dark'] .cmd-output-wrap.cmd-output-visible {
+  border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+  background: color-mix(in srgb, var(--theme-code-bg) 96%, var(--theme-floating-panel-bg));
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-inline-code,
+:root[data-theme='macos'][data-appearance='dark'] .message-inline-code,
+:root[data-theme='macos'][data-appearance='light'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='dark'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='light'] .message-image-button,
+:root[data-theme='macos'][data-appearance='dark'] .message-image-button,
+:root[data-theme='macos'][data-appearance='light'] .jump-to-latest-button,
+:root[data-theme='macos'][data-appearance='dark'] .jump-to-latest-button,
+:root[data-theme='macos'][data-appearance='light'] .message-file-chip,
+:root[data-theme='macos'][data-appearance='dark'] .message-file-chip {
+  border-radius: var(--theme-macos-control-radius);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-inline-code,
+:root[data-theme='macos'][data-appearance='dark'] .message-inline-code,
+:root[data-theme='macos'][data-appearance='light'] .message-file-chip,
+:root[data-theme='macos'][data-appearance='dark'] .message-file-chip {
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 88%, transparent);
+  box-shadow: inset 0 1px 0 var(--theme-border-soft);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-code-block,
+:root[data-theme='macos'][data-appearance='dark'] .message-code-block {
+  border-radius: calc(var(--theme-macos-panel-radius) - 2px);
+  border-color: color-mix(in srgb, var(--theme-border) 82%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 70%, transparent),
+    var(--theme-shadow-md);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-code-language,
+:root[data-theme='macos'][data-appearance='dark'] .message-code-language {
+  background: color-mix(in srgb, var(--theme-code-header-bg) 86%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-blockquote,
+:root[data-theme='macos'][data-appearance='dark'] .message-blockquote,
+:root[data-theme='macos'][data-appearance='light'] .message-table,
+:root[data-theme='macos'][data-appearance='dark'] .message-table {
+  border-radius: calc(var(--theme-macos-panel-radius) - 4px);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .jump-to-latest-button,
+:root[data-theme='macos'][data-appearance='dark'] .jump-to-latest-button,
+:root[data-theme='macos'][data-appearance='light'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='dark'] .message-copy-button,
+:root[data-theme='macos'][data-appearance='light'] .message-image-button,
+:root[data-theme='macos'][data-appearance='dark'] .message-image-button {
+  background: color-mix(in srgb, var(--theme-control-bg) 92%, var(--theme-main-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 88%, transparent);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-sm);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.4)) saturate(155%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.4)) saturate(155%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .message-copy-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .message-copy-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .message-image-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .message-image-button:hover,
+:root[data-theme='macos'][data-appearance='light'] .jump-to-latest-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .jump-to-latest-button:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 88%, var(--theme-floating-panel-bg));
+}
+
+:root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down,
+:root[data-theme='macos'][data-appearance='light'] .account-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .account-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-menu,
+:root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-menu,
+:root[data-theme='macos'][data-appearance='light'] .composer-search-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .composer-search-dropdown-menu,
+:root[data-theme='macos'][data-appearance='light'] .skill-picker,
+:root[data-theme='macos'][data-appearance='dark'] .skill-picker {
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.9)) saturate(160%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.9)) saturate(160%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu,
+:root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu {
+  background: var(--theme-floating-panel-bg);
+  border-color: var(--theme-border);
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-lg);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.9)) saturate(160%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.9)) saturate(160%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .organize-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .organize-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .project-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .project-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .thread-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .rename-thread-panel,
+:root[data-theme='macos'][data-appearance='dark'] .rename-thread-panel,
+:root[data-theme='macos'][data-appearance='light'] .file-link-context-menu,
+:root[data-theme='macos'][data-appearance='dark'] .file-link-context-menu {
+  border-radius: calc(var(--theme-macos-panel-radius) - 2px);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.82)) saturate(165%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.82)) saturate(165%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-panel {
+  border-radius: calc(var(--theme-macos-panel-radius) - 2px);
+  border-color: color-mix(in srgb, var(--theme-border) 72%, transparent);
+  background: color-mix(in srgb, var(--theme-floating-panel-bg) 99.4%, var(--theme-main-bg));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 90%, transparent),
+    0 16px 40px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.2)) saturate(114%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.2)) saturate(114%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-actions,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-actions {
+  border-bottom-color: color-mix(in srgb, var(--theme-border) 58%, transparent);
+  background: color-mix(in srgb, var(--theme-floating-panel-bg) 97%, var(--theme-main-bg));
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.14)) saturate(110%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.14)) saturate(110%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .api-panel-root,
+:root[data-theme='macos'][data-appearance='dark'] .api-panel-root {
+  border-radius: var(--theme-macos-panel-radius);
+  border-color: color-mix(in srgb, var(--theme-border) 70%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--theme-floating-panel-bg) 96%, transparent) 0%,
+      color-mix(in srgb, var(--theme-elevated-bg) 90%, transparent) 100%
+    );
+  box-shadow:
+    inset 0 1px 0 var(--theme-border-soft),
+    var(--theme-shadow-md);
+  backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(155%);
+  -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.5)) saturate(155%);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .api-panel-header,
+:root[data-theme='macos'][data-appearance='dark'] .api-panel-header {
+  border-bottom-color: color-mix(in srgb, var(--theme-border) 56%, transparent);
+  background: color-mix(in srgb, var(--theme-control-bg) 34%, transparent);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .api-method-code,
+:root[data-theme='macos'][data-appearance='dark'] .api-method-code {
+  border: 1px solid color-mix(in srgb, var(--theme-border) 76%, transparent);
+  border-radius: var(--theme-macos-control-radius);
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 82%, transparent);
+}
+
+:root[data-theme][data-appearance] .account-menu-trigger,
+:root[data-theme][data-appearance] .account-menu-switch,
+:root[data-theme][data-appearance] .thread-type-menu-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .account-menu-trigger:hover,
+:root[data-theme][data-appearance] .account-menu-switch:hover,
+:root[data-theme][data-appearance] .thread-type-menu-trigger:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .account-menu-trigger-chevron,
+:root[data-theme][data-appearance] .account-menu-empty,
+:root[data-theme][data-appearance] .account-menu-item-meta,
+:root[data-theme][data-appearance] .project-menu-label,
+:root[data-theme][data-appearance] .project-empty,
+:root[data-theme][data-appearance] .thread-tree-loading,
+:root[data-theme][data-appearance] .thread-tree-no-results,
+:root[data-theme][data-appearance] .thread-type-menu-empty,
+:root[data-theme][data-appearance] .thread-type-menu-count,
+:root[data-theme][data-appearance] .search-dropdown-option-desc,
+:root[data-theme][data-appearance] .search-dropdown-empty,
+:root[data-theme][data-appearance] .skill-picker-empty,
+:root[data-theme][data-appearance] .skill-picker-desc,
+:root[data-theme][data-appearance] .api-panel-count,
+:root[data-theme][data-appearance] .api-panel-loading {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .account-menu-panel,
+:root[data-theme][data-appearance] .thread-type-menu-panel,
+:root[data-theme][data-appearance] .thread-type-menu-actions,
+:root[data-theme][data-appearance] .skill-picker,
+:root[data-theme][data-appearance] .skill-picker-header,
+:root[data-theme][data-appearance] .api-panel-root,
+:root[data-theme][data-appearance] .api-panel-header {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+:root[data-theme][data-appearance] .account-menu-title,
+:root[data-theme][data-appearance] .account-menu-item-email,
+:root[data-theme][data-appearance] .thread-type-menu-label,
+:root[data-theme][data-appearance] .search-dropdown-option.is-selected,
+:root[data-theme][data-appearance] .skill-picker-name,
+:root[data-theme][data-appearance] .api-panel-title {
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .account-menu-item {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+}
+
+:root[data-theme][data-appearance] .account-menu-item.is-active {
+  border-color: var(--theme-success-border);
+  background: var(--theme-success-soft-bg);
+}
+
+:root[data-theme][data-appearance] .account-menu-error {
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+:root[data-theme][data-appearance] .project-menu-trigger,
+:root[data-theme][data-appearance] .organize-menu-trigger,
+:root[data-theme][data-appearance] .thread-start-button {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-trigger,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-trigger {
+  border-color: color-mix(in srgb, var(--theme-border) 44%, transparent);
+  background: color-mix(in srgb, var(--theme-control-bg) 58%, transparent);
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-trigger:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-trigger:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 78%, var(--theme-floating-panel-bg));
+  border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-panel,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-panel,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-actions,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-actions,
+:root[data-theme='macos'][data-appearance='light'] .api-panel-root,
+:root[data-theme='macos'][data-appearance='dark'] .api-panel-root,
+:root[data-theme='macos'][data-appearance='light'] .api-panel-header,
+:root[data-theme='macos'][data-appearance='dark'] .api-panel-header {
+  border-color: color-mix(in srgb, var(--theme-border) 64%, transparent);
+}
+
+:root[data-theme][data-appearance] .project-menu-trigger:hover,
+:root[data-theme][data-appearance] .organize-menu-trigger:hover,
+:root[data-theme][data-appearance] .thread-start-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .project-menu-input,
+:root[data-theme][data-appearance] .search-dropdown-search,
+:root[data-theme][data-appearance] .skill-picker-search {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-search::placeholder,
+:root[data-theme][data-appearance] .skill-picker-search::placeholder {
+  color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-menu-wrap-up,
+:root[data-theme][data-appearance] .search-dropdown-menu-wrap-down {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  box-shadow: var(--theme-shadow-lg);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-search-wrap {
+  border-color: var(--theme-border);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-option,
+:root[data-theme][data-appearance] .skill-picker-item,
+:root[data-theme][data-appearance] .thread-type-menu-option,
+:root[data-theme][data-appearance] .thread-type-menu-action-button {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-option:hover,
+:root[data-theme][data-appearance] .search-dropdown-option.is-highlighted,
+:root[data-theme][data-appearance] .skill-picker-item:hover,
+:root[data-theme][data-appearance] .skill-picker-item.is-highlighted,
+:root[data-theme][data-appearance] .thread-type-menu-option:hover,
+:root[data-theme][data-appearance] .thread-type-menu-action-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .search-dropdown-option-check {
+  color: var(--theme-success-text);
+}
+
+:root[data-theme][data-appearance] .thread-tree-header,
+:root[data-theme][data-appearance] .project-icon-stack,
+:root[data-theme][data-appearance] .project-empty,
+:root[data-theme][data-appearance] .api-method-code {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .api-method-code {
+  background: var(--theme-control-bg);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-option,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-option,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-action-button,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-action-button {
+  color: var(--theme-text-secondary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-option:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-option:hover,
+:root[data-theme='macos'][data-appearance='light'] .thread-type-menu-action-button:hover,
+:root[data-theme='macos'][data-appearance='dark'] .thread-type-menu-action-button:hover {
+  background: color-mix(in srgb, var(--theme-control-hover-bg) 72%, transparent);
+  color: var(--theme-text-primary);
+}
+
+:root[data-theme='macos'][data-appearance='light'] .api-method-code,
+:root[data-theme='macos'][data-appearance='dark'] .api-method-code {
+  background: color-mix(in srgb, var(--theme-control-bg) 84%, var(--theme-main-bg));
+}
+
+:root[data-theme][data-appearance] .conversation-loading,
+:root[data-theme][data-appearance] .conversation-empty {
+  color: var(--theme-text-muted);
 }
 
 @media (max-width: 768px) {
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-panel,
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-account-section,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-account-section,
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-telegram-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-telegram-panel {
+    border-radius: calc(var(--theme-macos-panel-radius) - 3px);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .content-header,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-shell,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-shell {
+    background: color-mix(in srgb, var(--theme-floating-panel-bg) 97%, var(--theme-main-bg));
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 90%, transparent),
+      0 10px 24px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.34)) saturate(118%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.34)) saturate(118%);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .mobile-drawer,
+  :root[data-theme='macos'][data-appearance='dark'] .mobile-drawer {
+    border-right: 1px solid color-mix(in srgb, var(--theme-border) 66%, transparent);
+    border-top-right-radius: calc(var(--theme-macos-panel-radius) + 4px);
+    border-bottom-right-radius: calc(var(--theme-macos-panel-radius) + 4px);
+    background: color-mix(in srgb, var(--theme-sidebar-bg) 96%, var(--theme-main-bg));
+    box-shadow:
+      inset -1px 0 0 color-mix(in srgb, var(--theme-border-soft) 88%, transparent),
+      16px 0 36px rgba(15, 23, 42, 0.16);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.28)) saturate(114%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.28)) saturate(114%);
+    overflow: clip;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .content-header,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header {
+    gap: 0.5rem;
+    min-height: 3rem;
+    padding: 0.75rem 0.75rem 0.5rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--theme-border) 60%, transparent);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .content-header .content-leading,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header .content-leading,
+  :root[data-theme='macos'][data-appearance='light'] .content-header .content-actions,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header .content-actions {
+    gap: 0.375rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .content-header .content-title,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header .content-title {
+    font-size: 0.9375rem;
+    line-height: 1.25rem;
+    letter-spacing: -0.015em;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-shell,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-shell {
+    border-radius: calc(var(--theme-macos-panel-radius) - 1px);
+    border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+    background: color-mix(in srgb, var(--theme-elevated-bg) 98%, var(--theme-main-bg));
+    padding: 0.6875rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-input-wrap,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-input-wrap {
+    border-radius: calc(var(--theme-macos-panel-radius) - 8px);
+    background: color-mix(in srgb, var(--theme-control-bg) 88%, var(--theme-main-bg));
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--theme-border) 54%, transparent),
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 90%, transparent);
+    padding-inline: 0.25rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-controls,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-controls {
+    gap: 0.5rem;
+    margin-top: 0.625rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--provider,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--provider,
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--language,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--language {
+    padding-inline: 0.625rem;
+    gap: 0.5rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--provider .sidebar-settings-provider-select,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--provider .sidebar-settings-provider-select {
+    max-width: 8rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--language .sidebar-settings-language-dropdown,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--language .sidebar-settings-language-dropdown {
+    max-width: 6.25rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--language .sidebar-settings-language-dropdown .composer-dropdown-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--language .sidebar-settings-language-dropdown .composer-dropdown-trigger {
+    padding-inline: 0.5rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .sidebar-settings-row--language .sidebar-settings-language-dropdown .composer-dropdown-value,
+  :root[data-theme='macos'][data-appearance='dark'] .sidebar-settings-row--language .sidebar-settings-language-dropdown .composer-dropdown-value {
+    max-width: 3.5rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-trigger,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-submit,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-submit,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-stop,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-stop,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-mic,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-mic {
+    height: 2.5rem;
+    width: 2.5rem;
+    border-radius: 999px;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .content-header-branch-dropdown .composer-dropdown-trigger,
+  :root[data-theme='macos'][data-appearance='dark'] .content-header-branch-dropdown .composer-dropdown-trigger {
+    min-height: 2.25rem;
+    padding-inline: 0.75rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--theme-border) 52%, transparent);
+    background: color-mix(in srgb, var(--theme-control-bg) 86%, var(--theme-main-bg));
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 88%, transparent),
+      0 1px 2px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.18)) saturate(118%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.18)) saturate(118%);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .message-card,
+  :root[data-theme='macos'][data-appearance='dark'] .message-card,
+  :root[data-theme='macos'][data-appearance='light'] .plan-card,
+  :root[data-theme='macos'][data-appearance='dark'] .plan-card,
+  :root[data-theme='macos'][data-appearance='light'] .request-card,
+  :root[data-theme='macos'][data-appearance='dark'] .request-card,
+  :root[data-theme='macos'][data-appearance='light'] .cmd-row,
+  :root[data-theme='macos'][data-appearance='dark'] .cmd-row {
+    border-radius: calc(var(--theme-macos-panel-radius) - 5px);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 86%, transparent),
+      0 1px 0 rgba(15, 23, 42, 0.04);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.12)) saturate(108%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.12)) saturate(108%);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .message-card,
+  :root[data-theme='macos'][data-appearance='dark'] .message-card,
+  :root[data-theme='macos'][data-appearance='light'] .plan-card,
+  :root[data-theme='macos'][data-appearance='dark'] .plan-card {
+    border-color: color-mix(in srgb, var(--theme-border) 68%, transparent);
+    background: color-mix(in srgb, var(--theme-floating-panel-bg) 99%, var(--theme-main-bg));
+    padding: 0.875rem 1rem;
+  }
+
+:root[data-theme='macos'][data-appearance='light'] .message-body[data-role='assistant'] .message-card,
+:root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='assistant'] .message-card,
+:root[data-theme='macos'][data-appearance='light'] .message-body[data-role='system'] .message-card,
+:root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='system'] .message-card {
+  width: 100%;
+  max-width: 100%;
+  padding: 0.875rem 1rem;
+}
+
+  :root[data-theme='macos'][data-appearance='light'] .plan-card,
+  :root[data-theme='macos'][data-appearance='dark'] .plan-card,
+  :root[data-theme='macos'][data-appearance='light'] .request-card,
+  :root[data-theme='macos'][data-appearance='dark'] .request-card {
+    gap: 0.75rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .request-card,
+  :root[data-theme='macos'][data-appearance='dark'] .request-card {
+    border-color: color-mix(in srgb, var(--theme-warning-border) 86%, transparent);
+    background: color-mix(in srgb, var(--theme-warning-soft-bg) 97%, var(--theme-main-bg));
+    padding: 0.875rem 1rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .message-body[data-role='user'] .message-card,
+  :root[data-theme='macos'][data-appearance='dark'] .message-body[data-role='user'] .message-card {
+    background: color-mix(in srgb, var(--theme-user-bubble-bg) 97%, var(--theme-main-bg));
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .message-card:has(> .plan-card),
+  :root[data-theme='macos'][data-appearance='dark'] .message-card:has(> .plan-card) {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    padding: 0;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .cmd-row,
+  :root[data-theme='macos'][data-appearance='dark'] .cmd-row {
+    border-color: color-mix(in srgb, var(--theme-border) 62%, transparent);
+    background: color-mix(in srgb, var(--theme-control-bg) 96%, var(--theme-main-bg));
+    gap: 0.625rem;
+    padding: 0.625rem 0.75rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .composer-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down,
+  :root[data-theme='macos'][data-appearance='light'] .account-menu-panel,
+  :root[data-theme='macos'][data-appearance='dark'] .account-menu-panel,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-menu,
+  :root[data-theme='macos'][data-appearance='light'] .skill-picker,
+  :root[data-theme='macos'][data-appearance='dark'] .skill-picker {
+    border-radius: calc(var(--theme-macos-panel-radius) - 2px);
+    border-color: color-mix(in srgb, var(--theme-border) 72%, transparent);
+    background: color-mix(in srgb, var(--theme-floating-panel-bg) 99.4%, var(--theme-main-bg));
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 90%, transparent),
+      0 16px 40px rgba(15, 23, 42, 0.18);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.2)) saturate(114%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.2)) saturate(114%);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .diff-viewer-mobile-sheet,
+  :root[data-theme='macos'][data-appearance='dark'] .diff-viewer-mobile-sheet {
+    border-top-left-radius: calc(var(--theme-macos-panel-radius) + 2px);
+    border-top-right-radius: calc(var(--theme-macos-panel-radius) + 2px);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-color: color-mix(in srgb, var(--theme-border) 72%, transparent);
+    background: color-mix(in srgb, var(--theme-floating-panel-bg) 99.5%, var(--theme-main-bg));
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, var(--theme-border-soft) 90%, transparent),
+      0 -12px 32px rgba(15, 23, 42, 0.18);
+    backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.18)) saturate(112%);
+    -webkit-backdrop-filter: blur(calc(var(--theme-backdrop-blur) * 0.18)) saturate(112%);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .diff-viewer-mobile-sheet-handle,
+  :root[data-theme='macos'][data-appearance='dark'] .diff-viewer-mobile-sheet-handle {
+    width: 2.5rem;
+    height: 0.3125rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--theme-text-muted) 30%, transparent);
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .composer-dropdown-option,
+  :root[data-theme='macos'][data-appearance='dark'] .composer-dropdown-option,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-option,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-option,
+  :root[data-theme='macos'][data-appearance='light'] .skill-picker-item,
+  :root[data-theme='macos'][data-appearance='dark'] .skill-picker-item,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-item,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-item,
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-setting,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-setting,
+  :root[data-theme='macos'][data-appearance='light'] .account-menu-item,
+  :root[data-theme='macos'][data-appearance='dark'] .account-menu-item {
+    min-height: 2.5rem;
+    border-radius: 1rem;
+    padding-inline: 0.75rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .thread-composer-attach-mode-button,
+  :root[data-theme='macos'][data-appearance='dark'] .thread-composer-attach-mode-button,
+  :root[data-theme='macos'][data-appearance='light'] .account-menu-switch,
+  :root[data-theme='macos'][data-appearance='dark'] .account-menu-switch {
+    min-height: 2rem;
+    padding-inline: 0.75rem;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up .search-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up .search-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down .search-dropdown-menu,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down .search-dropdown-menu {
+    border-color: transparent;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-up,
+  :root[data-theme='macos'][data-appearance='light'] .search-dropdown-menu-wrap-down,
+  :root[data-theme='macos'][data-appearance='dark'] .search-dropdown-menu-wrap-down {
+    padding-inline: 0.125rem;
+  }
+
   .thread-composer-input,
   .composer-dropdown-search-input,
   .search-dropdown-search,
+  .skill-picker-search,
   .sidebar-search-input,
   .project-menu-input,
   .rename-thread-input,

--- a/src/style.css
+++ b/src/style.css
@@ -47,9 +47,31 @@
   --theme-heading-text: #18181b;
   --theme-content-title-text: #0f172a;
   --theme-sidebar-control-text: #52525b;
+  --theme-sidebar-row-text: #0f172a;
+  --theme-project-title-text: #3f3f46;
+  --theme-thread-title-text: #27272a;
+  --theme-thread-time-text: #71717a;
   --theme-composer-shell-border: #d4d4d8;
   --theme-composer-input-disabled-bg: #f4f4f5;
   --theme-composer-input-disabled-text: #71717a;
+  --theme-settings-row-text: #3f3f46;
+  --theme-settings-value-text: #71717a;
+  --theme-settings-button-hover-bg: #e4e4e7;
+  --theme-settings-button-hover-text: #18181b;
+  --theme-settings-control-bg: #ffffff;
+  --theme-settings-control-border: #e4e4e7;
+  --theme-settings-control-text: #3f3f46;
+  --theme-settings-toggle-bg: #d4d4d8;
+  --theme-settings-account-section-bg: rgb(250 250 250 / 0.6);
+  --theme-settings-account-count-bg: #e4e4e7;
+  --theme-settings-account-count-text: #52525b;
+  --theme-settings-account-id-bg: #f4f4f5;
+  --theme-settings-account-id-text: #52525b;
+  --theme-settings-account-action-bg: #ffffff;
+  --theme-settings-account-action-border: #e4e4e7;
+  --theme-settings-account-action-text: #3f3f46;
+  --theme-settings-account-action-hover-bg: #f4f4f5;
+  --theme-settings-account-action-hover-text: #3f3f46;
   --theme-runtime-bg: #f4f4f5;
   --theme-runtime-selected-bg: #ffffff;
   --theme-runtime-selected-border: #e4e4e7;
@@ -160,9 +182,31 @@
   --theme-content-title-text: #e4e4e7;
   --theme-settings-button-text: #a1a1aa;
   --theme-sidebar-control-text: #a1a1aa;
+  --theme-sidebar-row-text: #f4f4f5;
+  --theme-project-title-text: #d4d4d8;
+  --theme-thread-title-text: #e4e4e7;
+  --theme-thread-time-text: #71717a;
   --theme-composer-shell-border: #3f3f46;
   --theme-composer-input-disabled-bg: #3f3f46;
   --theme-composer-input-disabled-text: #71717a;
+  --theme-settings-row-text: #d4d4d8;
+  --theme-settings-value-text: #a1a1aa;
+  --theme-settings-button-hover-bg: #27272a;
+  --theme-settings-button-hover-text: #e4e4e7;
+  --theme-settings-control-bg: #27272a;
+  --theme-settings-control-border: #52525b;
+  --theme-settings-control-text: #e4e4e7;
+  --theme-settings-toggle-bg: #52525b;
+  --theme-settings-account-section-bg: rgb(39 39 42 / 0.7);
+  --theme-settings-account-count-bg: #3f3f46;
+  --theme-settings-account-count-text: #d4d4d8;
+  --theme-settings-account-id-bg: #27272a;
+  --theme-settings-account-id-text: #d4d4d8;
+  --theme-settings-account-action-bg: #3f3f46;
+  --theme-settings-account-action-border: #52525b;
+  --theme-settings-account-action-text: #e4e4e7;
+  --theme-settings-account-action-hover-bg: #52525b;
+  --theme-settings-account-action-hover-text: #e4e4e7;
   --theme-runtime-bg: #18181b;
   --theme-runtime-selected-bg: #27272a;
   --theme-runtime-selected-border: #52525b;
@@ -810,8 +854,8 @@ body {
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button:hover {
-  background: var(--theme-control-hover-bg);
-  color: var(--theme-text-primary);
+  background: var(--theme-settings-button-hover-bg, var(--theme-control-hover-bg));
+  color: var(--theme-settings-button-hover-text, var(--theme-text-primary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-button-version {
@@ -824,7 +868,7 @@ body {
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row {
-  color: var(--theme-text-primary);
+  color: var(--theme-settings-row-text, var(--theme-text-primary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row:hover {
@@ -832,9 +876,15 @@ body {
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-language-dropdown .composer-dropdown-trigger {
-  border-color: var(--theme-border);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-secondary);
+  border-color: var(--theme-settings-control-border, var(--theme-border));
+  background: var(--theme-settings-control-bg, var(--theme-control-bg));
+  color: var(--theme-settings-control-text, var(--theme-text-secondary));
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-provider-select {
+  border-color: var(--theme-settings-control-border, var(--theme-border));
+  background: var(--theme-settings-control-bg, var(--theme-control-bg));
+  color: var(--theme-settings-control-text, var(--theme-text-secondary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-row + .sidebar-settings-row {
@@ -845,6 +895,10 @@ body {
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-section {
   border-color: var(--theme-border);
   background: var(--theme-panel-subtle-bg);
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-section {
+  background: var(--theme-settings-account-section-bg, var(--theme-panel-subtle-bg));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-field-label,
@@ -876,23 +930,32 @@ body {
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-collapse,
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-refresh,
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-switch {
-  border-color: var(--theme-border);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-secondary);
+  border-color: var(--theme-settings-account-action-border, var(--theme-border));
+  background: var(--theme-settings-account-action-bg, var(--theme-control-bg));
+  color: var(--theme-settings-account-action-text, var(--theme-text-secondary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-collapse:hover,
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-refresh:hover,
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-switch:hover {
-  background: var(--theme-control-hover-bg);
-  color: var(--theme-text-primary);
+  background: var(--theme-settings-account-action-hover-bg, var(--theme-control-hover-bg));
+  color: var(--theme-settings-account-action-hover-text, var(--theme-text-primary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-count,
-:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-id,
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-value {
   background: var(--theme-control-active-bg);
-  color: var(--theme-text-secondary);
+  color: var(--theme-settings-value-text, var(--theme-text-secondary));
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-count {
+  background: var(--theme-settings-account-count-bg, var(--theme-control-active-bg));
+  color: var(--theme-settings-account-count-text, var(--theme-text-secondary));
+}
+
+:root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-id {
+  background: var(--theme-settings-account-id-bg, var(--theme-control-active-bg));
+  color: var(--theme-settings-account-id-text, var(--theme-text-secondary));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-account-item {
@@ -911,7 +974,7 @@ body {
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-toggle {
-  background: var(--theme-border-strong);
+  background: var(--theme-settings-toggle-bg, var(--theme-border-strong));
 }
 
 :root[data-appearance='dark']:not([data-theme='macos']) .sidebar-settings-toggle::after {
@@ -992,6 +1055,14 @@ body {
 :root[data-theme][data-appearance] .conversation-empty,
 :root[data-theme][data-appearance] .worktree-init-status.is-running {
   color: var(--theme-text-muted);
+}
+
+:root[data-theme][data-appearance] .project-title {
+  color: var(--theme-project-title-text, var(--theme-text-muted));
+}
+
+:root[data-theme][data-appearance] .thread-row-time {
+  color: var(--theme-thread-time-text, var(--theme-text-muted));
 }
 
 :root[data-theme][data-appearance] .sidebar-settings-context-value[data-state='ok'],
@@ -1101,6 +1172,10 @@ body {
 :root[data-theme][data-appearance] .request-title,
 :root[data-theme][data-appearance] .request-reason {
   color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-row-title {
+  color: var(--theme-thread-title-text, var(--theme-text-primary));
 }
 
 :root[data-theme][data-appearance] .new-thread-hero {
@@ -1553,6 +1628,11 @@ body {
 :root[data-theme][data-appearance] .skill-card,
 :root[data-theme][data-appearance] .thread-composer-attach-mode-button {
   color: var(--theme-text-secondary);
+}
+
+:root[data-theme][data-appearance] .project-header-row,
+:root[data-theme][data-appearance] .thread-row {
+  color: var(--theme-sidebar-row-text, var(--theme-text-secondary));
 }
 
 :root[data-theme][data-appearance] .review-pane-file:hover,

--- a/src/style.css
+++ b/src/style.css
@@ -27,27 +27,28 @@
   --theme-shell-bg: #f1f5f9;
   --theme-sidebar-bg: #f1f5f9;
   --theme-main-bg: #ffffff;
-  --theme-panel-bg: rgba(255, 255, 255, 0.94);
-  --theme-panel-subtle-bg: rgba(248, 250, 252, 0.9);
-  --theme-elevated-bg: rgba(255, 255, 255, 0.96);
+  --theme-panel-bg: #ffffff;
+  --theme-panel-subtle-bg: #fafafa;
+  --theme-elevated-bg: #ffffff;
   --theme-elevated-strong-bg: #ffffff;
   --theme-user-bubble-bg: #e2e8f0;
-  --theme-code-bg: #09090b;
-  --theme-code-header-bg: rgba(24, 24, 27, 0.92);
-  --theme-code-text: #f8fafc;
+  --theme-code-bg: #020617;
+  --theme-code-header-bg: rgba(15, 23, 42, 0.94);
+  --theme-code-text: #f1f5f9;
   --theme-code-muted: #94a3b8;
   --theme-border: #e4e4e7;
   --theme-border-strong: #d4d4d8;
   --theme-border-soft: rgba(228, 228, 231, 0.72);
   --theme-text-primary: #0f172a;
   --theme-text-secondary: #3f3f46;
+  --theme-text-subtle: #52525b;
   --theme-text-muted: #71717a;
   --theme-link: #0969da;
   --theme-link-hover: #1f6feb;
   --theme-link-decoration: rgba(9, 105, 218, 0.28);
-  --theme-control-bg: rgba(255, 255, 255, 0.94);
-  --theme-control-hover-bg: #f4f4f5;
-  --theme-control-active-bg: #e4e4e7;
+  --theme-control-bg: #ffffff;
+  --theme-control-hover-bg: #fafafa;
+  --theme-control-active-bg: #f4f4f5;
   --theme-accent: #18181b;
   --theme-accent-hover: #27272a;
   --theme-accent-contrast: #ffffff;
@@ -75,9 +76,44 @@
   --theme-info-soft-bg: rgba(14, 165, 233, 0.1);
   --theme-info-border: rgba(14, 165, 233, 0.35);
   --theme-info-text: #0369a1;
-  --theme-selection-bg: rgba(228, 228, 231, 0.88);
+  --theme-selection-bg: #e4e4e7;
   --theme-selection-border: rgba(212, 212, 216, 0.9);
   --theme-selection-text: #0f172a;
+  --theme-message-text: #1e293b;
+  --theme-message-heading: #0f172a;
+  --theme-message-muted: #64748b;
+  --theme-message-blockquote-border: #cbd5e1;
+  --theme-message-blockquote-bg: rgba(248, 250, 252, 0.7);
+  --theme-message-blockquote-text: #334155;
+  --theme-message-inline-code-border: #e2e8f0;
+  --theme-message-inline-code-bg: rgba(241, 245, 249, 0.6);
+  --theme-message-inline-code-text: #0f172a;
+  --theme-message-table-bg: #ffffff;
+  --theme-message-table-head-bg: #f1f5f9;
+  --theme-message-divider-bg: rgba(203, 213, 225, 0.8);
+  --theme-plan-bg: #f0f9ff;
+  --theme-plan-border: #bae6fd;
+  --theme-plan-card-text: #0f172a;
+  --theme-plan-title: #0c4a6e;
+  --theme-plan-text: #334155;
+  --theme-plan-badge-bg: #bae6fd;
+  --theme-plan-badge-text: #0c4a6e;
+  --theme-plan-inline-code-bg: rgba(226, 232, 240, 0.8);
+  --theme-plan-inline-code-text: #0f172a;
+  --theme-plan-table-bg: rgba(255, 255, 255, 0.9);
+  --theme-plan-step-bg: rgba(255, 255, 255, 0.8);
+  --theme-plan-step-border: rgba(255, 255, 255, 0.7);
+  --theme-plan-step-text: #1e293b;
+  --theme-plan-step-status-bg: #e2e8f0;
+  --theme-plan-step-status-text: #334155;
+  --theme-plan-step-completed-bg: rgba(236, 253, 245, 0.8);
+  --theme-plan-step-completed-border: #a7f3d0;
+  --theme-plan-step-completed-status-bg: #a7f3d0;
+  --theme-plan-step-completed-status-text: #064e3b;
+  --theme-plan-step-in-progress-bg: rgba(255, 251, 235, 0.8);
+  --theme-plan-step-in-progress-border: #fde68a;
+  --theme-plan-step-in-progress-status-bg: #fde68a;
+  --theme-plan-step-in-progress-status-text: #78350f;
   --theme-overlay: rgba(15, 23, 42, 0.4);
   --theme-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
   --theme-shadow-md: 0 14px 36px rgba(15, 23, 42, 0.1);
@@ -92,13 +128,13 @@
   --theme-shell-bg: #18181b;
   --theme-sidebar-bg: #18181b;
   --theme-main-bg: #09090b;
-  --theme-panel-bg: rgba(39, 39, 42, 0.96);
-  --theme-panel-subtle-bg: rgba(39, 39, 42, 0.84);
-  --theme-elevated-bg: rgba(39, 39, 42, 0.96);
+  --theme-panel-bg: #27272a;
+  --theme-panel-subtle-bg: #27272a;
+  --theme-elevated-bg: #27272a;
   --theme-elevated-strong-bg: #27272a;
   --theme-user-bubble-bg: #3f3f46;
   --theme-code-bg: #09090b;
-  --theme-code-header-bg: rgba(24, 24, 27, 0.96);
+  --theme-code-header-bg: #18181b;
   --theme-code-text: #f4f4f5;
   --theme-code-muted: #a1a1aa;
   --theme-border: #3f3f46;
@@ -106,13 +142,14 @@
   --theme-border-soft: rgba(63, 63, 70, 0.82);
   --theme-text-primary: #f4f4f5;
   --theme-text-secondary: #d4d4d8;
+  --theme-text-subtle: #d4d4d8;
   --theme-text-muted: #a1a1aa;
   --theme-link: #7dd3fc;
   --theme-link-hover: #bae6fd;
   --theme-link-decoration: rgba(125, 211, 252, 0.28);
-  --theme-control-bg: rgba(39, 39, 42, 0.94);
+  --theme-control-bg: #3f3f46;
   --theme-control-hover-bg: #3f3f46;
-  --theme-control-active-bg: #52525b;
+  --theme-control-active-bg: #3f3f46;
   --theme-accent: #3f3f46;
   --theme-accent-hover: #52525b;
   --theme-accent-contrast: #f4f4f5;
@@ -140,9 +177,44 @@
   --theme-info-soft-bg: rgba(14, 165, 233, 0.12);
   --theme-info-border: rgba(14, 165, 233, 0.35);
   --theme-info-text: #bae6fd;
-  --theme-selection-bg: rgba(63, 63, 70, 0.92);
+  --theme-selection-bg: #27272a;
   --theme-selection-border: rgba(82, 82, 91, 0.92);
   --theme-selection-text: #f4f4f5;
+  --theme-message-text: #e4e4e7;
+  --theme-message-heading: #f4f4f5;
+  --theme-message-muted: #a1a1aa;
+  --theme-message-blockquote-border: #52525b;
+  --theme-message-blockquote-bg: rgba(39, 39, 42, 0.7);
+  --theme-message-blockquote-text: #d4d4d8;
+  --theme-message-inline-code-border: #52525b;
+  --theme-message-inline-code-bg: rgba(63, 63, 70, 0.6);
+  --theme-message-inline-code-text: #e4e4e7;
+  --theme-message-table-bg: rgba(24, 24, 27, 0.9);
+  --theme-message-table-head-bg: #27272a;
+  --theme-message-divider-bg: rgba(63, 63, 70, 0.8);
+  --theme-plan-bg: rgba(8, 47, 73, 0.4);
+  --theme-plan-border: #075985;
+  --theme-plan-card-text: #0f172a;
+  --theme-plan-title: #bae6fd;
+  --theme-plan-text: #d4d4d8;
+  --theme-plan-badge-bg: #075985;
+  --theme-plan-badge-text: #e0f2fe;
+  --theme-plan-inline-code-bg: rgba(63, 63, 70, 0.6);
+  --theme-plan-inline-code-text: #e4e4e7;
+  --theme-plan-table-bg: rgba(24, 24, 27, 0.9);
+  --theme-plan-step-bg: rgba(24, 24, 27, 0.7);
+  --theme-plan-step-border: #3f3f46;
+  --theme-plan-step-text: #e4e4e7;
+  --theme-plan-step-status-bg: #3f3f46;
+  --theme-plan-step-status-text: #e4e4e7;
+  --theme-plan-step-completed-bg: rgba(2, 44, 34, 0.4);
+  --theme-plan-step-completed-border: #064e3b;
+  --theme-plan-step-completed-status-bg: #064e3b;
+  --theme-plan-step-completed-status-text: #a7f3d0;
+  --theme-plan-step-in-progress-bg: rgba(69, 26, 3, 0.4);
+  --theme-plan-step-in-progress-border: #78350f;
+  --theme-plan-step-in-progress-status-bg: #78350f;
+  --theme-plan-step-in-progress-status-text: #fde68a;
   --theme-overlay: rgba(0, 0, 0, 0.42);
   --theme-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
   --theme-shadow-md: 0 14px 36px rgba(0, 0, 0, 0.32);
@@ -171,6 +243,7 @@
   --theme-border-soft: rgba(213, 221, 232, 0.8);
   --theme-text-primary: #111827;
   --theme-text-secondary: #374151;
+  --theme-text-subtle: #4b5563;
   --theme-text-muted: #6b7280;
   --theme-link: #2563eb;
   --theme-link-hover: #1d4ed8;
@@ -208,6 +281,41 @@
   --theme-selection-bg: rgba(219, 228, 239, 0.9);
   --theme-selection-border: rgba(193, 204, 218, 0.9);
   --theme-selection-text: #111827;
+  --theme-message-text: #1f2937;
+  --theme-message-heading: #111827;
+  --theme-message-muted: #6b7280;
+  --theme-message-blockquote-border: #c1ccda;
+  --theme-message-blockquote-bg: rgba(239, 244, 250, 0.72);
+  --theme-message-blockquote-text: #374151;
+  --theme-message-inline-code-border: #d5dde8;
+  --theme-message-inline-code-bg: rgba(219, 228, 239, 0.6);
+  --theme-message-inline-code-text: #111827;
+  --theme-message-table-bg: #ffffff;
+  --theme-message-table-head-bg: #eef2f7;
+  --theme-message-divider-bg: rgba(193, 204, 218, 0.8);
+  --theme-plan-bg: rgba(219, 234, 254, 0.72);
+  --theme-plan-border: rgba(147, 197, 253, 0.72);
+  --theme-plan-card-text: #111827;
+  --theme-plan-title: #1e3a8a;
+  --theme-plan-text: #374151;
+  --theme-plan-badge-bg: rgba(191, 219, 254, 0.9);
+  --theme-plan-badge-text: #1e3a8a;
+  --theme-plan-inline-code-bg: rgba(213, 221, 232, 0.8);
+  --theme-plan-inline-code-text: #111827;
+  --theme-plan-table-bg: rgba(255, 255, 255, 0.9);
+  --theme-plan-step-bg: rgba(255, 255, 255, 0.78);
+  --theme-plan-step-border: rgba(255, 255, 255, 0.68);
+  --theme-plan-step-text: #1f2937;
+  --theme-plan-step-status-bg: #dbe4ef;
+  --theme-plan-step-status-text: #374151;
+  --theme-plan-step-completed-bg: rgba(16, 185, 129, 0.12);
+  --theme-plan-step-completed-border: rgba(16, 185, 129, 0.35);
+  --theme-plan-step-completed-status-bg: rgba(16, 185, 129, 0.32);
+  --theme-plan-step-completed-status-text: #047857;
+  --theme-plan-step-in-progress-bg: rgba(245, 158, 11, 0.12);
+  --theme-plan-step-in-progress-border: rgba(245, 158, 11, 0.35);
+  --theme-plan-step-in-progress-status-bg: rgba(245, 158, 11, 0.32);
+  --theme-plan-step-in-progress-status-text: #b45309;
   --theme-overlay: rgba(15, 23, 42, 0.42);
   --theme-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.07);
   --theme-shadow-md: 0 16px 36px rgba(15, 23, 42, 0.11);
@@ -236,6 +344,7 @@
   --theme-border-soft: rgba(55, 65, 81, 0.82);
   --theme-text-primary: #e5e7eb;
   --theme-text-secondary: #cbd5e1;
+  --theme-text-subtle: #cbd5e1;
   --theme-text-muted: #9ca3af;
   --theme-link: #93c5fd;
   --theme-link-hover: #bfdbfe;
@@ -273,6 +382,41 @@
   --theme-selection-bg: rgba(55, 65, 81, 0.92);
   --theme-selection-border: rgba(75, 85, 99, 0.92);
   --theme-selection-text: #e5e7eb;
+  --theme-message-text: #d1d5db;
+  --theme-message-heading: #f9fafb;
+  --theme-message-muted: #9ca3af;
+  --theme-message-blockquote-border: #4b5563;
+  --theme-message-blockquote-bg: rgba(31, 41, 55, 0.7);
+  --theme-message-blockquote-text: #cbd5e1;
+  --theme-message-inline-code-border: #4b5563;
+  --theme-message-inline-code-bg: rgba(55, 65, 81, 0.6);
+  --theme-message-inline-code-text: #e5e7eb;
+  --theme-message-table-bg: rgba(17, 24, 39, 0.9);
+  --theme-message-table-head-bg: #1f2937;
+  --theme-message-divider-bg: rgba(55, 65, 81, 0.8);
+  --theme-plan-bg: rgba(30, 58, 138, 0.28);
+  --theme-plan-border: rgba(59, 130, 246, 0.35);
+  --theme-plan-card-text: #111827;
+  --theme-plan-title: #bfdbfe;
+  --theme-plan-text: #dbeafe;
+  --theme-plan-badge-bg: rgba(59, 130, 246, 0.2);
+  --theme-plan-badge-text: #bfdbfe;
+  --theme-plan-inline-code-bg: rgba(55, 65, 81, 0.6);
+  --theme-plan-inline-code-text: #e5e7eb;
+  --theme-plan-table-bg: rgba(17, 24, 39, 0.9);
+  --theme-plan-step-bg: rgba(17, 24, 39, 0.7);
+  --theme-plan-step-border: #374151;
+  --theme-plan-step-text: #e5e7eb;
+  --theme-plan-step-status-bg: #374151;
+  --theme-plan-step-status-text: #e5e7eb;
+  --theme-plan-step-completed-bg: rgba(6, 78, 59, 0.38);
+  --theme-plan-step-completed-border: rgba(16, 185, 129, 0.35);
+  --theme-plan-step-completed-status-bg: #064e3b;
+  --theme-plan-step-completed-status-text: #a7f3d0;
+  --theme-plan-step-in-progress-bg: rgba(120, 53, 15, 0.32);
+  --theme-plan-step-in-progress-border: rgba(245, 158, 11, 0.35);
+  --theme-plan-step-in-progress-status-bg: #78350f;
+  --theme-plan-step-in-progress-status-text: #fde68a;
   --theme-overlay: rgba(0, 0, 0, 0.46);
   --theme-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
   --theme-shadow-md: 0 14px 36px rgba(0, 0, 0, 0.34);
@@ -319,6 +463,7 @@
   --theme-border-soft: rgb(var(--color-textQuinary-light));
   --theme-text-primary: rgb(var(--color-text-light));
   --theme-text-secondary: rgb(var(--color-textSecondary-light));
+  --theme-text-subtle: rgb(var(--color-textSecondary-light));
   --theme-text-muted: rgb(var(--color-textTertiary-light));
   --theme-link: rgb(var(--color-blue-light));
   --theme-link-hover: rgb(var(--color-blue-dark));
@@ -356,6 +501,41 @@
   --theme-selection-bg: rgb(var(--color-selectionFocused-light));
   --theme-selection-border: color-mix(in srgb, rgb(var(--color-selectionFocusedFill-light)) 32%, transparent);
   --theme-selection-text: #12304f;
+  --theme-message-text: rgb(var(--color-text-light));
+  --theme-message-heading: rgb(var(--color-text-light));
+  --theme-message-muted: rgb(var(--color-textTertiary-light));
+  --theme-message-blockquote-border: rgb(var(--color-fillSecondary-light));
+  --theme-message-blockquote-bg: rgb(var(--color-materialThin-light));
+  --theme-message-blockquote-text: rgb(var(--color-textSecondary-light));
+  --theme-message-inline-code-border: rgb(var(--color-fill-light));
+  --theme-message-inline-code-bg: rgb(var(--color-controlEnabled-light));
+  --theme-message-inline-code-text: rgb(var(--color-text-light));
+  --theme-message-table-bg: rgb(var(--color-materialThick-light));
+  --theme-message-table-head-bg: rgb(var(--color-materialMedium-light));
+  --theme-message-divider-bg: rgb(var(--color-fillSecondary-light));
+  --theme-plan-bg: rgb(var(--color-materialMedium-light));
+  --theme-plan-border: rgb(var(--color-fillSecondary-light));
+  --theme-plan-card-text: rgb(var(--color-text-light));
+  --theme-plan-title: rgb(var(--color-text-light));
+  --theme-plan-text: rgb(var(--color-textSecondary-light));
+  --theme-plan-badge-bg: rgb(var(--color-selectionUnfocusedFill-light));
+  --theme-plan-badge-text: rgb(var(--color-text-light));
+  --theme-plan-inline-code-bg: rgb(var(--color-controlEnabled-light));
+  --theme-plan-inline-code-text: rgb(var(--color-text-light));
+  --theme-plan-table-bg: rgb(var(--color-materialThick-light));
+  --theme-plan-step-bg: rgb(var(--color-materialThick-light));
+  --theme-plan-step-border: rgb(var(--color-fillSecondary-light));
+  --theme-plan-step-text: rgb(var(--color-text-light));
+  --theme-plan-step-status-bg: rgb(var(--color-selectionUnfocusedFill-light));
+  --theme-plan-step-status-text: rgb(var(--color-text-light));
+  --theme-plan-step-completed-bg: color-mix(in srgb, rgb(var(--color-green-light)) 12%, transparent);
+  --theme-plan-step-completed-border: color-mix(in srgb, rgb(var(--color-green-light)) 30%, transparent);
+  --theme-plan-step-completed-status-bg: color-mix(in srgb, rgb(var(--color-green-light)) 28%, transparent);
+  --theme-plan-step-completed-status-text: rgb(var(--color-green-dark));
+  --theme-plan-step-in-progress-bg: color-mix(in srgb, rgb(var(--color-orange-light)) 14%, transparent);
+  --theme-plan-step-in-progress-border: color-mix(in srgb, rgb(var(--color-orange-light)) 30%, transparent);
+  --theme-plan-step-in-progress-status-bg: color-mix(in srgb, rgb(var(--color-orange-light)) 30%, transparent);
+  --theme-plan-step-in-progress-status-text: rgb(var(--color-orange-dark));
   --theme-overlay: rgb(var(--color-popover-light));
   --theme-shadow-sm: 0 1px 3px rgba(29, 29, 31, 0.08);
   --theme-shadow-md: 0 12px 28px rgba(29, 29, 31, 0.09);
@@ -405,6 +585,7 @@
   --theme-border-soft: rgb(var(--color-textQuinary-dark));
   --theme-text-primary: rgb(var(--color-text-dark));
   --theme-text-secondary: rgb(var(--color-textSecondary-dark));
+  --theme-text-subtle: rgb(var(--color-textSecondary-dark));
   --theme-text-muted: rgb(var(--color-textTertiary-dark));
   --theme-link: rgb(var(--color-blue-dark));
   --theme-link-hover: rgb(var(--color-blue-light));
@@ -442,6 +623,41 @@
   --theme-selection-bg: rgb(var(--color-selectionFocused-dark));
   --theme-selection-border: color-mix(in srgb, rgb(var(--color-selectionFocusedFill-dark)) 32%, transparent);
   --theme-selection-text: #f5f5f7;
+  --theme-message-text: rgb(var(--color-text-dark));
+  --theme-message-heading: rgb(var(--color-text-dark));
+  --theme-message-muted: rgb(var(--color-textTertiary-dark));
+  --theme-message-blockquote-border: rgb(var(--color-fillSecondary-dark));
+  --theme-message-blockquote-bg: rgb(var(--color-materialThin-dark));
+  --theme-message-blockquote-text: rgb(var(--color-textSecondary-dark));
+  --theme-message-inline-code-border: rgb(var(--color-fill-dark));
+  --theme-message-inline-code-bg: color-mix(in srgb, rgb(var(--color-controlEnabled-dark)) 58%, rgb(var(--color-materialOpaque-dark)));
+  --theme-message-inline-code-text: rgb(var(--color-text-dark));
+  --theme-message-table-bg: rgb(var(--color-materialThick-dark));
+  --theme-message-table-head-bg: rgb(var(--color-materialMedium-dark));
+  --theme-message-divider-bg: rgb(var(--color-fillSecondary-dark));
+  --theme-plan-bg: rgb(var(--color-materialMedium-dark));
+  --theme-plan-border: rgb(var(--color-fillSecondary-dark));
+  --theme-plan-card-text: rgb(var(--color-text-dark));
+  --theme-plan-title: rgb(var(--color-text-dark));
+  --theme-plan-text: rgb(var(--color-textSecondary-dark));
+  --theme-plan-badge-bg: rgb(var(--color-selectionUnfocusedFill-dark));
+  --theme-plan-badge-text: rgb(var(--color-text-dark));
+  --theme-plan-inline-code-bg: color-mix(in srgb, rgb(var(--color-controlEnabled-dark)) 58%, rgb(var(--color-materialOpaque-dark)));
+  --theme-plan-inline-code-text: rgb(var(--color-text-dark));
+  --theme-plan-table-bg: rgb(var(--color-materialThick-dark));
+  --theme-plan-step-bg: rgb(var(--color-materialThick-dark));
+  --theme-plan-step-border: rgb(var(--color-fillSecondary-dark));
+  --theme-plan-step-text: rgb(var(--color-text-dark));
+  --theme-plan-step-status-bg: rgb(var(--color-selectionUnfocusedFill-dark));
+  --theme-plan-step-status-text: rgb(var(--color-text-dark));
+  --theme-plan-step-completed-bg: color-mix(in srgb, rgb(var(--color-green-dark)) 12%, transparent);
+  --theme-plan-step-completed-border: color-mix(in srgb, rgb(var(--color-green-dark)) 28%, transparent);
+  --theme-plan-step-completed-status-bg: color-mix(in srgb, rgb(var(--color-green-dark)) 28%, transparent);
+  --theme-plan-step-completed-status-text: rgb(var(--color-green-light));
+  --theme-plan-step-in-progress-bg: color-mix(in srgb, rgb(var(--color-orange-dark)) 14%, transparent);
+  --theme-plan-step-in-progress-border: color-mix(in srgb, rgb(var(--color-orange-dark)) 30%, transparent);
+  --theme-plan-step-in-progress-status-bg: color-mix(in srgb, rgb(var(--color-orange-dark)) 30%, transparent);
+  --theme-plan-step-in-progress-status-text: rgb(var(--color-orange-light));
   --theme-overlay: rgb(var(--color-popover-dark));
   --theme-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.22);
   --theme-shadow-md: 0 12px 28px rgba(0, 0, 0, 0.24);
@@ -506,27 +722,27 @@ body {
 }
 
 .message-text {
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
 }
 
 .message-list,
 .message-italic-text {
-  color: var(--theme-text-primary);
+  color: var(--theme-message-text);
 }
 
 .message-heading,
 .message-bold-text {
-  color: var(--theme-text-primary);
+  color: var(--theme-message-heading);
 }
 
 .message-inline-code {
-  border-color: var(--theme-border);
-  background: var(--theme-control-bg);
-  color: var(--theme-text-primary);
+  border-color: var(--theme-message-inline-code-border);
+  background: var(--theme-message-inline-code-bg);
+  color: var(--theme-message-inline-code-text);
 }
 
 .message-code-block {
-  border-color: var(--theme-border);
+  border-color: var(--theme-message-inline-code-border);
   background: var(--theme-code-bg);
   color: var(--theme-code-text);
 }
@@ -1107,6 +1323,39 @@ body {
 :root[data-theme][data-appearance] .sidebar-settings-account-remove.is-confirming {
   background: var(--theme-warning-soft-bg);
   color: var(--theme-warning-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-item {
+  border-color: var(--theme-plan-step-border);
+  background: var(--theme-plan-step-bg);
+  color: var(--theme-plan-step-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-item[data-status='completed'] {
+  border-color: var(--theme-plan-step-completed-border);
+  background: var(--theme-plan-step-completed-bg);
+  color: var(--theme-plan-step-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-item[data-status='inProgress'] {
+  border-color: var(--theme-plan-step-in-progress-border);
+  background: var(--theme-plan-step-in-progress-bg);
+  color: var(--theme-plan-step-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-status {
+  background: var(--theme-plan-step-status-bg);
+  color: var(--theme-plan-step-status-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-status[data-status='completed'] {
+  background: var(--theme-plan-step-completed-status-bg);
+  color: var(--theme-plan-step-completed-status-text);
+}
+
+:root[data-theme][data-appearance] .plan-step-status[data-status='inProgress'] {
+  background: var(--theme-plan-step-in-progress-status-bg);
+  color: var(--theme-plan-step-in-progress-status-text);
 }
 
 :root[data-theme][data-appearance] .review-pane-file-op[data-operation='rename'],

--- a/src/style.css
+++ b/src/style.css
@@ -45,6 +45,11 @@
   --theme-text-muted: #71717a;
   --theme-shell-text: #0f172a;
   --theme-heading-text: #18181b;
+  --theme-content-title-text: #0f172a;
+  --theme-sidebar-control-text: #52525b;
+  --theme-composer-shell-border: #d4d4d8;
+  --theme-composer-input-disabled-bg: #f4f4f5;
+  --theme-composer-input-disabled-text: #71717a;
   --theme-runtime-bg: #f4f4f5;
   --theme-runtime-selected-bg: #ffffff;
   --theme-runtime-selected-border: #e4e4e7;
@@ -152,7 +157,12 @@
   --theme-text-muted: #a1a1aa;
   --theme-shell-text: #f4f4f5;
   --theme-heading-text: #f4f4f5;
+  --theme-content-title-text: #e4e4e7;
   --theme-settings-button-text: #a1a1aa;
+  --theme-sidebar-control-text: #a1a1aa;
+  --theme-composer-shell-border: #3f3f46;
+  --theme-composer-input-disabled-bg: #3f3f46;
+  --theme-composer-input-disabled-text: #71717a;
   --theme-runtime-bg: #18181b;
   --theme-runtime-selected-bg: #27272a;
   --theme-runtime-selected-border: #52525b;
@@ -1052,6 +1062,10 @@ body {
   background: var(--theme-panel-bg);
 }
 
+:root[data-theme][data-appearance] .thread-composer-shell {
+  border-color: var(--theme-composer-shell-border, var(--theme-border));
+}
+
 :root[data-theme][data-appearance] .file-change-list,
 :root[data-theme][data-appearance] .request-card,
 :root[data-theme][data-appearance] .build-badge,
@@ -1477,6 +1491,15 @@ body {
 :root[data-theme][data-appearance] .skills-hub-search,
 :root[data-theme][data-appearance] .thread-composer-input {
   color: var(--theme-text-primary);
+}
+
+:root[data-theme][data-appearance] .thread-composer-input:disabled {
+  background: var(--theme-composer-input-disabled-bg, var(--theme-control-active-bg));
+  color: var(--theme-composer-input-disabled-text, var(--theme-text-muted));
+}
+
+:root[data-theme][data-appearance] .content-title {
+  color: var(--theme-content-title-text, var(--theme-text-primary));
 }
 
 :root[data-theme][data-appearance] .rename-thread-input,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,21 @@
+export type AppearanceMode = 'system' | 'light' | 'dark'
+export type EffectiveTheme = 'light' | 'dark'
+
+export const APPEARANCE_MODES: AppearanceMode[] = ['system', 'light', 'dark']
+
+export function getStoredAppearanceMode(value: string | null | undefined): AppearanceMode {
+  return APPEARANCE_MODES.includes(value as AppearanceMode) ? (value as AppearanceMode) : 'system'
+}
+
+export function getEffectiveTheme(mode: AppearanceMode, prefersDark: boolean): EffectiveTheme {
+  if (mode === 'system') {
+    return prefersDark ? 'dark' : 'light'
+  }
+  return mode
+}
+
+export function cycleAppearanceMode(mode: AppearanceMode): AppearanceMode {
+  const index = APPEARANCE_MODES.indexOf(mode)
+  if (index === -1) return 'system'
+  return APPEARANCE_MODES[(index + 1) % APPEARANCE_MODES.length]
+}

--- a/src/theme/app-shell-theme.css
+++ b/src/theme/app-shell-theme.css
@@ -1,6 +1,6 @@
 .content-root {
   background: var(--theme-main-bg);
-  color: var(--theme-text-primary);
+  color: var(--theme-shell-text, var(--theme-text-primary));
 }
 
 .sidebar-search-toggle {
@@ -104,7 +104,7 @@
 }
 
 .new-thread-hero {
-  color: var(--theme-text-primary);
+  color: var(--theme-heading-text, var(--theme-text-primary));
 }
 
 .new-thread-folder-dropdown,
@@ -402,7 +402,7 @@
 
 .new-thread-hero,
 .new-thread-open-folder-title {
-  color: var(--theme-text-primary);
+  color: var(--theme-heading-text, var(--theme-text-primary));
 }
 
 .new-thread-folder-dropdown,

--- a/src/theme/app-shell-theme.css
+++ b/src/theme/app-shell-theme.css
@@ -111,25 +111,20 @@
 .new-thread-folder-selected,
 .new-thread-branch-select-label,
 .new-thread-branch-select-help,
-.new-thread-runtime-help,
-.new-thread-trending-title,
-.new-thread-trending-empty,
-.new-thread-trending-tip-meta {
+.new-thread-runtime-help {
   color: var(--theme-text-muted);
 }
 
 .new-thread-folder-action,
 .new-thread-open-folder-item-open,
-.new-thread-branch-dropdown .composer-dropdown-trigger,
-.new-thread-trending-scope-dropdown .composer-dropdown-trigger {
+.new-thread-branch-dropdown .composer-dropdown-trigger {
   border-color: var(--theme-border);
   background: var(--theme-control-bg);
   color: var(--theme-text-secondary);
 }
 
 .new-thread-folder-action:hover,
-.new-thread-open-folder-item-open:hover,
-.new-thread-trending-tip:hover {
+.new-thread-open-folder-item-open:hover {
   background: var(--theme-control-hover-bg);
   color: var(--theme-text-primary);
 }
@@ -163,7 +158,6 @@
 .new-thread-open-folder-path,
 .new-thread-open-folder-status,
 .new-thread-open-folder-item-main,
-.new-thread-trending-tip,
 .sidebar-settings-language-dropdown .composer-dropdown-trigger {
   border-color: var(--theme-border);
   background: var(--theme-panel-subtle-bg);
@@ -235,12 +229,10 @@
   background: var(--theme-control-hover-bg);
 }
 
-.new-thread-trending-tip-name,
 .worktree-init-status-title {
   color: var(--theme-text-primary);
 }
 
-.new-thread-trending-tip-description,
 .worktree-init-status-message {
   color: var(--theme-text-secondary);
 }
@@ -409,26 +401,20 @@
 }
 
 .new-thread-hero,
-.new-thread-open-folder-title,
-.new-thread-trending-tip-name {
+.new-thread-open-folder-title {
   color: var(--theme-text-primary);
 }
 
 .new-thread-folder-dropdown,
 .new-thread-branch-select-label,
 .new-thread-branch-select-help,
-.new-thread-runtime-help,
-.new-thread-trending-title,
-.new-thread-trending-empty,
-.new-thread-trending-tip-meta,
-.new-thread-trending-tip-description {
+.new-thread-runtime-help {
   color: var(--theme-text-muted);
 }
 
 .content-header-branch-dropdown .composer-dropdown-trigger,
 .new-thread-folder-action,
-.new-thread-branch-dropdown .composer-dropdown-trigger,
-.new-thread-trending-scope-dropdown .composer-dropdown-trigger {
+.new-thread-branch-dropdown .composer-dropdown-trigger {
   border-color: var(--theme-border);
   background: var(--theme-control-bg);
   color: var(--theme-text-secondary);
@@ -436,8 +422,7 @@
 
 .new-thread-folder-action:hover:not(:disabled),
 .content-header-branch-dropdown .composer-dropdown-trigger:hover,
-.new-thread-branch-dropdown .composer-dropdown-trigger:hover,
-.new-thread-trending-scope-dropdown .composer-dropdown-trigger:hover {
+.new-thread-branch-dropdown .composer-dropdown-trigger:hover {
   background: var(--theme-control-hover-bg);
   color: var(--theme-text-primary);
 }
@@ -466,8 +451,7 @@
 .new-thread-open-folder-path,
 .new-thread-open-folder-status,
 .new-thread-open-folder-item-main,
-.new-thread-open-folder-item-open,
-.new-thread-trending-tip {
+.new-thread-open-folder-item-open {
   border-color: var(--theme-border);
 }
 
@@ -478,8 +462,7 @@
   background: var(--theme-panel-subtle-bg);
 }
 
-.new-thread-open-folder-item-open,
-.new-thread-trending-tip {
+.new-thread-open-folder-item-open {
   background: var(--theme-control-bg);
 }
 
@@ -540,8 +523,7 @@
 }
 
 .new-thread-open-folder-item-main:hover:not(:disabled),
-.new-thread-open-folder-item-open:hover:not(:disabled),
-.new-thread-trending-tip:hover {
+.new-thread-open-folder-item-open:hover:not(:disabled) {
   border-color: var(--theme-border-strong);
   background: var(--theme-control-hover-bg);
   color: var(--theme-text-primary);

--- a/src/theme/app-shell-theme.css
+++ b/src/theme/app-shell-theme.css
@@ -1,0 +1,553 @@
+.content-root {
+  background: var(--theme-main-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-search-toggle {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-search-toggle:hover {
+  border-color: var(--theme-border);
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-search-toggle[aria-pressed='true'] {
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+}
+
+.sidebar-search-bar {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+}
+
+.sidebar-search-bar:focus-within {
+  border-color: var(--theme-border-strong);
+}
+
+.sidebar-search-bar-icon,
+.sidebar-search-clear {
+  color: var(--theme-text-muted);
+}
+
+.sidebar-search-input {
+  color: var(--theme-text-primary);
+}
+
+.sidebar-search-input::placeholder {
+  color: var(--theme-text-muted);
+}
+
+.sidebar-search-clear:hover {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-skills-link {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-skills-link:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-skills-link.is-active {
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+}
+
+.content-error {
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+.content-header-terminal-toggle {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.content-header-terminal-toggle:hover {
+  border-color: var(--theme-border-strong);
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.content-header-terminal-toggle[aria-pressed='true'] {
+  border-color: var(--theme-selection-border);
+  background: var(--theme-selection-bg);
+  color: var(--theme-selection-text);
+}
+
+.content-header-terminal-shortcut {
+  color: var(--theme-text-muted);
+}
+
+.content-header-branch-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.content-header-branch-dropdown.is-review-open .composer-dropdown-trigger {
+  border-color: var(--theme-info-border);
+  background: var(--theme-info-soft-bg);
+  color: var(--theme-info-text);
+}
+
+.content-header-branch-dropdown.is-review-open .composer-dropdown-chevron {
+  color: var(--theme-info-solid-text);
+}
+
+.new-thread-hero {
+  color: var(--theme-text-primary);
+}
+
+.new-thread-folder-dropdown,
+.new-thread-folder-selected,
+.new-thread-branch-select-label,
+.new-thread-branch-select-help,
+.new-thread-runtime-help,
+.new-thread-trending-title,
+.new-thread-trending-empty,
+.new-thread-trending-tip-meta {
+  color: var(--theme-text-muted);
+}
+
+.new-thread-folder-action,
+.new-thread-open-folder-item-open,
+.new-thread-branch-dropdown .composer-dropdown-trigger,
+.new-thread-trending-scope-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.new-thread-folder-action:hover,
+.new-thread-open-folder-item-open:hover,
+.new-thread-trending-tip:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-folder-action-primary,
+.new-thread-folder-action[aria-pressed='true'] {
+  border-color: var(--theme-accent);
+  background: var(--theme-accent);
+  color: var(--theme-accent-contrast);
+}
+
+.new-thread-open-folder {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
+  box-shadow: var(--theme-shadow-lg);
+}
+
+.new-thread-open-folder-title {
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-close,
+.new-thread-open-folder-label,
+.new-thread-open-folder-toggle,
+.new-thread-open-folder-status,
+.worktree-init-status.is-running {
+  color: var(--theme-text-secondary);
+}
+
+.new-thread-open-folder-path,
+.new-thread-open-folder-status,
+.new-thread-open-folder-item-main,
+.new-thread-trending-tip,
+.sidebar-settings-language-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-subtle-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-toggle-input,
+.new-thread-open-folder-filter,
+.new-thread-open-folder-create-input {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-toggle-input:focus-visible {
+  box-shadow: 0 0 0 3px var(--theme-selection-border);
+}
+
+.new-thread-open-folder-toggle-input:checked {
+  border-color: var(--theme-accent);
+  background-color: var(--theme-elevated-strong-bg);
+}
+
+.new-thread-open-folder-toggle-input::after {
+  border-right-color: var(--theme-accent);
+  border-bottom-color: var(--theme-accent);
+}
+
+.new-thread-open-folder-filter:focus,
+.new-thread-open-folder-create-input:focus {
+  border-color: var(--theme-border-strong);
+}
+
+.new-thread-open-folder-filter::placeholder,
+.new-thread-open-folder-create-input::placeholder {
+  color: var(--theme-text-muted);
+}
+
+.sidebar-settings-language-dropdown .composer-dropdown-trigger:hover {
+  background: var(--theme-control-hover-bg);
+}
+
+.new-thread-open-folder-error,
+.worktree-init-status.is-error {
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+.new-thread-open-folder-list {
+  scrollbar-color: var(--theme-text-muted) color-mix(in srgb, var(--theme-control-bg) 80%, transparent);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-track {
+  background: color-mix(in srgb, var(--theme-control-bg) 80%, transparent);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb {
+  background: var(--theme-text-muted);
+  border-color: color-mix(in srgb, var(--theme-control-bg) 80%, transparent);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb:hover {
+  background: var(--theme-text-secondary);
+}
+
+.new-thread-open-folder-item-main:hover {
+  border-color: var(--theme-border-strong);
+  background: var(--theme-control-hover-bg);
+}
+
+.new-thread-trending-tip-name,
+.worktree-init-status-title {
+  color: var(--theme-text-primary);
+}
+
+.new-thread-trending-tip-description,
+.worktree-init-status-message {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-settings-area {
+  background: var(--theme-sidebar-bg);
+  border-top-color: var(--theme-border);
+}
+
+.sidebar-settings-button {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-settings-button:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-panel,
+.sidebar-settings-telegram-panel,
+.sidebar-settings-account-section {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+}
+
+.sidebar-settings-row {
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-row:hover {
+  background: var(--theme-control-hover-bg);
+}
+
+.sidebar-settings-row + .sidebar-settings-row,
+.sidebar-settings-rate-limits,
+.sidebar-settings-build-label {
+  border-color: var(--theme-border);
+}
+
+.sidebar-settings-field-label,
+.sidebar-settings-account-title,
+.sidebar-settings-context-value {
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-field-help,
+.sidebar-settings-context-meta,
+.sidebar-settings-build-label,
+.sidebar-settings-account-empty,
+.sidebar-settings-account-meta,
+.sidebar-settings-account-quota,
+.sidebar-settings-value {
+  color: var(--theme-text-muted);
+}
+
+.sidebar-settings-input,
+.sidebar-settings-textarea,
+.sidebar-settings-account-item,
+.sidebar-settings-account-collapse,
+.sidebar-settings-account-refresh,
+.sidebar-settings-account-switch,
+.sidebar-settings-account-remove {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-input:focus,
+.sidebar-settings-textarea:focus {
+  border-color: var(--theme-border-strong);
+  box-shadow: 0 0 0 2px var(--theme-selection-border);
+}
+
+.sidebar-settings-telegram-error,
+.sidebar-settings-account-error,
+.sidebar-settings-error {
+  background: var(--theme-danger-soft-bg);
+  color: var(--theme-danger-text);
+}
+
+.sidebar-settings-telegram-save {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-settings-telegram-save:hover,
+.sidebar-settings-account-collapse:hover,
+.sidebar-settings-account-refresh:hover,
+.sidebar-settings-account-switch:hover,
+.sidebar-settings-account-remove:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.sidebar-settings-account-count,
+.sidebar-settings-account-id {
+  background: var(--theme-control-active-bg);
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-settings-account-item.is-active {
+  border-color: var(--theme-success-border);
+  background: var(--theme-success-soft-bg);
+}
+
+.sidebar-settings-account-item.is-active .sidebar-settings-account-id {
+  background: color-mix(in srgb, var(--theme-success-soft-bg) 85%, var(--theme-control-bg));
+  color: var(--theme-success-text);
+}
+
+.sidebar-settings-account-item.is-unavailable {
+  border-color: var(--theme-danger-border);
+  background: var(--theme-danger-soft-bg);
+}
+
+.sidebar-settings-account-item.is-unavailable .sidebar-settings-account-id {
+  background: color-mix(in srgb, var(--theme-danger-soft-bg) 85%, var(--theme-control-bg));
+  color: var(--theme-danger-text);
+}
+
+.sidebar-settings-account-remove {
+  border-color: var(--theme-warning-border);
+}
+
+.sidebar-settings-account-remove.is-confirming {
+  background: var(--theme-warning-soft-bg);
+  color: var(--theme-warning-text);
+}
+
+.sidebar-settings-toggle {
+  background: var(--theme-border-strong);
+}
+
+.sidebar-settings-toggle::after {
+  background: var(--theme-elevated-strong-bg);
+}
+
+.sidebar-settings-toggle.is-on {
+  background: var(--theme-accent);
+}
+
+.sidebar-settings-context-value[data-state='ok'] {
+  color: var(--theme-success-text);
+}
+
+.sidebar-settings-context-value[data-state='warning'] {
+  color: var(--theme-warning-text);
+}
+
+.sidebar-settings-context-value[data-state='danger'] {
+  color: var(--theme-danger-text);
+}
+
+.sidebar-skills-link,
+.new-thread-open-folder-close,
+.new-thread-open-folder-toggle,
+.new-thread-folder-selected {
+  color: var(--theme-text-secondary);
+}
+
+.sidebar-skills-link:hover,
+.new-thread-open-folder-close:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-hero,
+.new-thread-open-folder-title,
+.new-thread-trending-tip-name {
+  color: var(--theme-text-primary);
+}
+
+.new-thread-folder-dropdown,
+.new-thread-branch-select-label,
+.new-thread-branch-select-help,
+.new-thread-runtime-help,
+.new-thread-trending-title,
+.new-thread-trending-empty,
+.new-thread-trending-tip-meta,
+.new-thread-trending-tip-description {
+  color: var(--theme-text-muted);
+}
+
+.content-header-branch-dropdown .composer-dropdown-trigger,
+.new-thread-folder-action,
+.new-thread-branch-dropdown .composer-dropdown-trigger,
+.new-thread-trending-scope-dropdown .composer-dropdown-trigger {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-secondary);
+}
+
+.new-thread-folder-action:hover:not(:disabled),
+.content-header-branch-dropdown .composer-dropdown-trigger:hover,
+.new-thread-branch-dropdown .composer-dropdown-trigger:hover,
+.new-thread-trending-scope-dropdown .composer-dropdown-trigger:hover {
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-folder-action-primary,
+.new-thread-folder-action[aria-pressed='true'] {
+  border-color: var(--theme-accent);
+  background: var(--theme-accent);
+  color: var(--theme-accent-contrast);
+}
+
+.new-thread-open-folder-overlay {
+  background: var(--theme-overlay);
+}
+
+.new-thread-open-folder {
+  border-color: var(--theme-border);
+  background: var(--theme-panel-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-label {
+  color: var(--theme-text-muted);
+}
+
+.new-thread-open-folder-path,
+.new-thread-open-folder-status,
+.new-thread-open-folder-item-main,
+.new-thread-open-folder-item-open,
+.new-thread-trending-tip {
+  border-color: var(--theme-border);
+}
+
+.new-thread-open-folder-path,
+.new-thread-open-folder-status,
+.new-thread-open-folder-item-main,
+.worktree-init-status.is-running {
+  background: var(--theme-panel-subtle-bg);
+}
+
+.new-thread-open-folder-item-open,
+.new-thread-trending-tip {
+  background: var(--theme-control-bg);
+}
+
+.new-thread-open-folder-path,
+.new-thread-open-folder-status,
+.new-thread-open-folder-item-open,
+.worktree-init-status.is-running {
+  color: var(--theme-text-secondary);
+}
+
+.new-thread-open-folder-toggle-input,
+.new-thread-open-folder-filter,
+.new-thread-open-folder-create-input {
+  border-color: var(--theme-border);
+  background: var(--theme-control-bg);
+  color: var(--theme-text-primary);
+}
+
+.new-thread-open-folder-filter:focus,
+.new-thread-open-folder-create-input:focus {
+  border-color: var(--theme-border-strong);
+}
+
+.new-thread-open-folder-filter::placeholder,
+.new-thread-open-folder-create-input::placeholder {
+  color: var(--theme-text-muted);
+}
+
+.new-thread-open-folder-toggle-input:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-selection-bg) 85%, transparent);
+}
+
+.new-thread-open-folder-toggle-input:checked {
+  border-color: var(--theme-accent);
+  background-color: var(--theme-control-bg);
+}
+
+.new-thread-open-folder-toggle-input::after {
+  border-right-color: var(--theme-accent);
+  border-bottom-color: var(--theme-accent);
+}
+
+.new-thread-open-folder-list {
+  scrollbar-color: var(--theme-text-muted) var(--theme-panel-subtle-bg);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-track {
+  background: var(--theme-panel-subtle-bg);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb {
+  background: var(--theme-text-muted);
+  border: 2px solid var(--theme-panel-subtle-bg);
+}
+
+.new-thread-open-folder-list::-webkit-scrollbar-thumb:hover {
+  background: var(--theme-text-secondary);
+}
+
+.new-thread-open-folder-item-main:hover:not(:disabled),
+.new-thread-open-folder-item-open:hover:not(:disabled),
+.new-thread-trending-tip:hover {
+  border-color: var(--theme-border-strong);
+  background: var(--theme-control-hover-bg);
+  color: var(--theme-text-primary);
+}
+
+.worktree-init-status.is-running {
+  border-color: var(--theme-info-border);
+  color: var(--theme-info-text);
+}

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,0 +1,60 @@
+export type ThemeId = 'default' | 'graphite' | 'macos'
+
+export type BuiltInTheme = {
+  id: ThemeId
+  label: string
+}
+
+export const BUILT_IN_THEMES: BuiltInTheme[] = [
+  { id: 'default', label: 'Default' },
+  { id: 'graphite', label: 'Graphite' },
+  { id: 'macos', label: 'macOS' },
+]
+
+export const DEFAULT_THEME_ID: ThemeId = 'default'
+
+const THEME_META_COLORS: Record<ThemeId, { light: string, dark: string }> = {
+  default: {
+    light: '#f1f5f9',
+    dark: '#18181b',
+  },
+  graphite: {
+    light: '#eef2f7',
+    dark: '#111827',
+  },
+  macos: {
+    light: '#f5f5f7',
+    dark: '#1c1c1e',
+  },
+}
+
+export const DEFAULT_THEME_META_COLOR = THEME_META_COLORS[DEFAULT_THEME_ID].light
+
+export function getStoredThemeId(value: string | null | undefined): ThemeId {
+  return BUILT_IN_THEMES.some((theme) => theme.id === value)
+    ? (value as ThemeId)
+    : DEFAULT_THEME_ID
+}
+
+export function getThemeMetaColor(themeId: ThemeId, appearance: 'light' | 'dark'): string {
+  return THEME_META_COLORS[themeId][appearance]
+}
+
+export function normalizeMetaThemeColor(rawValue: string | null | undefined, fallback: string): string {
+  const value = rawValue?.trim()
+  if (!value) return fallback
+
+  const lowerValue = value.toLowerCase()
+  if (lowerValue.includes('var(') || lowerValue.includes('color-mix(')) {
+    return fallback
+  }
+
+  return value
+}
+
+export function cycleThemeId(current: ThemeId): ThemeId {
+  const ids = BUILT_IN_THEMES.map((theme) => theme.id)
+  const index = ids.indexOf(current)
+  if (index === -1) return DEFAULT_THEME_ID
+  return ids[(index + 1) % ids.length] as ThemeId
+}

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -35,6 +35,7 @@ const skillsHubVue = readFileSync(resolve(process.cwd(), 'src/components/content
 const threadComposerVue = readFileSync(resolve(process.cwd(), 'src/components/content/ThreadComposer.vue'), 'utf8')
 const threadConversationVue = readFileSync(resolve(process.cwd(), 'src/components/content/ThreadConversation.vue'), 'utf8')
 const desktopLayoutVue = readFileSync(resolve(process.cwd(), 'src/components/layout/DesktopLayout.vue'), 'utf8')
+const sidebarThreadControlsVue = readFileSync(resolve(process.cwd(), 'src/components/sidebar/SidebarThreadControls.vue'), 'utf8')
 const sidebarThreadTreeVue = readFileSync(resolve(process.cwd(), 'src/components/sidebar/SidebarThreadTree.vue'), 'utf8')
 
 function getThemeTokenBlock(theme: string, appearance: string): Record<string, string> {
@@ -161,6 +162,11 @@ test('default theme tokens resolve to the legacy light palette', () => {
   assert.equal(tokens['--theme-text-muted'], '#71717a')
   assert.equal(tokens['--theme-shell-text'], '#0f172a')
   assert.equal(tokens['--theme-heading-text'], '#18181b')
+  assert.equal(tokens['--theme-content-title-text'], '#0f172a')
+  assert.equal(tokens['--theme-sidebar-control-text'], '#52525b')
+  assert.equal(tokens['--theme-composer-shell-border'], '#d4d4d8')
+  assert.equal(tokens['--theme-composer-input-disabled-bg'], '#f4f4f5')
+  assert.equal(tokens['--theme-composer-input-disabled-text'], '#71717a')
   assert.equal(tokens['--theme-runtime-bg'], '#f4f4f5')
   assert.equal(tokens['--theme-runtime-selected-bg'], '#ffffff')
   assert.equal(tokens['--theme-runtime-selected-border'], '#e4e4e7')
@@ -225,7 +231,12 @@ test('default theme tokens resolve to the legacy dark palette', () => {
   assert.equal(tokens['--theme-text-muted'], '#a1a1aa')
   assert.equal(tokens['--theme-shell-text'], '#f4f4f5')
   assert.equal(tokens['--theme-heading-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-content-title-text'], '#e4e4e7')
   assert.equal(tokens['--theme-settings-button-text'], '#a1a1aa')
+  assert.equal(tokens['--theme-sidebar-control-text'], '#a1a1aa')
+  assert.equal(tokens['--theme-composer-shell-border'], '#3f3f46')
+  assert.equal(tokens['--theme-composer-input-disabled-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-composer-input-disabled-text'], '#71717a')
   assert.equal(tokens['--theme-runtime-bg'], '#18181b')
   assert.equal(tokens['--theme-runtime-selected-bg'], '#27272a')
   assert.equal(tokens['--theme-runtime-selected-text'], '#f4f4f5')
@@ -358,6 +369,22 @@ test('legacy component styling remains the default base for non-macos themes', (
   assert.match(
     styleCss,
     /:root\[data-theme\]\[data-appearance\] \.runtime-toggle-option\.is-selected\s*\{\s*border-color: var\(--theme-runtime-selected-border, var\(--theme-selection-border\)\);\s*background: var\(--theme-runtime-selected-bg, var\(--theme-selection-bg\)\);\s*color: var\(--theme-runtime-selected-text, var\(--theme-selection-text\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.thread-composer-shell\s*\{\s*border-color: var\(--theme-composer-shell-border, var\(--theme-border\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.thread-composer-input:disabled\s*\{\s*background: var\(--theme-composer-input-disabled-bg, var\(--theme-control-active-bg\)\);\s*color: var\(--theme-composer-input-disabled-text, var\(--theme-text-muted\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.content-title\s*\{\s*color: var\(--theme-content-title-text, var\(--theme-text-primary\)\);/
+  )
+  assert.match(
+    sidebarThreadControlsVue,
+    /color: var\(--theme-sidebar-control-text, var\(--theme-text-subtle\)\);/
   )
   assert.doesNotMatch(styleCss, /^\.sidebar-settings-panel\s*\{/m)
   assert.doesNotMatch(styleCss, /^\.sidebar-settings-row\s*\{/m)

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -159,6 +159,12 @@ test('default theme tokens resolve to the legacy light palette', () => {
   assert.equal(tokens['--theme-text-secondary'], '#3f3f46')
   assert.equal(tokens['--theme-text-subtle'], '#52525b')
   assert.equal(tokens['--theme-text-muted'], '#71717a')
+  assert.equal(tokens['--theme-shell-text'], '#0f172a')
+  assert.equal(tokens['--theme-heading-text'], '#18181b')
+  assert.equal(tokens['--theme-runtime-bg'], '#f4f4f5')
+  assert.equal(tokens['--theme-runtime-selected-bg'], '#ffffff')
+  assert.equal(tokens['--theme-runtime-selected-border'], '#e4e4e7')
+  assert.equal(tokens['--theme-runtime-selected-text'], '#18181b')
   assert.equal(tokens['--theme-code-bg'], '#020617')
   assert.equal(tokens['--theme-code-header-bg'], 'rgba(15, 23, 42, 0.94)')
   assert.equal(tokens['--theme-code-text'], '#f1f5f9')
@@ -217,6 +223,13 @@ test('default theme tokens resolve to the legacy dark palette', () => {
   assert.equal(tokens['--theme-text-secondary'], '#d4d4d8')
   assert.equal(tokens['--theme-text-subtle'], '#d4d4d8')
   assert.equal(tokens['--theme-text-muted'], '#a1a1aa')
+  assert.equal(tokens['--theme-shell-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-heading-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-settings-button-text'], '#a1a1aa')
+  assert.equal(tokens['--theme-runtime-bg'], '#18181b')
+  assert.equal(tokens['--theme-runtime-selected-bg'], '#27272a')
+  assert.equal(tokens['--theme-runtime-selected-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-accent'], '#18181b')
   assert.equal(tokens['--theme-code-bg'], '#09090b')
   assert.equal(tokens['--theme-code-header-bg'], '#18181b')
   assert.equal(tokens['--theme-code-text'], '#f4f4f5')
@@ -332,15 +345,19 @@ test('legacy component styling remains the default base for non-macos themes', (
   )
   assert.match(
     composerRuntimeDropdownVue,
-    /\.runtime-toggle\s*\{\s*@apply inline-flex items-center gap-1 rounded-full border p-1;\s*border-color: var\(--theme-border\);\s*background: color-mix\(in srgb, var\(--theme-control-bg\) 84%, var\(--theme-main-bg\)\);/
+    /\.runtime-toggle\s*\{\s*@apply inline-flex items-center gap-1 rounded-full border p-1;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-runtime-bg, color-mix\(in srgb, var\(--theme-control-bg\) 84%, var\(--theme-main-bg\)\)\);/
   )
   assert.match(
     composerRuntimeDropdownVue,
-    /\.runtime-toggle-option\.is-selected\s*\{\s*border-color: var\(--theme-selection-border\);\s*background: var\(--theme-selection-bg\);\s*color: var\(--theme-selection-text\);/
+    /\.runtime-toggle-option\.is-selected\s*\{\s*border-color: var\(--theme-runtime-selected-border, var\(--theme-selection-border\)\);\s*background: var\(--theme-runtime-selected-bg, var\(--theme-selection-bg\)\);\s*color: var\(--theme-runtime-selected-text, var\(--theme-selection-text\)\);/
   )
   assert.match(
     styleCss,
     /:root\[data-theme\]\[data-appearance\] \.runtime-toggle-option\.is-selected,\s*:root\[data-theme\]\[data-appearance\] \.composer-dropdown-option\.is-selected,\s*:root\[data-theme\]\[data-appearance\] \.organize-menu-item\[data-active='true'\],\s*:root\[data-theme\]\[data-appearance\] \.thread-row\[data-active='true'\],/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.runtime-toggle-option\.is-selected\s*\{\s*border-color: var\(--theme-runtime-selected-border, var\(--theme-selection-border\)\);\s*background: var\(--theme-runtime-selected-bg, var\(--theme-selection-bg\)\);\s*color: var\(--theme-runtime-selected-text, var\(--theme-selection-text\)\);/
   )
   assert.doesNotMatch(styleCss, /^\.sidebar-settings-panel\s*\{/m)
   assert.doesNotMatch(styleCss, /^\.sidebar-settings-row\s*\{/m)

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,0 +1,390 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  APPEARANCE_MODES,
+  cycleAppearanceMode,
+  getEffectiveTheme,
+  getStoredAppearanceMode,
+  type AppearanceMode,
+} from '../src/theme.ts'
+import {
+  BUILT_IN_THEMES,
+  cycleThemeId,
+  DEFAULT_THEME_ID,
+  DEFAULT_THEME_META_COLOR,
+  getThemeMetaColor,
+  getStoredThemeId,
+  normalizeMetaThemeColor,
+  type ThemeId,
+} from '../src/theme/themes.ts'
+
+const styleCss = readFileSync(resolve(process.cwd(), 'src/style.css'), 'utf8')
+const appShellThemeCss = readFileSync(resolve(process.cwd(), 'src/theme/app-shell-theme.css'), 'utf8')
+const indexHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8')
+const manifestWebmanifest = readFileSync(resolve(process.cwd(), 'public/manifest.webmanifest'), 'utf8')
+const appVue = readFileSync(resolve(process.cwd(), 'src/App.vue'), 'utf8')
+const accountMenuVue = readFileSync(resolve(process.cwd(), 'src/components/content/AccountMenu.vue'), 'utf8')
+const composerDropdownVue = readFileSync(resolve(process.cwd(), 'src/components/content/ComposerDropdown.vue'), 'utf8')
+const composerRuntimeDropdownVue = readFileSync(resolve(process.cwd(), 'src/components/content/ComposerRuntimeDropdown.vue'), 'utf8')
+const composerSkillPickerVue = readFileSync(resolve(process.cwd(), 'src/components/content/ComposerSkillPicker.vue'), 'utf8')
+const reviewPaneVue = readFileSync(resolve(process.cwd(), 'src/components/content/ReviewPane.vue'), 'utf8')
+const skillsHubVue = readFileSync(resolve(process.cwd(), 'src/components/content/SkillsHub.vue'), 'utf8')
+const threadComposerVue = readFileSync(resolve(process.cwd(), 'src/components/content/ThreadComposer.vue'), 'utf8')
+const threadConversationVue = readFileSync(resolve(process.cwd(), 'src/components/content/ThreadConversation.vue'), 'utf8')
+const desktopLayoutVue = readFileSync(resolve(process.cwd(), 'src/components/layout/DesktopLayout.vue'), 'utf8')
+const sidebarThreadTreeVue = readFileSync(resolve(process.cwd(), 'src/components/sidebar/SidebarThreadTree.vue'), 'utf8')
+
+test('appearance modes remain system, light, and dark', () => {
+  assert.deepEqual(APPEARANCE_MODES, ['system', 'light', 'dark'])
+  assert.equal(getEffectiveTheme('system', false), 'light')
+  assert.equal(getEffectiveTheme('system', true), 'dark')
+  assert.equal(getEffectiveTheme('light', true), 'light')
+  assert.equal(getEffectiveTheme('dark', false), 'dark')
+})
+
+test('appearance mode helpers still sanitize and cycle values', () => {
+  assert.equal(getStoredAppearanceMode('system'), 'system')
+  assert.equal(getStoredAppearanceMode('light'), 'light')
+  assert.equal(getStoredAppearanceMode('dark'), 'dark')
+  assert.equal(getStoredAppearanceMode('missing'), 'system')
+  assert.equal(getStoredAppearanceMode(null), 'system')
+
+  let current: AppearanceMode = 'system'
+  const seen = new Set<AppearanceMode>()
+  for (let index = 0; index < APPEARANCE_MODES.length; index += 1) {
+    seen.add(current)
+    current = cycleAppearanceMode(current)
+  }
+
+  assert.deepEqual([...seen], APPEARANCE_MODES)
+  assert.equal(current, 'system')
+})
+
+test('theme helpers keep macos opt-in and leave default as fallback', () => {
+  assert.equal(DEFAULT_THEME_ID, 'default')
+  assert.deepEqual(
+    BUILT_IN_THEMES.map((theme) => theme.id),
+    ['default', 'graphite', 'macos']
+  )
+  assert.equal(getStoredThemeId('default'), 'default')
+  assert.equal(getStoredThemeId('graphite'), 'graphite')
+  assert.equal(getStoredThemeId('macos'), 'macos')
+  assert.equal(getStoredThemeId('missing' as ThemeId), DEFAULT_THEME_ID)
+  assert.equal(cycleThemeId('default'), 'graphite')
+  assert.equal(cycleThemeId('graphite'), 'macos')
+  assert.equal(cycleThemeId('macos'), 'default')
+  assert.equal(DEFAULT_THEME_META_COLOR, '#f1f5f9')
+  assert.equal(getThemeMetaColor('default', 'light'), '#f1f5f9')
+  assert.equal(getThemeMetaColor('default', 'dark'), '#18181b')
+  assert.equal(getThemeMetaColor('graphite', 'light'), '#eef2f7')
+  assert.equal(getThemeMetaColor('graphite', 'dark'), '#111827')
+  assert.equal(getThemeMetaColor('macos', 'light'), '#f5f5f7')
+  assert.equal(getThemeMetaColor('macos', 'dark'), '#1c1c1e')
+  assert.equal(normalizeMetaThemeColor('#f1f5f9', '#000000'), '#f1f5f9')
+  assert.equal(normalizeMetaThemeColor('rgb(245 245 247)', '#000000'), 'rgb(245 245 247)')
+  assert.equal(normalizeMetaThemeColor('rgb(var(--color-materialThick-dark))', '#1c1c1e'), '#1c1c1e')
+  assert.equal(normalizeMetaThemeColor('color-mix(in srgb, white 90%, black)', '#f5f5f7'), '#f5f5f7')
+  assert.equal(normalizeMetaThemeColor('', '#f5f5f7'), '#f5f5f7')
+})
+
+test('index bootstraps explicit appearance support before mount', () => {
+  assert.match(indexHtml, /<meta name="color-scheme" content="light dark"/)
+  assert.match(indexHtml, /<meta name="theme-color" content="#020617"/)
+  assert.match(indexHtml, /document\.documentElement/)
+  assert.match(indexHtml, /const readStorage = \(key\) => \{/)
+  assert.match(indexHtml, /try \{\s*return window\.localStorage\.getItem\(key\)\s*\} catch \{\s*return null\s*\}/)
+  assert.match(indexHtml, /meta\[name="theme-color"\]/)
+  assert.match(indexHtml, /themeColorMeta\.setAttribute\('content', themeColor\)/)
+  assert.match(indexHtml, /meta\[name="apple-mobile-web-app-status-bar-style"\]/)
+  assert.match(indexHtml, /statusBarMeta\.setAttribute\('content', effectiveAppearance === 'dark' \? 'black-translucent' : 'default'\)/)
+})
+
+test('manifest keeps upstream dark fallback browser chrome color', () => {
+  assert.match(manifestWebmanifest, /"background_color": "#020617"/)
+  assert.match(manifestWebmanifest, /"theme_color": "#020617"/)
+})
+
+test('shared stylesheet still defines token blocks and keeps macos styling scoped', () => {
+  assert.match(styleCss, /@import "tailwindcss-uikit-colors\/v4\/macos\.css";/)
+  assert.match(styleCss, /@import "\.\/theme\/app-shell-theme\.css";/)
+  assert.match(styleCss, /:root\[data-theme='default'\]\[data-appearance='light'\]/)
+  assert.match(styleCss, /:root\[data-theme='default'\]\[data-appearance='dark'\]/)
+  assert.match(styleCss, /:root\[data-theme='graphite'\]\[data-appearance='light'\]/)
+  assert.match(styleCss, /:root\[data-theme='graphite'\]\[data-appearance='dark'\]/)
+  assert.match(styleCss, /:root\[data-theme='macos'\]\[data-appearance='light'\]/)
+  assert.match(styleCss, /:root\[data-theme='macos'\]\[data-appearance='dark'\]/)
+  assert.match(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\]\s+\.desktop-layout,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\]\s+\.desktop-layout/
+  )
+  assert.doesNotMatch(
+    styleCss,
+    /:root\[data-theme='default'\]\[data-appearance='light'\]\s+\.desktop-layout,\s*:root\[data-theme='default'\]\[data-appearance='dark'\]\s+\.desktop-layout/
+  )
+})
+
+test('legacy settings styling stays on the main branch base with explicit appearance overrides while skills hub stays tokenized', () => {
+  assert.match(
+    appVue,
+    /\.sidebar-settings-panel\s*\{\s*@apply mb-1 max-h-\[min\(70vh,36rem\)\] overflow-y-auto rounded-lg border border-zinc-200 bg-white;/
+  )
+  assert.match(
+    appVue,
+    /\.sidebar-settings-row\s*\{\s*@apply flex items-center justify-between w-full px-3 py-2\.5 text-sm text-zinc-700 border-0 bg-transparent transition hover:bg-zinc-50 cursor-pointer;/
+  )
+  assert.match(
+    appVue,
+    /\.sidebar-settings-account-section\s*\{\s*@apply border-t border-zinc-100 bg-zinc-50\/60 px-3 py-3;/
+  )
+  assert.match(
+    appVue,
+    /\.sidebar-settings-value\s*\{\s*@apply text-xs text-zinc-500 bg-zinc-100 rounded px-1\.5 py-0\.5;/
+  )
+  assert.match(
+    appVue,
+    /\.sidebar-settings-toggle\s*\{\s*@apply relative w-9 h-5 rounded-full bg-zinc-300 transition-colors shrink-0;/
+  )
+  assert.match(
+    appVue,
+    /\.sidebar-settings-account-refresh\s*\{\s*@apply shrink-0 rounded-full border border-zinc-200 bg-white px-2\.5 py-1 text-xs text-zinc-700 transition hover:bg-zinc-50 disabled:cursor-default disabled:opacity-60;/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-panel\s*\{\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-bg\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-telegram-panel,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-section\s*\{\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-subtle-bg\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-count,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-id,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-value\s*\{\s*background: var\(--theme-control-active-bg\);\s*color: var\(--theme-text-secondary\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-toggle\s*\{\s*background: var\(--theme-border-strong\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-toggle\.is-on\s*\{\s*background: var\(--theme-selection-bg\);/
+  )
+  assert.match(
+    skillsHubVue,
+    /\.skills-hub-search-wrap\s*\{\s*@apply flex-1 flex items-center gap-2 rounded-xl border px-3 py-2 transition;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-bg\);/
+  )
+  assert.match(
+    skillsHubVue,
+    /\.skills-hub-search-btn\s*\{\s*@apply shrink-0 rounded-md border px-2 py-1 text-xs font-medium transition cursor-pointer;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-control-bg\);\s*color: var\(--theme-text-secondary\);/
+  )
+  assert.match(
+    skillsHubVue,
+    /\.skills-sync-panel\s*\{\s*@apply rounded-xl border p-3 flex flex-col gap-2;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-subtle-bg\);/
+  )
+})
+
+test('legacy component styling remains the default base for non-macos themes', () => {
+  assert.match(
+    desktopLayoutVue,
+    /\.desktop-layout\s*\{\s*@apply grid bg-slate-100 text-slate-900 overflow-hidden;/
+  )
+  assert.match(
+    accountMenuVue,
+    /\.account-menu-panel\s*\{\s*@apply absolute right-0 top-\[calc\(100%\+8px\)\] z-50 flex w-80 max-w-\[calc\(100vw-24px\)\] flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-3 shadow-lg;/
+  )
+  assert.match(
+    composerDropdownVue,
+    /\.composer-dropdown-menu\s*\{\s*@apply m-0 min-w-56 rounded-xl border border-zinc-200 bg-white p-1 shadow-lg;/
+  )
+  assert.match(
+    composerRuntimeDropdownVue,
+    /\.runtime-toggle\s*\{\s*@apply inline-flex items-center gap-1 rounded-full border p-1;\s*border-color: var\(--theme-border\);\s*background: color-mix\(in srgb, var\(--theme-control-bg\) 84%, var\(--theme-main-bg\)\);/
+  )
+  assert.match(
+    composerRuntimeDropdownVue,
+    /\.runtime-toggle-option\.is-selected\s*\{\s*border-color: var\(--theme-selection-border\);\s*background: var\(--theme-selection-bg\);\s*color: var\(--theme-selection-text\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.runtime-toggle-option\.is-selected,\s*:root\[data-theme\]\[data-appearance\] \.composer-dropdown-option\.is-selected,\s*:root\[data-theme\]\[data-appearance\] \.organize-menu-item\[data-active='true'\],\s*:root\[data-theme\]\[data-appearance\] \.thread-row\[data-active='true'\],/
+  )
+  assert.doesNotMatch(styleCss, /^\.sidebar-settings-panel\s*\{/m)
+  assert.doesNotMatch(styleCss, /^\.sidebar-settings-row\s*\{/m)
+  assert.doesNotMatch(styleCss, /^\.sidebar-settings-value\s*\{/m)
+  assert.doesNotMatch(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.sidebar-settings-toggle,/
+  )
+  assert.match(
+    composerSkillPickerVue,
+    /\.skill-picker\s*\{\s*@apply absolute z-40 w-72 max-sm:!left-4 max-sm:!right-4 max-sm:!w-auto max-h-64 rounded-xl border border-zinc-200 bg-white shadow-lg flex flex-col overflow-hidden;/
+  )
+  assert.match(
+    reviewPaneVue,
+    /\.review-pane\s*\{\s*@apply flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white;/
+  )
+  assert.match(
+    threadComposerVue,
+    /\.thread-composer-shell\s*\{\s*@apply relative rounded-2xl border border-zinc-300 bg-white p-2 sm:p-3 shadow-sm;/
+  )
+  assert.match(
+    threadConversationVue,
+    /\.plan-card\s*\{\s*@apply flex max-w-\[min\(var\(--chat-card-max,76ch\),100%\)\] flex-col gap-3 rounded-2xl border px-4 py-3;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-bg\);\s*color: var\(--theme-text-primary\);/
+  )
+  assert.doesNotMatch(
+    threadConversationVue,
+    /\.plan-card\s*\{\s*@apply flex max-w-\[min\(var\(--chat-card-max,76ch\),100%\)\] flex-col gap-3 rounded-2xl border border-sky-200 bg-sky-50 px-4 py-3 text-slate-900;/
+  )
+  assert.match(
+    sidebarThreadTreeVue,
+    /\.organize-menu-panel\s*\{\s*@apply absolute right-0 top-full mt-1 z-30 min-w-44 rounded-xl border border-zinc-200 bg-white\/95 p-1\.5 shadow-lg backdrop-blur-sm;/
+  )
+  assert.doesNotMatch(sidebarThreadTreeVue, /\.thread-row\s*\{\s*@apply hover:bg-zinc-200;\s*\}/)
+  assert.doesNotMatch(
+    sidebarThreadTreeVue,
+    /\.thread-row\[data-active='true'\]\s*\{\s*@apply bg-zinc-200;\s*\}/
+  )
+})
+
+test('theme app-shell stylesheet remains available for shared shell surfaces', () => {
+  assert.match(appShellThemeCss, /\.content-root\s*\{[\s\S]*var\(--theme-main-bg\)/)
+  assert.match(appShellThemeCss, /\.sidebar-search-bar\s*\{[\s\S]*var\(--theme-control-bg\)/)
+  assert.match(appShellThemeCss, /\.content-header-terminal-toggle\s*\{[\s\S]*var\(--theme-control-bg\)/)
+  assert.match(appShellThemeCss, /\.new-thread-open-folder\s*\{[\s\S]*var\(--theme-panel-bg\)/)
+})
+
+test('shared shell controls avoid hardcoded App-level colors and keep review-open state tokenized', () => {
+  assert.match(
+    appShellThemeCss,
+    /\.content-header-terminal-toggle\[aria-pressed='true'\]\s*\{[\s\S]*border-color: var\(--theme-selection-border\);[\s\S]*background: var\(--theme-selection-bg\);[\s\S]*color: var\(--theme-selection-text\);/
+  )
+  assert.match(
+    appShellThemeCss,
+    /\.content-header-branch-dropdown\.is-review-open \.composer-dropdown-trigger\s*\{[\s\S]*border-color: var\(--theme-info-border\);[\s\S]*background: var\(--theme-info-soft-bg\);[\s\S]*color: var\(--theme-info-text\);/
+  )
+  assert.doesNotMatch(
+    appShellThemeCss,
+    /\.new-thread-folder-action-primary,\s*\.new-thread-folder-action\[aria-pressed='true'\],\s*\.content-header-branch-dropdown\.is-review-open \.composer-dropdown-trigger/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.content-header-terminal-toggle\s*\{\s*@apply flex h-8 items-center gap-1\.5 rounded-full border border-zinc-200 bg-white px-2\.5 text-xs text-zinc-700 transition hover:bg-zinc-50;\s*\}/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.content-header-branch-dropdown\.is-review-open\s*:deep\(\.composer-dropdown-trigger\)\s*\{\s*@apply border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800;\s*\}/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.new-thread-open-folder-overlay\s*\{\s*@apply fixed inset-0 z-50 flex items-center justify-center bg-black\/40 p-4;/
+  )
+})
+
+test('shared shell active states stay centralized instead of drifting in App scoped CSS', () => {
+  assert.match(
+    appShellThemeCss,
+    /\.sidebar-skills-link\.is-active\s*\{[\s\S]*background: var\(--theme-selection-bg\);[\s\S]*color: var\(--theme-selection-text\);/
+  )
+  assert.match(
+    appShellThemeCss,
+    /\.new-thread-open-folder-toggle-input:focus-visible\s*\{[\s\S]*color-mix\(in srgb, var\(--theme-selection-bg\) 85%, transparent\)/
+  )
+  assert.match(
+    appShellThemeCss,
+    /\.new-thread-open-folder-toggle-input:checked\s*\{[\s\S]*border-color: var\(--theme-accent\);[\s\S]*background-color: var\(--theme-control-bg\);/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.sidebar-skills-link\.is-active\s*\{[^}]*background: var\(--theme-[^;]+;/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.new-thread-open-folder-toggle-input:focus-visible\s*\{[^}]*box-shadow:/
+  )
+  assert.doesNotMatch(
+    appVue,
+    /\.new-thread-open-folder-toggle-input:checked\s*\{[^}]*background-color:/
+  )
+})
+
+test('pressed sidebar search toggle keeps selected-state styling instead of generic control styling', () => {
+  assert.match(
+    appVue,
+    /\.sidebar-search-toggle\[aria-pressed='true'\]\s*\{\s*border-color: var\(--theme-selection-border\);\s*background: var\(--theme-selection-bg\);\s*color: var\(--theme-selection-text\);/
+  )
+  assert.doesNotMatch(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.sidebar-search-toggle\[aria-pressed='true'\],/
+  )
+})
+
+test('macos sidebar settings stay compact instead of using inflated fallback sizing', () => {
+  assert.match(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row \{[\s\S]*min-height: 2\.5rem;[\s\S]*padding-inline: 0\.75rem;/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-provider-select,[\s\S]*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-telegram-save \{[\s\S]*min-height: 1\.875rem;[\s\S]*padding-inline: 0\.625rem;/
+  )
+  assert.doesNotMatch(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row \{[\s\S]*min-height: 2\.75rem;/
+  )
+  assert.doesNotMatch(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-provider-select,[\s\S]*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-telegram-save \{[\s\S]*min-height: 2\.125rem;/
+  )
+  assert.match(
+    appVue,
+    /class="sidebar-settings-row sidebar-settings-row--select sidebar-settings-row--provider"/
+  )
+  assert.match(
+    appVue,
+    /class="sidebar-settings-row sidebar-settings-row--select sidebar-settings-row--language"/
+  )
+  assert.match(
+    styleCss,
+    /@media \(max-width: 768px\) \{[\s\S]*:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row--provider,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row--provider,\s*:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row--language,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row--language \{[\s\S]*padding-inline: 0\.625rem;[\s\S]*gap: 0\.5rem;/
+  )
+  assert.match(
+    styleCss,
+    /@media \(max-width: 768px\) \{[\s\S]*:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row--provider \.sidebar-settings-provider-select,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row--provider \.sidebar-settings-provider-select \{[\s\S]*max-width: 8rem;[\s\S]*:root\[data-theme='macos'\]\[data-appearance='light'\] \.sidebar-settings-row--language \.sidebar-settings-language-dropdown \.composer-dropdown-value,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.sidebar-settings-row--language \.sidebar-settings-language-dropdown \.composer-dropdown-value \{[\s\S]*max-width: 3\.5rem;/
+  )
+})
+
+test('macos assistant conversation cards keep panel padding inside the message shell', () => {
+  assert.match(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.message-body\[data-role='assistant'\] \.message-card,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.message-body\[data-role='assistant'\] \.message-card,\s*:root\[data-theme='macos'\]\[data-appearance='light'\] \.message-body\[data-role='system'\] \.message-card,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.message-body\[data-role='system'\] \.message-card\s*\{[^}]*padding:\s*0\.875rem 1rem;/
+  )
+  assert.match(
+    threadConversationVue,
+    /<style>\s*:root\[data-theme='macos'\]\[data-appearance='light'\] \.message-body\[data-role='assistant'\] \.message-card\[data-role='assistant'\],\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.message-body\[data-role='assistant'\] \.message-card\[data-role='assistant'\],\s*:root\[data-theme='macos'\]\[data-appearance='light'\] \.message-body\[data-role='system'\] \.message-card\[data-role='system'\],\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.message-body\[data-role='system'\] \.message-card\[data-role='system'\]\s*\{\s*padding:\s*0\.875rem 1rem;\s*\}\s*<\/style>/
+  )
+})
+
+test('queued message strip and pending request panels use theme tokens with macos polish', () => {
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.queued-messages-inner\s*\{[\s\S]*border-color: var\(--theme-border\);[\s\S]*background: color-mix\(in srgb, var\(--theme-panel-subtle-bg\) 92%, transparent\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.queued-row-edit,\s*:root\[data-theme\]\[data-appearance\] \.queued-row-steer\s*\{[\s\S]*border-color: var\(--theme-border\);[\s\S]*background: var\(--theme-control-bg\);[\s\S]*color: var\(--theme-text-secondary\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.thread-pending-request-shell\s*\{[\s\S]*border-color: var\(--theme-border\);[\s\S]*background: var\(--theme-panel-bg\);[\s\S]*color: var\(--theme-text-primary\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.thread-pending-request-primary\s*\{[\s\S]*border-color: var\(--theme-accent\);[\s\S]*background: var\(--theme-accent\);[\s\S]*color: var\(--theme-accent-contrast\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme='macos'\]\[data-appearance='light'\] \.queued-messages-inner,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.queued-messages-inner,\s*:root\[data-theme='macos'\]\[data-appearance='light'\] \.thread-pending-request-shell,\s*:root\[data-theme='macos'\]\[data-appearance='dark'\] \.thread-pending-request-shell\s*\{[\s\S]*border-radius: var\(--theme-macos-panel-radius\);/
+  )
+})

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -37,6 +37,22 @@ const threadConversationVue = readFileSync(resolve(process.cwd(), 'src/component
 const desktopLayoutVue = readFileSync(resolve(process.cwd(), 'src/components/layout/DesktopLayout.vue'), 'utf8')
 const sidebarThreadTreeVue = readFileSync(resolve(process.cwd(), 'src/components/sidebar/SidebarThreadTree.vue'), 'utf8')
 
+function getThemeTokenBlock(theme: string, appearance: string): Record<string, string> {
+  const escapedTheme = theme.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const escapedAppearance = appearance.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = styleCss.match(
+    new RegExp(`:root\\[data-theme='${escapedTheme}'\\]\\[data-appearance='${escapedAppearance}'\\]\\s*\\{([\\s\\S]*?)\\n\\}`)
+  )
+  assert.ok(match, `missing token block for ${theme}/${appearance}`)
+
+  return Object.fromEntries(
+    Array.from(match[1].matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)).map((tokenMatch) => [
+      `--${tokenMatch[1]}`,
+      tokenMatch[2].trim(),
+    ])
+  )
+}
+
 test('appearance modes remain system, light, and dark', () => {
   assert.deepEqual(APPEARANCE_MODES, ['system', 'light', 'dark'])
   assert.equal(getEffectiveTheme('system', false), 'light')
@@ -126,6 +142,122 @@ test('shared stylesheet still defines token blocks and keeps macos styling scope
   )
 })
 
+test('default theme tokens resolve to the legacy light palette', () => {
+  const tokens = getThemeTokenBlock('default', 'light')
+
+  assert.equal(tokens['--theme-body-background'], '#f1f5f9')
+  assert.equal(tokens['--theme-shell-bg'], '#f1f5f9')
+  assert.equal(tokens['--theme-sidebar-bg'], '#f1f5f9')
+  assert.equal(tokens['--theme-main-bg'], '#ffffff')
+  assert.equal(tokens['--theme-panel-bg'], '#ffffff')
+  assert.equal(tokens['--theme-panel-subtle-bg'], '#fafafa')
+  assert.equal(tokens['--theme-control-bg'], '#ffffff')
+  assert.equal(tokens['--theme-control-hover-bg'], '#fafafa')
+  assert.equal(tokens['--theme-control-active-bg'], '#f4f4f5')
+  assert.equal(tokens['--theme-selection-bg'], '#e4e4e7')
+  assert.equal(tokens['--theme-text-primary'], '#0f172a')
+  assert.equal(tokens['--theme-text-secondary'], '#3f3f46')
+  assert.equal(tokens['--theme-text-subtle'], '#52525b')
+  assert.equal(tokens['--theme-text-muted'], '#71717a')
+  assert.equal(tokens['--theme-code-bg'], '#020617')
+  assert.equal(tokens['--theme-code-header-bg'], 'rgba(15, 23, 42, 0.94)')
+  assert.equal(tokens['--theme-code-text'], '#f1f5f9')
+  assert.equal(tokens['--theme-code-muted'], '#94a3b8')
+  assert.equal(tokens['--theme-message-text'], '#1e293b')
+  assert.equal(tokens['--theme-message-heading'], '#0f172a')
+  assert.equal(tokens['--theme-message-muted'], '#64748b')
+  assert.equal(tokens['--theme-message-blockquote-border'], '#cbd5e1')
+  assert.equal(tokens['--theme-message-blockquote-bg'], 'rgba(248, 250, 252, 0.7)')
+  assert.equal(tokens['--theme-message-blockquote-text'], '#334155')
+  assert.equal(tokens['--theme-message-inline-code-border'], '#e2e8f0')
+  assert.equal(tokens['--theme-message-inline-code-bg'], 'rgba(241, 245, 249, 0.6)')
+  assert.equal(tokens['--theme-message-inline-code-text'], '#0f172a')
+  assert.equal(tokens['--theme-message-table-bg'], '#ffffff')
+  assert.equal(tokens['--theme-message-table-head-bg'], '#f1f5f9')
+  assert.equal(tokens['--theme-message-divider-bg'], 'rgba(203, 213, 225, 0.8)')
+  assert.equal(tokens['--theme-plan-bg'], '#f0f9ff')
+  assert.equal(tokens['--theme-plan-border'], '#bae6fd')
+  assert.equal(tokens['--theme-plan-card-text'], '#0f172a')
+  assert.equal(tokens['--theme-plan-title'], '#0c4a6e')
+  assert.equal(tokens['--theme-plan-text'], '#334155')
+  assert.equal(tokens['--theme-plan-badge-bg'], '#bae6fd')
+  assert.equal(tokens['--theme-plan-badge-text'], '#0c4a6e')
+  assert.equal(tokens['--theme-plan-inline-code-bg'], 'rgba(226, 232, 240, 0.8)')
+  assert.equal(tokens['--theme-plan-inline-code-text'], '#0f172a')
+  assert.equal(tokens['--theme-plan-table-bg'], 'rgba(255, 255, 255, 0.9)')
+  assert.equal(tokens['--theme-plan-step-bg'], 'rgba(255, 255, 255, 0.8)')
+  assert.equal(tokens['--theme-plan-step-border'], 'rgba(255, 255, 255, 0.7)')
+  assert.equal(tokens['--theme-plan-step-text'], '#1e293b')
+  assert.equal(tokens['--theme-plan-step-status-bg'], '#e2e8f0')
+  assert.equal(tokens['--theme-plan-step-status-text'], '#334155')
+  assert.equal(tokens['--theme-plan-step-completed-bg'], 'rgba(236, 253, 245, 0.8)')
+  assert.equal(tokens['--theme-plan-step-completed-border'], '#a7f3d0')
+  assert.equal(tokens['--theme-plan-step-completed-status-bg'], '#a7f3d0')
+  assert.equal(tokens['--theme-plan-step-completed-status-text'], '#064e3b')
+  assert.equal(tokens['--theme-plan-step-in-progress-bg'], 'rgba(255, 251, 235, 0.8)')
+  assert.equal(tokens['--theme-plan-step-in-progress-border'], '#fde68a')
+  assert.equal(tokens['--theme-plan-step-in-progress-status-bg'], '#fde68a')
+  assert.equal(tokens['--theme-plan-step-in-progress-status-text'], '#78350f')
+})
+
+test('default theme tokens resolve to the legacy dark palette', () => {
+  const tokens = getThemeTokenBlock('default', 'dark')
+
+  assert.equal(tokens['--theme-body-background'], '#18181b')
+  assert.equal(tokens['--theme-shell-bg'], '#18181b')
+  assert.equal(tokens['--theme-sidebar-bg'], '#18181b')
+  assert.equal(tokens['--theme-main-bg'], '#09090b')
+  assert.equal(tokens['--theme-panel-bg'], '#27272a')
+  assert.equal(tokens['--theme-panel-subtle-bg'], '#27272a')
+  assert.equal(tokens['--theme-control-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-control-hover-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-control-active-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-selection-bg'], '#27272a')
+  assert.equal(tokens['--theme-text-primary'], '#f4f4f5')
+  assert.equal(tokens['--theme-text-secondary'], '#d4d4d8')
+  assert.equal(tokens['--theme-text-subtle'], '#d4d4d8')
+  assert.equal(tokens['--theme-text-muted'], '#a1a1aa')
+  assert.equal(tokens['--theme-code-bg'], '#09090b')
+  assert.equal(tokens['--theme-code-header-bg'], '#18181b')
+  assert.equal(tokens['--theme-code-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-code-muted'], '#a1a1aa')
+  assert.equal(tokens['--theme-message-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-message-heading'], '#f4f4f5')
+  assert.equal(tokens['--theme-message-muted'], '#a1a1aa')
+  assert.equal(tokens['--theme-message-blockquote-border'], '#52525b')
+  assert.equal(tokens['--theme-message-blockquote-bg'], 'rgba(39, 39, 42, 0.7)')
+  assert.equal(tokens['--theme-message-blockquote-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-message-inline-code-border'], '#52525b')
+  assert.equal(tokens['--theme-message-inline-code-bg'], 'rgba(63, 63, 70, 0.6)')
+  assert.equal(tokens['--theme-message-inline-code-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-message-table-bg'], 'rgba(24, 24, 27, 0.9)')
+  assert.equal(tokens['--theme-message-table-head-bg'], '#27272a')
+  assert.equal(tokens['--theme-message-divider-bg'], 'rgba(63, 63, 70, 0.8)')
+  assert.equal(tokens['--theme-plan-bg'], 'rgba(8, 47, 73, 0.4)')
+  assert.equal(tokens['--theme-plan-border'], '#075985')
+  assert.equal(tokens['--theme-plan-card-text'], '#0f172a')
+  assert.equal(tokens['--theme-plan-title'], '#bae6fd')
+  assert.equal(tokens['--theme-plan-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-plan-badge-bg'], '#075985')
+  assert.equal(tokens['--theme-plan-badge-text'], '#e0f2fe')
+  assert.equal(tokens['--theme-plan-inline-code-bg'], 'rgba(63, 63, 70, 0.6)')
+  assert.equal(tokens['--theme-plan-inline-code-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-plan-table-bg'], 'rgba(24, 24, 27, 0.9)')
+  assert.equal(tokens['--theme-plan-step-bg'], 'rgba(24, 24, 27, 0.7)')
+  assert.equal(tokens['--theme-plan-step-border'], '#3f3f46')
+  assert.equal(tokens['--theme-plan-step-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-plan-step-status-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-plan-step-status-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-plan-step-completed-bg'], 'rgba(2, 44, 34, 0.4)')
+  assert.equal(tokens['--theme-plan-step-completed-border'], '#064e3b')
+  assert.equal(tokens['--theme-plan-step-completed-status-bg'], '#064e3b')
+  assert.equal(tokens['--theme-plan-step-completed-status-text'], '#a7f3d0')
+  assert.equal(tokens['--theme-plan-step-in-progress-bg'], 'rgba(69, 26, 3, 0.4)')
+  assert.equal(tokens['--theme-plan-step-in-progress-border'], '#78350f')
+  assert.equal(tokens['--theme-plan-step-in-progress-status-bg'], '#78350f')
+  assert.equal(tokens['--theme-plan-step-in-progress-status-text'], '#fde68a')
+})
+
 test('legacy settings styling stays on the main branch base with explicit appearance overrides while skills hub stays tokenized', () => {
   assert.match(
     appVue,
@@ -173,11 +305,11 @@ test('legacy settings styling stays on the main branch base with explicit appear
   )
   assert.match(
     skillsHubVue,
-    /\.skills-hub-search-wrap\s*\{\s*@apply flex-1 flex items-center gap-2 rounded-xl border px-3 py-2 transition;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-bg\);/
+    /\.skills-hub-sort\s*\{\s*@apply shrink-0 rounded-lg border px-2\.5 py-1\.5 text-xs font-medium transition cursor-pointer;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-control-bg\);\s*color: var\(--theme-text-secondary\);/
   )
   assert.match(
     skillsHubVue,
-    /\.skills-hub-search-btn\s*\{\s*@apply shrink-0 rounded-md border px-2 py-1 text-xs font-medium transition cursor-pointer;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-control-bg\);\s*color: var\(--theme-text-secondary\);/
+    /\.skills-sync-badge\s*\{\s*@apply text-xs rounded-md border px-2 py-0\.5;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-control-bg\);\s*color: var\(--theme-text-secondary\);/
   )
   assert.match(
     skillsHubVue,
@@ -231,11 +363,15 @@ test('legacy component styling remains the default base for non-macos themes', (
   )
   assert.match(
     threadConversationVue,
-    /\.plan-card\s*\{\s*@apply flex max-w-\[min\(var\(--chat-card-max,76ch\),100%\)\] flex-col gap-3 rounded-2xl border px-4 py-3;\s*border-color: var\(--theme-border\);\s*background: var\(--theme-panel-bg\);\s*color: var\(--theme-text-primary\);/
+    /\.plan-card\s*\{\s*@apply flex max-w-\[min\(var\(--chat-card-max,76ch\),100%\)\] flex-col gap-3 rounded-2xl border px-4 py-3;\s*border-color: var\(--theme-plan-border\);\s*background: var\(--theme-plan-bg\);\s*color: var\(--theme-plan-card-text\);/
   )
   assert.doesNotMatch(
     threadConversationVue,
     /\.plan-card\s*\{\s*@apply flex max-w-\[min\(var\(--chat-card-max,76ch\),100%\)\] flex-col gap-3 rounded-2xl border border-sky-200 bg-sky-50 px-4 py-3 text-slate-900;/
+  )
+  assert.doesNotMatch(
+    threadConversationVue,
+    /\.message-card\[data-role='assistant'\],\s*\.message-card\[data-role='system'\]\s*\{[^}]*width: fit-content;/
   )
   assert.match(
     sidebarThreadTreeVue,

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -164,9 +164,31 @@ test('default theme tokens resolve to the legacy light palette', () => {
   assert.equal(tokens['--theme-heading-text'], '#18181b')
   assert.equal(tokens['--theme-content-title-text'], '#0f172a')
   assert.equal(tokens['--theme-sidebar-control-text'], '#52525b')
+  assert.equal(tokens['--theme-sidebar-row-text'], '#0f172a')
+  assert.equal(tokens['--theme-project-title-text'], '#3f3f46')
+  assert.equal(tokens['--theme-thread-title-text'], '#27272a')
+  assert.equal(tokens['--theme-thread-time-text'], '#71717a')
   assert.equal(tokens['--theme-composer-shell-border'], '#d4d4d8')
   assert.equal(tokens['--theme-composer-input-disabled-bg'], '#f4f4f5')
   assert.equal(tokens['--theme-composer-input-disabled-text'], '#71717a')
+  assert.equal(tokens['--theme-settings-row-text'], '#3f3f46')
+  assert.equal(tokens['--theme-settings-value-text'], '#71717a')
+  assert.equal(tokens['--theme-settings-button-hover-bg'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-button-hover-text'], '#18181b')
+  assert.equal(tokens['--theme-settings-control-bg'], '#ffffff')
+  assert.equal(tokens['--theme-settings-control-border'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-control-text'], '#3f3f46')
+  assert.equal(tokens['--theme-settings-toggle-bg'], '#d4d4d8')
+  assert.equal(tokens['--theme-settings-account-section-bg'], 'rgb(250 250 250 / 0.6)')
+  assert.equal(tokens['--theme-settings-account-count-bg'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-account-count-text'], '#52525b')
+  assert.equal(tokens['--theme-settings-account-id-bg'], '#f4f4f5')
+  assert.equal(tokens['--theme-settings-account-id-text'], '#52525b')
+  assert.equal(tokens['--theme-settings-account-action-bg'], '#ffffff')
+  assert.equal(tokens['--theme-settings-account-action-border'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-account-action-text'], '#3f3f46')
+  assert.equal(tokens['--theme-settings-account-action-hover-bg'], '#f4f4f5')
+  assert.equal(tokens['--theme-settings-account-action-hover-text'], '#3f3f46')
   assert.equal(tokens['--theme-runtime-bg'], '#f4f4f5')
   assert.equal(tokens['--theme-runtime-selected-bg'], '#ffffff')
   assert.equal(tokens['--theme-runtime-selected-border'], '#e4e4e7')
@@ -234,9 +256,31 @@ test('default theme tokens resolve to the legacy dark palette', () => {
   assert.equal(tokens['--theme-content-title-text'], '#e4e4e7')
   assert.equal(tokens['--theme-settings-button-text'], '#a1a1aa')
   assert.equal(tokens['--theme-sidebar-control-text'], '#a1a1aa')
+  assert.equal(tokens['--theme-sidebar-row-text'], '#f4f4f5')
+  assert.equal(tokens['--theme-project-title-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-thread-title-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-thread-time-text'], '#71717a')
   assert.equal(tokens['--theme-composer-shell-border'], '#3f3f46')
   assert.equal(tokens['--theme-composer-input-disabled-bg'], '#3f3f46')
   assert.equal(tokens['--theme-composer-input-disabled-text'], '#71717a')
+  assert.equal(tokens['--theme-settings-row-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-settings-value-text'], '#a1a1aa')
+  assert.equal(tokens['--theme-settings-button-hover-bg'], '#27272a')
+  assert.equal(tokens['--theme-settings-button-hover-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-control-bg'], '#27272a')
+  assert.equal(tokens['--theme-settings-control-border'], '#52525b')
+  assert.equal(tokens['--theme-settings-control-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-toggle-bg'], '#52525b')
+  assert.equal(tokens['--theme-settings-account-section-bg'], 'rgb(39 39 42 / 0.7)')
+  assert.equal(tokens['--theme-settings-account-count-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-settings-account-count-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-settings-account-id-bg'], '#27272a')
+  assert.equal(tokens['--theme-settings-account-id-text'], '#d4d4d8')
+  assert.equal(tokens['--theme-settings-account-action-bg'], '#3f3f46')
+  assert.equal(tokens['--theme-settings-account-action-border'], '#52525b')
+  assert.equal(tokens['--theme-settings-account-action-text'], '#e4e4e7')
+  assert.equal(tokens['--theme-settings-account-action-hover-bg'], '#52525b')
+  assert.equal(tokens['--theme-settings-account-action-hover-text'], '#e4e4e7')
   assert.equal(tokens['--theme-runtime-bg'], '#18181b')
   assert.equal(tokens['--theme-runtime-selected-bg'], '#27272a')
   assert.equal(tokens['--theme-runtime-selected-text'], '#f4f4f5')
@@ -317,11 +361,27 @@ test('legacy settings styling stays on the main branch base with explicit appear
   )
   assert.match(
     styleCss,
-    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-count,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-id,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-value\s*\{\s*background: var\(--theme-control-active-bg\);\s*color: var\(--theme-text-secondary\);/
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-section\s*\{\s*background: var\(--theme-settings-account-section-bg, var\(--theme-panel-subtle-bg\)\);/
   )
   assert.match(
     styleCss,
-    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-toggle\s*\{\s*background: var\(--theme-border-strong\);/
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-refresh,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-switch\s*\{\s*border-color: var\(--theme-settings-account-action-border, var\(--theme-border\)\);\s*background: var\(--theme-settings-account-action-bg, var\(--theme-control-bg\)\);\s*color: var\(--theme-settings-account-action-text, var\(--theme-text-secondary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-count,\s*:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-value\s*\{\s*background: var\(--theme-control-active-bg\);\s*color: var\(--theme-settings-value-text, var\(--theme-text-secondary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-count\s*\{\s*background: var\(--theme-settings-account-count-bg, var\(--theme-control-active-bg\)\);\s*color: var\(--theme-settings-account-count-text, var\(--theme-text-secondary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-account-id\s*\{\s*background: var\(--theme-settings-account-id-bg, var\(--theme-control-active-bg\)\);\s*color: var\(--theme-settings-account-id-text, var\(--theme-text-secondary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-toggle\s*\{\s*background: var\(--theme-settings-toggle-bg, var\(--theme-border-strong\)\);/
   )
   assert.match(
     styleCss,
@@ -381,6 +441,22 @@ test('legacy component styling remains the default base for non-macos themes', (
   assert.match(
     styleCss,
     /:root\[data-theme\]\[data-appearance\] \.content-title\s*\{\s*color: var\(--theme-content-title-text, var\(--theme-text-primary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.project-title\s*\{\s*color: var\(--theme-project-title-text, var\(--theme-text-muted\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.thread-row-title\s*\{\s*color: var\(--theme-thread-title-text, var\(--theme-text-primary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-theme\]\[data-appearance\] \.project-header-row,\s*:root\[data-theme\]\[data-appearance\] \.thread-row\s*\{\s*color: var\(--theme-sidebar-row-text, var\(--theme-text-secondary\)\);/
+  )
+  assert.match(
+    styleCss,
+    /:root\[data-appearance='dark'\]:not\(\[data-theme='macos'\]\) \.sidebar-settings-provider-select\s*\{\s*border-color: var\(--theme-settings-control-border, var\(--theme-border\)\);\s*background: var\(--theme-settings-control-bg, var\(--theme-control-bg\)\);\s*color: var\(--theme-settings-control-text, var\(--theme-text-secondary\)\);/
   )
   assert.match(
     sidebarThreadControlsVue,

--- a/tests.md
+++ b/tests.md
@@ -3597,3 +3597,31 @@ The `Select folder` dialog now lets the user edit the current folder path direct
 
 #### Rollback/Cleanup
 - Return the chooser to the original folder if the test changed the selected project path
+
+---
+
+### Default theme legacy parity refresh
+
+#### Feature/Change Name
+The default theme keeps the legacy sidebar control, header title, composer shell, and disabled composer input colors while the token-based theme system remains active.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173` or the active Vite port
+2. A reference upstream build available for side-by-side comparison when doing visual parity checks
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open the main app shell and compare the sidebar icon controls, content header title, and composer shell border with the upstream/default reference
+2. Confirm a disabled composer input, such as the no-thread-selected state, keeps the old muted background and text color
+3. Switch to dark theme and repeat the same checks for the content header title, sidebar icon controls, composer border, and disabled composer input
+4. Run the theme parity Playwright check and inspect the generated light/dark screenshots under `output/playwright/`
+
+#### Expected Results
+- Sidebar icon controls use the old muted zinc tone in light and dark themes
+- The content header title keeps the old dark-theme zinc-200 tone instead of becoming brighter
+- The composer shell keeps the old default border shade
+- Disabled composer inputs keep the old muted background/text styling
+- Light theme and dark theme both remain readable and visually aligned with the upstream default look
+
+#### Rollback/Cleanup
+- Stop any temporary upstream/reference Vite server used for side-by-side comparison

--- a/tests.md
+++ b/tests.md
@@ -3611,14 +3611,17 @@ The default theme keeps the legacy sidebar control, header title, composer shell
 3. Light theme and dark theme both available from the appearance switcher
 
 #### Steps
-1. In light theme, open the main app shell and compare the sidebar icon controls, content header title, and composer shell border with the upstream/default reference
+1. In light theme, open the main app shell and compare the sidebar icon controls, project/thread list text, content header title, and composer shell border with the upstream/default reference
 2. Confirm a disabled composer input, such as the no-thread-selected state, keeps the old muted background and text color
-3. Switch to dark theme and repeat the same checks for the content header title, sidebar icon controls, composer border, and disabled composer input
-4. Run the theme parity Playwright check and inspect the generated light/dark screenshots under `output/playwright/`
+3. Open the settings panel and compare shared settings rows, buttons, toggles, provider selects, and account controls against the upstream/default reference
+4. Switch to dark theme and repeat the same checks for the project/thread list, content header title, sidebar icon controls, settings controls, account controls, composer border, and disabled composer input
+5. Run the theme parity Playwright check and inspect the generated light/dark screenshots under `output/playwright/`
 
 #### Expected Results
 - Sidebar icon controls use the old muted zinc tone in light and dark themes
+- Project and thread rows keep their old title, metadata, and inherited row tones
 - The content header title keeps the old dark-theme zinc-200 tone instead of becoming brighter
+- Dark settings controls keep the old row, value, hover, toggle, provider-select, account-section, account-count, and account-action tones
 - The composer shell keeps the old default border shade
 - Disabled composer inputs keep the old muted background/text styling
 - Light theme and dark theme both remain readable and visually aligned with the upstream default look


### PR DESCRIPTION
## Summary
- separate theme selection from appearance mode and persist both independently
- add semantic theme tokens for `default`, `graphite`, and opt-in `macos`
- centralize shared shell styling through token-based theme layers while keeping legacy themes intact
- sync browser/app chrome metadata with the active theme and appearance
- harden first-paint theme bootstrapping and keep the upstream dark install-time fallback
- add focused automated coverage for the core theme system

## Intended result
The app keeps its existing default light/dark visuals while gaining a reusable theme-token layer. Users can independently choose appearance mode and built-in theme, with `macos` available as an opt-in theme instead of replacing the default UI.

A downstream preview branch shows the future theme direction this foundation enables:
https://github.com/friuns2/codexUI/compare/main...olujicz:codexUI:preview/theme-support-direction

That preview branch is not included in this PR; it is provided only as context for why the theme-token foundation is useful

## Verification
- `node --test test/theme.test.ts`
- `pnpm test:unit`
- `pnpm run build`

## Notes
- future theme polish is intentionally left out of this PR; see the downstream preview branch for the intended direction
- directory and integrated terminal surfaces are split into a follow-up PR to keep review scope narrower
- legacy themes are intentionally preserved; this change adds theme infrastructure without replacing existing visual baselines
- the final follow-up commit specifically restores legacy visual parity after the token migration

## Reviewer focus
- theme/appearance state separation and localStorage migration behavior
- first-paint bootstrap in `index.html`
- legacy light/dark parity after token migration
- `macos` theme opt-in styling only, without replacing default visuals
- new `tailwindcss-uikit-colors` dependency for macOS color tokens