### PR TITLE
Fix plan mode follow-up behavior

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2789,13 +2789,11 @@ function onRollback(payload: { turnId: string }): void {
   void rollbackSelectedThread(payload.turnId)
 }
 
-function onImplementPlan(payload: { turnId: string; text: string }): void {
+function onImplementPlan(payload: { turnId: string }): void {
   if (isHomeRoute.value || !selectedThreadId.value) return
-  const text = payload.text.trim()
-  if (!text) return
   setSelectedCollaborationMode('default')
   scheduleMobileConversationJumpToLatest()
-  void sendMessageToSelectedThread(text, [], [], 'steer', [])
+  void sendMessageToSelectedThread('Implement', [], [], 'steer', [], undefined, 'default')
 }
 
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -772,6 +772,7 @@
                     @update-scroll-state="onUpdateThreadScrollState"
                     @fork-thread="onForkThreadFromMessage"
                     @rollback="onRollback"
+                    @implement-plan="onImplementPlan"
                     @respond-server-request="onRespondServerRequest" />
                 </div>
 
@@ -2786,6 +2787,15 @@ function onRollback(payload: { turnId: string }): void {
     }
   }
   void rollbackSelectedThread(payload.turnId)
+}
+
+function onImplementPlan(payload: { turnId: string; text: string }): void {
+  if (isHomeRoute.value || !selectedThreadId.value) return
+  const text = payload.text.trim()
+  if (!text) return
+  setSelectedCollaborationMode('default')
+  scheduleMobileConversationJumpToLatest()
+  void sendMessageToSelectedThread(text, [], [], 'steer', [])
 }
 
 

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { startThreadTurn } from './codexGateway'
+
+function mockRpcFetch(): { requests: Array<{ method: string, params: Record<string, unknown> }> } {
+  const requests: Array<{ method: string, params: Record<string, unknown> }> = []
+
+  vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const body = typeof init?.body === 'string'
+      ? JSON.parse(init.body) as { method: string, params: Record<string, unknown> }
+      : { method: '', params: {} }
+
+    requests.push(body)
+
+    return new Response(JSON.stringify({
+      result: {
+        turn: {
+          id: `turn-${requests.length}`,
+        },
+      },
+    }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+  }))
+
+  return { requests }
+}
+
+describe('startThreadTurn collaboration mode payloads', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sends default collaboration mode explicitly after a plan turn', async () => {
+    const { requests } = mockRpcFetch()
+
+    await startThreadTurn('thread-1', 'make a plan', [], 'gpt-5.4', 'medium', undefined, [], 'plan')
+    await startThreadTurn('thread-1', 'implement it', [], 'gpt-5.4', 'medium', undefined, [], 'default')
+
+    expect(requests).toHaveLength(2)
+    expect(requests[0].method).toBe('turn/start')
+    expect(requests[0].params.collaborationMode).toEqual({
+      mode: 'plan',
+      settings: {
+        model: 'gpt-5.4',
+        reasoning_effort: 'medium',
+        developer_instructions: null,
+      },
+    })
+    expect(requests[1].method).toBe('turn/start')
+    expect(requests[1].params.collaborationMode).toEqual({
+      mode: 'default',
+      settings: {
+        model: 'gpt-5.4',
+        reasoning_effort: 'medium',
+        developer_instructions: null,
+      },
+    })
+  })
+})

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1474,7 +1474,7 @@ export async function startThreadTurn(
     if (typeof effort === 'string' && effort.length > 0) {
       params.effort = effort
     }
-    if (collaborationMode && collaborationMode !== 'default') {
+    if (collaborationMode) {
       const collaborationModeSettings = await resolveCollaborationModeSettings(collaborationMode, normalizedModel, effort)
       params.collaborationMode = {
         mode: collaborationMode,

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -951,13 +951,13 @@ function showImplementPlanButton(message: UiMessage): boolean {
     && message.messageType !== 'plan.live'
     && message.role === 'assistant'
     && Boolean(message.turnId)
-    && readPlanSteps(message).length > 0
 }
 
 function implementPlan(message: UiMessage): void {
   const turnId = message.turnId?.trim() ?? ''
   if (!turnId) return
-  const planText = buildPlanMessageText(readPlanExplanation(message), readPlanSteps(message))
+  const parsedPlanText = buildPlanMessageText(readPlanExplanation(message), readPlanSteps(message))
+  const planText = parsedPlanText || message.text.trim()
   if (!planText) return
   emit('implementPlan', {
     turnId,

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -297,6 +297,15 @@
                     </li>
                   </ol>
                   <div v-else class="plan-card-markdown" v-html="renderMarkdownBlocksAsHtml(message.text)" />
+                  <div v-if="showImplementPlanButton(message)" class="plan-card-actions">
+                    <button
+                      type="button"
+                      class="plan-card-implement-button"
+                      @click="implementPlan(message)"
+                    >
+                      Implement plan
+                    </button>
+                  </div>
                 </div>
                 <div
                   v-else
@@ -925,6 +934,37 @@ function isPlanMessage(message: UiMessage): boolean {
   return message.messageType === 'plan' || message.messageType === 'plan.live'
 }
 
+function buildPlanMessageText(explanation: string, steps: UiPlanStep[]): string {
+  const lines: string[] = []
+  if (explanation.trim()) {
+    lines.push(explanation.trim())
+  }
+  for (const step of steps) {
+    const marker = step.status === 'completed' ? 'x' : step.status === 'inProgress' ? '~' : ' '
+    lines.push(`- [${marker}] ${step.step}`)
+  }
+  return lines.join('\n').trim()
+}
+
+function showImplementPlanButton(message: UiMessage): boolean {
+  return isPlanMessage(message)
+    && message.messageType !== 'plan.live'
+    && message.role === 'assistant'
+    && Boolean(message.turnId)
+    && readPlanSteps(message).length > 0
+}
+
+function implementPlan(message: UiMessage): void {
+  const turnId = message.turnId?.trim() ?? ''
+  if (!turnId) return
+  const planText = buildPlanMessageText(readPlanExplanation(message), readPlanSteps(message))
+  if (!planText) return
+  emit('implementPlan', {
+    turnId,
+    text: `Implement this plan:\n\n${planText}`,
+  })
+}
+
 function isFileChangeMessage(message: UiMessage): boolean {
   return message.messageType === 'fileChange'
     && message.fileChangeStatus === 'completed'
@@ -1194,6 +1234,7 @@ const emit = defineEmits<{
   updateScrollState: [payload: { threadId: string; state: ThreadScrollState }]
   forkThread: [payload: { threadId: string; turnIndex: number }]
   rollback: [payload: { turnId: string }]
+  implementPlan: [payload: { turnId: string; text: string }]
   respondServerRequest: [payload: { id: number; result?: unknown; error?: { code?: number; message: string } }]
 }>()
 
@@ -4632,6 +4673,14 @@ onBeforeUnmount(() => {
 
 .plan-step-text {
   @apply min-w-0 flex-1;
+}
+
+.plan-card-actions {
+  @apply mt-3 flex justify-end;
+}
+
+.plan-card-implement-button {
+  @apply inline-flex items-center rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-800 transition hover:border-slate-400 hover:bg-slate-50;
 }
 
 .message-text {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -956,13 +956,7 @@ function showImplementPlanButton(message: UiMessage): boolean {
 function implementPlan(message: UiMessage): void {
   const turnId = message.turnId?.trim() ?? ''
   if (!turnId) return
-  const parsedPlanText = buildPlanMessageText(readPlanExplanation(message), readPlanSteps(message))
-  const planText = parsedPlanText || message.text.trim()
-  if (!planText) return
-  emit('implementPlan', {
-    turnId,
-    text: `Implement this plan:\n\n${planText}`,
-  })
+  emit('implementPlan', { turnId })
 }
 
 function isFileChangeMessage(message: UiMessage): boolean {
@@ -1234,7 +1228,7 @@ const emit = defineEmits<{
   updateScrollState: [payload: { threadId: string; state: ThreadScrollState }]
   forkThread: [payload: { threadId: string; turnIndex: number }]
   rollback: [payload: { turnId: string }]
-  implementPlan: [payload: { turnId: string; text: string }]
+  implementPlan: [payload: { turnId: string }]
   respondServerRequest: [payload: { id: number; result?: unknown; error?: { code?: number; message: string } }]
 }>()
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4151,6 +4151,7 @@ export function useDesktopState() {
     mode: 'steer' | 'queue' = 'steer',
     fileAttachments: FileAttachment[] = [],
     queueInsertIndex?: number,
+    collaborationModeOverride?: CollaborationModeKind,
   ): Promise<void> {
     if (isUpdatingSpeedMode.value) return
 
@@ -4177,7 +4178,11 @@ export function useDesktopState() {
         imageUrls,
         skills,
         fileAttachments,
-        collaborationMode: selectedCollaborationMode.value,
+        collaborationMode: collaborationModeOverride === 'plan'
+          ? 'plan'
+          : collaborationModeOverride === 'default'
+            ? 'default'
+            : selectedCollaborationMode.value,
       })
       queuedMessagesByThreadId.value = {
         ...queuedMessagesByThreadId.value,
@@ -4188,7 +4193,14 @@ export function useDesktopState() {
 
     if (isInProgress) {
       shouldAutoScrollOnNextAgentEvent = true
-      void startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments).catch((unknownError) => {
+      void startTurnForThread(
+        threadId,
+        nextText,
+        imageUrls,
+        skills,
+        fileAttachments,
+        collaborationModeOverride,
+      ).catch((unknownError) => {
         const errorMessage = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
         setTurnErrorForThread(threadId, errorMessage)
         error.value = errorMessage
@@ -4206,7 +4218,11 @@ export function useDesktopState() {
         details: buildPendingTurnDetails(
           readModelIdForThread(threadId),
           selectedReasoningEffort.value,
-          selectedCollaborationMode.value,
+          collaborationModeOverride === 'plan'
+            ? 'plan'
+            : collaborationModeOverride === 'default'
+              ? 'default'
+              : selectedCollaborationMode.value,
         ),
       },
     )
@@ -4214,7 +4230,14 @@ export function useDesktopState() {
     setThreadInProgress(threadId, true)
 
     try {
-      await startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments)
+      await startTurnForThread(
+        threadId,
+        nextText,
+        imageUrls,
+        skills,
+        fileAttachments,
+        collaborationModeOverride,
+      )
     } catch (unknownError) {
       shouldAutoScrollOnNextAgentEvent = false
       setThreadInProgress(threadId, false)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1860,6 +1860,12 @@ export function useDesktopState() {
     clearInterruptPersistenceGate(threadId)
   }
 
+  function maybeUnblockInterruptForActiveTurn(threadId: string, turnId: string): void {
+    if (!threadId || !turnId) return
+    if (interruptBlockedUntilPersistedByThreadId.value[threadId] !== true) return
+    clearInterruptPersistenceGate(threadId)
+  }
+
   function markServerListedThreads(serverThreadIds: Set<string>): void {
     const pendingThreadIds = Object.keys(interruptBlockedUntilPersistedByThreadId.value)
     if (pendingThreadIds.length === 0) return
@@ -3260,6 +3266,7 @@ export function useDesktopState() {
         ...activeTurnIdByThreadId.value,
         [startedTurn.threadId]: startedTurn.turnId,
       }
+      maybeUnblockInterruptForActiveTurn(startedTurn.threadId, startedTurn.turnId)
       clearLivePlansForThread(startedTurn.threadId)
       clearLiveFileChangesForThread(startedTurn.threadId)
       setTurnSummaryForThread(startedTurn.threadId, null)
@@ -4371,6 +4378,7 @@ export function useDesktopState() {
           ...activeTurnIdByThreadId.value,
           [threadId]: startedTurnId,
         }
+        maybeUnblockInterruptForActiveTurn(threadId, startedTurnId)
       }
 
       resumedThreadById.value = {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -266,6 +266,20 @@ function readSelectedCollaborationMode(
   return normalizeCollaborationMode(state[contextId])
 }
 
+function writeSelectedCollaborationModeForContext(
+  state: Record<string, CollaborationModeKind>,
+  threadId: string,
+  mode: CollaborationModeKind,
+): Record<string, CollaborationModeKind> {
+  const contextId = toThreadContextId(threadId)
+  if (mode === 'plan') {
+    const next = cloneStringKeyedRecord(state)
+    next[contextId] = 'plan'
+    return next
+  }
+  return omitStringKeyedRecordKey(state, contextId)
+}
+
 function saveSelectedCollaborationModeMap(state: Record<string, CollaborationModeKind>): void {
   if (typeof window === 'undefined') return
   try {
@@ -1333,15 +1347,23 @@ export function useDesktopState() {
     const currentMode = readSelectedCollaborationMode(selectedCollaborationModeByContext.value, selectedThreadId.value)
     if (currentMode === nextMode && selectedCollaborationMode.value === nextMode) return
     selectedCollaborationMode.value = nextMode
-    if (nextMode === 'plan') {
-      const nextModeMap = cloneStringKeyedRecord(selectedCollaborationModeByContext.value)
-      nextModeMap[contextId] = nextMode
-      selectedCollaborationModeByContext.value = nextModeMap
-    } else {
-      selectedCollaborationModeByContext.value = omitStringKeyedRecordKey(
-        selectedCollaborationModeByContext.value,
-        contextId,
-      )
+    selectedCollaborationModeByContext.value = writeSelectedCollaborationModeForContext(
+      selectedCollaborationModeByContext.value,
+      contextId,
+      nextMode,
+    )
+    saveSelectedCollaborationModeMap(selectedCollaborationModeByContext.value)
+  }
+
+  function setSelectedCollaborationModeForThread(threadId: string, mode: CollaborationModeKind): void {
+    const nextMode = mode === 'plan' ? 'plan' : 'default'
+    selectedCollaborationModeByContext.value = writeSelectedCollaborationModeForContext(
+      selectedCollaborationModeByContext.value,
+      threadId,
+      nextMode,
+    )
+    if (threadId.trim() === selectedThreadId.value) {
+      selectedCollaborationMode.value = nextMode
     }
     saveSelectedCollaborationModeMap(selectedCollaborationModeByContext.value)
   }
@@ -4216,6 +4238,10 @@ export function useDesktopState() {
     const nextText = text.trim()
     const targetCwd = cwd.trim()
     const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
+    const selectedMode = readSelectedCollaborationMode(
+      selectedCollaborationModeByContext.value,
+      NEW_THREAD_COLLABORATION_MODE_CONTEXT,
+    )
     if (!nextText && imageUrls.length === 0 && fileAttachments.length === 0) return ''
 
     isSendingMessage.value = true
@@ -4227,12 +4253,14 @@ export function useDesktopState() {
         const startedThread = await startThread(targetCwd || undefined, selectedModel || undefined)
         threadId = startedThread.threadId
         setThreadModelId(threadId, startedThread.model)
+        setSelectedCollaborationModeForThread(threadId, selectedMode)
       } catch (unknownError) {
         if (selectedModel && selectedModel !== MODEL_FALLBACK_ID && isUnsupportedChatGptModelError(unknownError)) {
           await applyFallbackModelSelection()
           const fallbackThread = await startThread(targetCwd || undefined, MODEL_FALLBACK_ID)
           threadId = fallbackThread.threadId
           setThreadModelId(threadId, fallbackThread.model)
+          setSelectedCollaborationModeForThread(threadId, selectedMode)
         } else {
           throw unknownError
         }
@@ -4255,7 +4283,7 @@ export function useDesktopState() {
           details: buildPendingTurnDetails(
             readModelIdForThread(threadId),
             selectedReasoningEffort.value,
-            selectedCollaborationMode.value,
+            selectedMode,
           ),
         },
       )
@@ -4264,7 +4292,7 @@ export function useDesktopState() {
       const capturedThreadId = threadId
       const capturedCwd = targetCwd || null
       const capturedPrompt = nextText
-      void startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments)
+      void startTurnForThread(threadId, nextText, imageUrls, skills, fileAttachments, selectedMode)
         .catch((unknownError) => {
           shouldAutoScrollOnNextAgentEvent = false
           setThreadInProgress(threadId, false)
@@ -4300,9 +4328,12 @@ export function useDesktopState() {
     imageUrls: string[] = [],
     skills: Array<{ name: string; path: string }> = [],
     fileAttachments: FileAttachment[] = [],
+    collaborationModeOverride?: CollaborationModeKind,
   ): Promise<void> {
     const reasoningEffort = selectedReasoningEffort.value
-    const collaborationMode = selectedCollaborationMode.value
+    const collaborationMode = collaborationModeOverride === 'plan' ? 'plan' : collaborationModeOverride === 'default'
+      ? 'default'
+      : selectedCollaborationMode.value
     const normalizedText = nextText.trim()
     const normalizedImageUrls = [...imageUrls]
     if (

--- a/src/style.css
+++ b/src/style.css
@@ -1022,7 +1022,7 @@
 }
 
 :root.dark .plan-card {
-  @apply border-sky-800 bg-sky-950/40;
+  @apply border-sky-700/70 bg-slate-900/78;
 }
 
 :root.dark .plan-card-title {
@@ -1034,7 +1034,30 @@
 }
 
 :root.dark .plan-card-explanation {
-  @apply text-zinc-300;
+  @apply text-zinc-200;
+}
+
+:root.dark .plan-card-markdown .message-text,
+:root.dark .plan-card-markdown .message-heading,
+:root.dark .plan-card-markdown .message-list,
+:root.dark .plan-card-markdown .message-list-item-text {
+  @apply text-zinc-200;
+}
+
+:root.dark .plan-card-markdown .message-heading-h6 {
+  @apply text-zinc-400;
+}
+
+:root.dark .plan-card-markdown .message-blockquote {
+  @apply border-zinc-600 bg-zinc-800/70 text-zinc-300;
+}
+
+:root.dark .plan-card-markdown .message-inline-code {
+  @apply bg-zinc-800 text-zinc-100;
+}
+
+:root.dark .plan-card-markdown .message-file-link {
+  @apply text-sky-300 decoration-sky-500;
 }
 
 :root.dark .plan-card-markdown .message-table {
@@ -1042,7 +1065,7 @@
 }
 
 :root.dark .plan-step-item {
-  @apply border-zinc-700 bg-zinc-900/70 text-zinc-200;
+  @apply border-zinc-700 bg-zinc-800/72 text-zinc-100;
 }
 
 :root.dark .plan-step-item[data-status='completed'] {
@@ -1063,6 +1086,10 @@
 
 :root.dark .plan-step-status[data-status='inProgress'] {
   @apply bg-amber-900 text-amber-200;
+}
+
+:root.dark .plan-card-implement-button {
+  @apply border-zinc-600 bg-zinc-800 text-zinc-100 hover:border-zinc-500 hover:bg-zinc-700;
 }
 
 :root.dark .message-image-button {

--- a/tests.md
+++ b/tests.md
@@ -3369,7 +3369,7 @@ Completed plan cards show an `Implement plan` button that turns plan mode off an
 
 #### Expected Results
 - Completed plan cards render the `Implement plan` action even when the plan body is structured as headings/lists instead of checkbox steps
-- Clicking the button sends an implementation prompt based on the plan text
+- Clicking the button sends a simple implementation follow-up message instead of copying the whole plan body into chat
 - The next turn runs in default mode rather than plan mode
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -3350,6 +3350,33 @@ New threads started from the home composer honor the selected plan mode for the 
 
 ---
 
+### Completed plan cards expose implement action
+
+#### Feature/Change Name
+Completed plan cards show an `Implement plan` button that turns plan mode off and sends an implementation prompt built from the plan content.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. An existing thread contains a completed persisted plan card
+3. The thread composer is available for follow-up messages
+
+#### Steps
+1. Open a thread containing a completed plan card
+2. Verify the plan card shows `Implement plan` at the bottom
+3. Click `Implement plan`
+4. Confirm the composer thread switches back to default mode
+5. Inspect the next `turn/start` request or the resulting assistant behavior
+
+#### Expected Results
+- Completed plan cards render the `Implement plan` action even when the plan body is structured as headings/lists instead of checkbox steps
+- Clicking the button sends an implementation prompt based on the plan text
+- The next turn runs in default mode rather than plan mode
+
+#### Rollback/Cleanup
+- Archive or delete any test thread created only for this check
+
+---
+
 ### Terminal focus does not fullscreen panel
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -3377,6 +3377,33 @@ Completed plan cards show an `Implement plan` button that turns plan mode off an
 
 ---
 
+### Dark theme plan card contrast
+
+#### Feature/Change Name
+Plan cards in dark mode keep readable contrast and a lighter surface than the surrounding page background, including the `Implement plan` action.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. A thread contains a visible plan card
+3. Appearance is set to `Dark`
+
+#### Steps
+1. Open a thread containing a plan card in dark mode
+2. Inspect the card background, title, explanation text, headings, lists, inline code, and blockquote styling
+3. Verify the `Implement plan` button is readable and visually distinct
+4. Hover the `Implement plan` button and confirm the hover state remains visible
+
+#### Expected Results
+- The plan card surface is distinguishable from the page background without looking crushed into near-black
+- Plan text and headings stay readable in dark mode
+- Inline code, file links, and blockquotes keep enough contrast to scan comfortably
+- The `Implement plan` button remains readable and clickable in dark mode
+
+#### Rollback/Cleanup
+- Reset appearance to the previous user preference
+
+---
+
 ### Terminal focus does not fullscreen panel
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -3294,6 +3294,33 @@ Thread and new-chat header action buttons stay pinned to the right edge while lo
 
 ---
 
+### Stop button activates promptly for new threads
+
+#### Feature/Change Name
+The composer stop control switches from the temporary saving spinner to a real stop button as soon as the active turn id is available for a newly created thread.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. Home route available with a writable project/folder selected
+3. Codex can start a normal assistant turn
+
+#### Steps
+1. Open `http://127.0.0.1:4173/#/`
+2. Send a short prompt from the new-thread composer
+3. Immediately watch the right-side composer control after routing into the new thread
+4. Before the full response finishes, verify the temporary saving spinner transitions into the stop icon/button
+5. Click `Stop` while the turn is still running
+
+#### Expected Results
+- A new thread may briefly show the saving spinner while the turn starts
+- The control becomes an actual stop button as soon as the active turn id is known, without waiting for thread-list persistence
+- Clicking stop interrupts the running turn
+
+#### Rollback/Cleanup
+- Archive or delete the test thread if it was created only for this check
+
+---
+
 ### Terminal focus does not fullscreen panel
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -3321,6 +3321,35 @@ The composer stop control switches from the temporary saving spinner to a real s
 
 ---
 
+### New-thread plan mode persists and toggles correctly
+
+#### Feature/Change Name
+New threads started from the home composer honor the selected plan mode for the first turn, and turning plan mode off on the created thread switches later turns back to default mode.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:4173`
+2. Home route available with a writable project/folder selected
+3. At least one model is available for plan mode
+
+#### Steps
+1. Open `http://127.0.0.1:4173/#/`
+2. Enable `Plan mode` in the new-thread composer
+3. Send a prompt that produces a visible plan response
+4. After routing into the new thread, confirm the composer still shows `Plan mode` enabled
+5. Toggle `Plan mode` off in that thread
+6. Send another prompt in the same thread
+7. Confirm the next turn runs in default mode rather than generating another plan-first response
+
+#### Expected Results
+- The very first turn of a newly created thread uses the plan-mode setting chosen on the home composer
+- The newly created thread retains that plan-mode selection after route transition
+- Turning plan mode off updates the thread-scoped mode, and later turns in that thread no longer use plan mode
+
+#### Rollback/Cleanup
+- Archive or delete any test thread created only for this check
+
+---
+
 ### Terminal focus does not fullscreen panel
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- preserve plan mode when creating new threads
- add implement-plan action on completed plan cards
- send default collaboration mode explicitly after plan turns
- fix stop button and plan card dark-theme regressions

## Validation
- pnpm run test:unit
- browser checks for plan mode, implement-plan button, and stop button behavior