### PR TITLE
Add Composio directory integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "profile:thread": "PROFILE_ROUTE='#/thread/019da7c0-4e12-7a91-837c-f7c11cc8ab6c' node scripts/profile-browser-runtime.cjs"
   },
   "dependencies": {
+    "@composio/client": "0.1.0-alpha.66",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "commander": "^13.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -907,10 +907,12 @@ const SETTINGS_HELP = {
 type ChatWidthMode = 'standard' | 'wide' | 'extra-wide'
 
 type DirectoryTryItemPayload = {
-  kind: 'app' | 'plugin' | 'skill'
+  kind: 'app' | 'plugin' | 'skill' | 'composio'
   name: string
   displayName: string
   skillPath?: string
+  prompt?: string
+  attachedSkills?: Array<{ name: string; path: string }>
 }
 
 type ChatWidthPreset = {
@@ -3468,8 +3470,15 @@ async function submitFirstMessageForNewThread(
 }
 
 function buildDirectoryTryPrompt(payload: DirectoryTryItemPayload): string {
+  if (payload.prompt?.trim()) return payload.prompt.trim()
   const label = payload.displayName.trim() || payload.name.trim()
-  const itemType = payload.kind === 'skill' ? 'skill' : payload.kind === 'plugin' ? 'plugin' : 'app'
+  const itemType = payload.kind === 'skill'
+    ? 'skill'
+    : payload.kind === 'plugin'
+      ? 'plugin'
+      : payload.kind === 'composio'
+        ? 'Composio connector'
+        : 'app'
   return `Test ${label} ${itemType}. Give me a list of what it can do and one useful example.`
 }
 
@@ -3481,7 +3490,9 @@ async function onTryDirectoryItem(payload: DirectoryTryItemPayload): Promise<voi
   if (directoryTryInFlightKey.value) return
   directoryTryInFlightKey.value = getDirectoryTryItemKey(payload)
   const text = buildDirectoryTryPrompt(payload)
-  const skills = payload.kind === 'skill' && payload.skillPath
+  const skills = payload.attachedSkills?.length
+    ? payload.attachedSkills
+    : payload.kind === 'skill' && payload.skillPath
     ? [{ name: payload.name, path: payload.skillPath }]
     : []
   try {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -155,6 +155,68 @@ export type DirectoryMcpLoginResult = {
   authorizationUrl: string
 }
 
+export type DirectoryComposioStatus = {
+  available: boolean
+  authenticated: boolean
+  cliVersion: string
+  email: string
+  defaultOrgName: string
+  defaultOrgId: string
+  webUrl: string
+  baseUrl: string
+  testUserId: string
+}
+
+export type DirectoryComposioConnection = {
+  id: string
+  wordId: string
+  alias: string
+  status: string
+  authScheme: string
+  createdAt: string
+  updatedAt: string
+  isComposioManaged: boolean
+  isDisabled: boolean
+}
+
+export type DirectoryComposioConnector = {
+  slug: string
+  name: string
+  description: string
+  logoUrl: string
+  latestVersion: string
+  toolsCount: number
+  triggersCount: number
+  isNoAuth: boolean
+  enabled: boolean
+  authModes: string[]
+  activeCount: number
+  totalConnections: number
+  connectionStatuses: string[]
+}
+
+export type DirectoryComposioTool = {
+  slug: string
+  name: string
+  description: string
+}
+
+export type DirectoryComposioConnectorDetail = {
+  connector: DirectoryComposioConnector
+  connections: DirectoryComposioConnection[]
+  tools: DirectoryComposioTool[]
+  dashboardUrl: string
+}
+
+export type DirectoryComposioLinkResult = {
+  status: string
+  message: string
+  connectedAccountId: string
+  redirectUrl: string
+  toolkit: string
+  projectType: string
+}
+
 type ProviderModelsResponse = {
   data?: unknown
 }
@@ -1921,6 +1983,46 @@ export async function startDirectoryMcpLogin(name: string): Promise<DirectoryMcp
   return {
     authorizationUrl: readString(payload.authorizationUrl ?? payload.authorization_url) ?? '',
   }
+}
+
+export async function getDirectoryComposioStatus(): Promise<DirectoryComposioStatus> {
+  const response = await fetch('/codex-api/composio/status')
+  if (!response.ok) {
+    throw new Error(`Failed to load Composio status (${response.status})`)
+  }
+  return await response.json() as DirectoryComposioStatus
+}
+
+export async function listDirectoryComposioConnectors(query = ''): Promise<DirectoryComposioConnector[]> {
+  const params = new URLSearchParams()
+  if (query.trim()) params.set('query', query.trim())
+  const suffix = params.toString()
+  const response = await fetch(`/codex-api/composio/connectors${suffix ? `?${suffix}` : ''}`)
+  if (!response.ok) {
+    throw new Error(`Failed to list Composio connectors (${response.status})`)
+  }
+  const payload = await response.json() as { data?: DirectoryComposioConnector[] }
+  return Array.isArray(payload.data) ? payload.data : []
+}
+
+export async function readDirectoryComposioConnector(slug: string): Promise<DirectoryComposioConnectorDetail> {
+  const response = await fetch(`/codex-api/composio/connector?slug=${encodeURIComponent(slug)}`)
+  if (!response.ok) {
+    throw new Error(`Failed to load Composio connector (${response.status})`)
+  }
+  return await response.json() as DirectoryComposioConnectorDetail
+}
+
+export async function startDirectoryComposioLogin(slug: string): Promise<DirectoryComposioLinkResult> {
+  const response = await fetch('/codex-api/composio/link', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to start Composio login (${response.status})`)
+  }
+  return await response.json() as DirectoryComposioLinkResult
 }
 
 export async function getAccountRateLimitsResponse(): Promise<GetAccountRateLimitsResponse> {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -217,6 +217,20 @@ export type DirectoryComposioLinkResult = {
   projectType: string
 }
 
+export type DirectoryComposioLoginResult = {
+  status: string
+  message: string
+  loginUrl: string
+  cliKey: string
+  expiresAt: string
+}
+
+export type DirectoryComposioInstallResult = {
+  ok: boolean
+  command: string
+  output: string
+}
+
 type ProviderModelsResponse = {
   data?: unknown
 }
@@ -2023,6 +2037,26 @@ export async function startDirectoryComposioLogin(slug: string): Promise<Directo
     throw new Error(`Failed to start Composio login (${response.status})`)
   }
   return await response.json() as DirectoryComposioLinkResult
+}
+
+export async function startDirectoryComposioCliLogin(): Promise<DirectoryComposioLoginResult> {
+  const response = await fetch('/codex-api/composio/login', {
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to start Composio CLI login (${response.status})`)
+  }
+  return await response.json() as DirectoryComposioLoginResult
+}
+
+export async function installDirectoryComposioCli(): Promise<DirectoryComposioInstallResult> {
+  const response = await fetch('/codex-api/composio/install', {
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to install Composio CLI (${response.status})`)
+  }
+  return await response.json() as DirectoryComposioInstallResult
 }
 
 export async function getAccountRateLimitsResponse(): Promise<GetAccountRateLimitsResponse> {

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -189,6 +189,126 @@
       </div>
     </section>
 
+    <section v-else-if="activeTab === 'composio'" class="directory-section">
+      <div class="directory-toolbar">
+        <input
+          v-model="composioSearchQuery"
+          class="directory-search"
+          type="search"
+          placeholder="Search Composio connectors..."
+          aria-label="Search Composio connectors"
+        />
+        <div class="directory-sort-group" role="group" aria-label="Sort Composio connectors">
+          <button
+            class="directory-sort-button"
+            :class="{ 'is-active': composioSortMode === 'popular' }"
+            type="button"
+            @click="composioSortMode = 'popular'"
+          >
+            Popular
+          </button>
+          <button
+            class="directory-sort-button"
+            :class="{ 'is-active': composioSortMode === 'name' }"
+            type="button"
+            @click="composioSortMode = 'name'"
+          >
+            A-Z
+          </button>
+          <button
+            class="directory-sort-button"
+            :class="{ 'is-active': composioSortMode === 'date' }"
+            type="button"
+            @click="composioSortMode = 'date'"
+          >
+            Date
+          </button>
+        </div>
+      </div>
+      <div v-if="composioError" class="directory-error">{{ composioError }}</div>
+      <div v-else-if="isLoadingComposio" class="directory-loading">Loading Composio connectors...</div>
+      <div v-else-if="!composioStatus?.available" class="directory-empty">
+        Composio CLI is not installed in this environment.
+      </div>
+      <div v-else-if="!composioStatus.authenticated" class="directory-empty">
+        Composio CLI is installed but not logged in. Run `composio login` or log in from your terminal, then refresh this tab.
+      </div>
+      <div v-else class="directory-section composio-section">
+        <article class="directory-card directory-card-wide composio-status-card">
+          <div class="directory-card-top">
+            <div class="directory-card-fallback composio-fallback">C</div>
+            <div class="directory-card-main">
+              <div class="directory-card-title-row">
+                <span class="directory-card-title">Composio workspace</span>
+                <span class="directory-badge">Connected</span>
+              </div>
+              <span class="directory-card-meta">{{ composioStatus.email || composioStatus.defaultOrgName || 'Authenticated' }}</span>
+            </div>
+          </div>
+          <p class="directory-card-description">
+            {{ composioWorkspaceSummary }}
+          </p>
+          <div class="directory-chip-row">
+            <span v-if="composioStatus.defaultOrgName" class="directory-chip">{{ composioStatus.defaultOrgName }}</span>
+            <span v-if="composioStatus.cliVersion" class="directory-chip">CLI {{ composioStatus.cliVersion }}</span>
+            <span v-if="composioConnectors.length" class="directory-chip">{{ composioConnectors.length }} connectors</span>
+          </div>
+          <div class="directory-card-actions">
+            <button class="directory-action-link" type="button" @click="openExternalUrl(composioStatus.webUrl)">
+              Open dashboard
+            </button>
+          </div>
+        </article>
+
+        <div v-if="visibleComposioConnectors.length === 0" class="directory-empty">No Composio connectors found.</div>
+        <div v-else class="directory-grid">
+          <article v-for="connector in visibleComposioConnectors" :key="connector.slug" class="directory-card">
+            <div class="directory-card-top">
+              <img v-if="connector.logoUrl" class="directory-card-icon" :src="connector.logoUrl" :alt="connector.name" loading="lazy" />
+              <div v-else class="directory-card-fallback composio-fallback">{{ connector.name.charAt(0) }}</div>
+              <div class="directory-card-main">
+                <div class="directory-card-title-row">
+                  <span class="directory-card-title">{{ connector.name }}</span>
+                  <span v-if="connector.activeCount > 0" class="directory-badge">Connected</span>
+                  <span v-else-if="connector.isNoAuth" class="directory-badge">No auth</span>
+                </div>
+                <span class="directory-card-meta">{{ composioMetaLabel(connector) }}</span>
+              </div>
+            </div>
+            <p v-if="connector.description" class="directory-card-description">{{ connector.description }}</p>
+            <div class="directory-chip-row">
+              <span class="directory-chip">{{ connector.toolsCount }} tools</span>
+              <span v-if="connector.triggersCount > 0" class="directory-chip">{{ connector.triggersCount }} triggers</span>
+              <span v-if="connector.authModes.length > 0" class="directory-chip">{{ connector.authModes.join(', ') }}</span>
+            </div>
+            <div class="directory-card-actions">
+              <button class="directory-action" type="button" @click="openComposioDetail(connector.slug)">
+                Details
+              </button>
+              <button
+                v-if="composioPrimaryActionLabel(connector)"
+                class="directory-action-link"
+                type="button"
+                :disabled="composioActionSlug === connector.slug"
+                @click="runComposioPrimaryAction(connector)"
+              >
+                {{ composioActionSlug === connector.slug ? 'Opening...' : composioPrimaryActionLabel(connector) }}
+              </button>
+              <button
+                v-if="canTryComposio(connector)"
+                class="directory-action primary"
+                type="button"
+                :disabled="isTryActionInFlight"
+                @click="tryComposio(connector)"
+              >
+                {{ props.tryInFlightKey === composioTryKey(connector.slug) ? 'Starting...' : 'Try it!' }}
+              </button>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section v-else-if="activeTab === 'mcps'" class="directory-section">
       <div class="directory-toolbar">
         <input
@@ -385,24 +505,133 @@
         </article>
       </div>
     </Teleport>
+
+    <Teleport to="body">
+      <div v-if="isComposioDetailOpen" class="directory-modal-overlay" @click.self="closeComposioDetail">
+        <article class="directory-modal">
+          <div class="directory-modal-header">
+            <div class="directory-card-top">
+              <img
+                v-if="selectedComposioDetail?.connector.logoUrl"
+                class="directory-card-icon"
+                :src="selectedComposioDetail.connector.logoUrl"
+                :alt="selectedComposioDetail.connector.name"
+                loading="lazy"
+              />
+              <div v-else class="directory-card-fallback composio-fallback">{{ selectedComposioDetail?.connector.name.charAt(0) }}</div>
+              <div class="directory-card-main">
+                <h3 class="directory-modal-title">{{ selectedComposioDetail?.connector.name || 'Composio' }}</h3>
+                <span class="directory-card-meta">{{ selectedComposioDetail ? composioMetaLabel(selectedComposioDetail.connector) : 'Connector' }}</span>
+              </div>
+            </div>
+            <button class="directory-modal-close" type="button" aria-label="Close Composio detail" @click="closeComposioDetail">Close</button>
+          </div>
+
+          <div class="directory-modal-body">
+            <div v-if="composioDetailError" class="directory-error">{{ composioDetailError }}</div>
+            <div v-else-if="isLoadingComposioDetail" class="directory-loading">Loading connector...</div>
+            <template v-else-if="selectedComposioDetail">
+              <p v-if="selectedComposioDetail.connector.description" class="directory-detail-description">
+                {{ selectedComposioDetail.connector.description }}
+              </p>
+
+              <div class="directory-detail-grid">
+                <div class="directory-detail-block">
+                  <h4 class="directory-detail-heading">Overview</h4>
+                  <div class="directory-chip-row">
+                    <span class="directory-chip">{{ selectedComposioDetail.connector.toolsCount }} tools</span>
+                    <span v-if="selectedComposioDetail.connector.triggersCount > 0" class="directory-chip">{{ selectedComposioDetail.connector.triggersCount }} triggers</span>
+                    <span v-if="selectedComposioDetail.connector.latestVersion" class="directory-chip">v{{ selectedComposioDetail.connector.latestVersion }}</span>
+                    <span v-if="selectedComposioDetail.connector.authModes.length > 0" class="directory-chip">{{ selectedComposioDetail.connector.authModes.join(', ') }}</span>
+                  </div>
+                </div>
+
+                <div class="directory-detail-block">
+                  <h4 class="directory-detail-heading">Connections</h4>
+                  <div v-if="selectedComposioDetail.connections.length === 0" class="directory-mini-list">
+                    No linked accounts yet.
+                  </div>
+                  <div v-else>
+                    <div v-for="connection in selectedComposioDetail.connections" :key="connection.id" class="directory-include-row">
+                      <span>
+                        {{ connection.alias || connection.wordId || connection.id }}
+                        <span class="directory-auth-status" :class="composioConnectionStatusClass(connection.status)">
+                          {{ composioConnectionStatusLabel(connection.status) }}
+                        </span>
+                      </span>
+                      <span class="directory-card-meta">{{ connection.authScheme || 'Auth' }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="selectedComposioDetail.tools.length > 0" class="directory-detail-block">
+                <h4 class="directory-detail-heading">Useful tools</h4>
+                <div v-for="tool in selectedComposioDetail.tools.slice(0, 8)" :key="tool.slug" class="directory-include-row">
+                  <span>{{ tool.name || tool.slug }}</span>
+                  <span class="directory-card-meta">{{ tool.slug }}</span>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <div class="directory-modal-footer">
+            <button
+              v-if="selectedComposioDetail"
+              class="directory-action-link"
+              type="button"
+              @click="openExternalUrl(selectedComposioDetail.dashboardUrl)"
+            >
+              Open dashboard
+            </button>
+            <button
+              v-if="selectedComposioDetail && composioPrimaryActionLabel(selectedComposioDetail.connector)"
+              class="directory-action"
+              type="button"
+              :disabled="composioActionSlug === selectedComposioDetail.connector.slug"
+              @click="runComposioPrimaryAction(selectedComposioDetail.connector)"
+            >
+              {{ composioActionSlug === selectedComposioDetail?.connector.slug ? 'Opening...' : composioPrimaryActionLabel(selectedComposioDetail.connector) }}
+            </button>
+            <button
+              v-if="selectedComposioDetail && canTryComposio(selectedComposioDetail.connector)"
+              class="directory-action primary"
+              type="button"
+              :disabled="isTryActionInFlight"
+              @click="tryComposio(selectedComposioDetail.connector, selectedComposioDetail.connections)"
+            >
+              {{ props.tryInFlightKey === composioTryKey(selectedComposioDetail.connector.slug) ? 'Starting...' : 'Try it!' }}
+            </button>
+          </div>
+        </article>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import {
+  getDirectoryComposioStatus,
   getMethodCatalog,
   installDirectoryPlugin,
+  listDirectoryComposioConnectors,
   listDirectoryApps,
   listDirectoryMcpServers,
   listDirectoryPlugins,
+  readDirectoryComposioConnector,
   readDirectoryPlugin,
   reloadDirectoryMcpServers,
   setDirectoryAppEnabled,
   setDirectoryPluginEnabled,
+  startDirectoryComposioLogin,
   startDirectoryMcpLogin,
   uninstallDirectoryPlugin,
   type DirectoryAppInfo,
+  type DirectoryComposioConnection,
+  type DirectoryComposioConnector,
+  type DirectoryComposioConnectorDetail,
+  type DirectoryComposioStatus,
   type DirectoryMcpServerStatus,
   type DirectoryPluginAppSummary,
   type DirectoryPluginDetail,
@@ -410,8 +639,9 @@ import {
 } from '../../api/codexGateway'
 import SkillsHub from './SkillsHub.vue'
 
-type DirectoryTab = 'plugins' | 'apps' | 'mcps' | 'skills'
+type DirectoryTab = 'plugins' | 'apps' | 'composio' | 'mcps' | 'skills'
 type DirectorySortMode = 'popular' | 'name' | 'date'
+const COMPOSIO_SKILL_PATH = '/Users/igor/.codex/skills/shared_skills/composio-cli/SKILL.md'
 
 const POPULAR_LIMIT = 100
 const POPULAR_APP_NAME_BONUSES: Array<[RegExp, number]> = [
@@ -458,6 +688,10 @@ const POPULAR_MCP_NAME_BONUSES: Array<[RegExp, number]> = [
   [/(github|gitlab|linear|slack|notion|filesystem|browser|computer|web|postgres|sqlite|database)/i, 120],
   [/(search|drive|docs|calendar|terminal|shell|deploy|cloud|memory)/i, 55],
 ]
+const POPULAR_COMPOSIO_NAME_BONUSES: Array<[RegExp, number]> = [
+  [/(gmail|google calendar|google docs|google sheets|google drive|github|slack|notion|linear|outlook|supabase)/i, 140],
+  [/(email|calendar|document|sheet|drive|repo|issue|message|project|database|crm|deploy)/i, 50],
+]
 
 const props = defineProps<{
   cwd?: string
@@ -466,10 +700,12 @@ const props = defineProps<{
 }>()
 
 export type DirectoryTryItemPayload = {
-  kind: 'app' | 'plugin' | 'skill'
+  kind: 'app' | 'plugin' | 'skill' | 'composio'
   name: string
   displayName: string
   skillPath?: string
+  prompt?: string
+  attachedSkills?: Array<{ name: string; path: string }>
 }
 
 const emit = defineEmits<{
@@ -480,6 +716,7 @@ const emit = defineEmits<{
 const tabs: Array<{ id: DirectoryTab; label: string; subtitle: string }> = [
   { id: 'plugins', label: 'Plugins', subtitle: 'Plugins make Codex work your way.' },
   { id: 'apps', label: 'Apps', subtitle: 'Connect Codex to external apps and services.' },
+  { id: 'composio', label: 'Composio', subtitle: 'Browse Composio connectors, auth state, and ready-to-try integrations.' },
   { id: 'mcps', label: 'MCPs', subtitle: 'Inspect configured MCP servers, tools, and resources.' },
   { id: 'skills', label: 'Skills', subtitle: 'Browse and discover skills from the OpenClaw community.' },
 ]
@@ -489,27 +726,38 @@ const methodSet = ref<Set<string>>(new Set())
 const methodsLoaded = ref(false)
 const plugins = ref<DirectoryPluginSummary[]>([])
 const apps = ref<DirectoryAppInfo[]>([])
+const composioStatus = ref<DirectoryComposioStatus | null>(null)
+const composioConnectors = ref<DirectoryComposioConnector[]>([])
 const mcpServers = ref<DirectoryMcpServerStatus[]>([])
 const pluginSortMode = ref<DirectorySortMode>('popular')
 const appSortMode = ref<DirectorySortMode>('popular')
+const composioSortMode = ref<DirectorySortMode>('popular')
 const mcpSortMode = ref<DirectorySortMode>('popular')
 const pluginSearchQuery = ref('')
 const appSearchQuery = ref('')
+const composioSearchQuery = ref('')
 const mcpSearchQuery = ref('')
 const isLoadingPlugins = ref(false)
 const isLoadingApps = ref(false)
+const isLoadingComposio = ref(false)
 const isLoadingMcps = ref(false)
 const isReloadingMcps = ref(false)
 const pluginError = ref('')
 const appError = ref('')
+const composioError = ref('')
 const mcpError = ref('')
 const selectedPlugin = ref<DirectoryPluginSummary | null>(null)
 const selectedPluginDetail = ref<DirectoryPluginDetail | null>(null)
 const isPluginDetailOpen = ref(false)
 const isLoadingPluginDetail = ref(false)
 const pluginDetailError = ref('')
+const selectedComposioDetail = ref<DirectoryComposioConnectorDetail | null>(null)
+const isComposioDetailOpen = ref(false)
+const isLoadingComposioDetail = ref(false)
+const composioDetailError = ref('')
 const isPluginActionInFlight = ref(false)
 const appActionId = ref('')
+const composioActionSlug = ref('')
 const installAuthApps = ref<DirectoryPluginAppSummary[]>([])
 const mcpLoginServerName = ref('')
 const expandedMcpNames = ref<Set<string>>(new Set())
@@ -529,6 +777,7 @@ const isTryActionInFlight = computed(() => (props.tryInFlightKey ?? '').length >
 const isActiveLoading = computed(() =>
   activeTab.value === 'plugins' ? isLoadingPlugins.value
     : activeTab.value === 'apps' ? isLoadingApps.value
+      : activeTab.value === 'composio' ? isLoadingComposio.value
       : activeTab.value === 'mcps' ? isLoadingMcps.value
         : false,
 )
@@ -545,8 +794,19 @@ const selectedPluginScreenshots = computed(() => {
 })
 const visiblePlugins = computed(() => limitPopularRows(sortPlugins(filterPlugins(plugins.value, pluginSearchQuery.value), pluginSortMode.value), pluginSortMode.value, pluginSearchQuery.value))
 const visibleApps = computed(() => limitPopularApps(sortApps(filterApps(apps.value, appSearchQuery.value), appSortMode.value), appSortMode.value, appSearchQuery.value))
+const visibleComposioConnectors = computed(() => limitPopularRows(sortComposioConnectors(filterComposioConnectors(composioConnectors.value, composioSearchQuery.value), composioSortMode.value), composioSortMode.value, composioSearchQuery.value))
 const visibleMcpServers = computed(() => limitPopularRows(sortMcpServers(filterMcpServers(mcpServers.value, mcpSearchQuery.value), mcpSortMode.value), mcpSortMode.value, mcpSearchQuery.value))
 const mcpStatusByName = computed(() => new Map(mcpServers.value.map((server) => [server.name, server])))
+const composioWorkspaceSummary = computed(() => {
+  const status = composioStatus.value
+  if (!status) return 'Composio CLI shares the login and connections from this machine.'
+  const parts = [
+    status.email || status.defaultOrgName,
+    status.defaultOrgId ? `org ${status.defaultOrgId}` : '',
+    status.baseUrl || '',
+  ].filter(Boolean)
+  return parts.join(' · ') || 'Composio CLI shares the login and connections from this machine.'
+})
 
 function normalizeSearch(value: string): string {
   return value.trim().toLowerCase()
@@ -644,6 +904,16 @@ function filterApps(rows: DirectoryAppInfo[], query: string): DirectoryAppInfo[]
   ], query))
 }
 
+function filterComposioConnectors(rows: DirectoryComposioConnector[], query: string): DirectoryComposioConnector[] {
+  return rows.filter((connector) => includesSearch([
+    connector.name,
+    connector.slug,
+    connector.description,
+    ...connector.authModes,
+    ...connector.connectionStatuses,
+  ], query))
+}
+
 function filterMcpServers(rows: DirectoryMcpServerStatus[], query: string): DirectoryMcpServerStatus[] {
   return rows.filter((server) => includesSearch([
     server.name,
@@ -689,6 +959,16 @@ function mcpPopularScore(server: DirectoryMcpServerStatus): number {
   )
 }
 
+function composioPopularScore(connector: DirectoryComposioConnector): number {
+  return (
+    (connector.activeCount * 1_000) +
+    (connector.isNoAuth ? 300 : 0) +
+    (connector.toolsCount * 3) +
+    (connector.triggersCount * 4) +
+    bonusForName(`${connector.name} ${connector.slug} ${connector.description}`, POPULAR_COMPOSIO_NAME_BONUSES)
+  )
+}
+
 function sortPlugins(rows: DirectoryPluginSummary[], sortMode: DirectorySortMode): DirectoryPluginSummary[] {
   if (sortMode === 'name') return [...rows].sort((a, b) => a.displayName.localeCompare(b.displayName))
   if (sortMode === 'date') return [...rows]
@@ -699,6 +979,12 @@ function sortApps(rows: DirectoryAppInfo[], sortMode: DirectorySortMode): Direct
   if (sortMode === 'name') return [...rows].sort((a, b) => a.name.localeCompare(b.name))
   if (sortMode === 'date') return [...rows].sort((a, b) => a.catalogRank - b.catalogRank)
   return [...rows].sort((a, b) => (appPopularScore(b) - appPopularScore(a)) || a.name.localeCompare(b.name))
+}
+
+function sortComposioConnectors(rows: DirectoryComposioConnector[], sortMode: DirectorySortMode): DirectoryComposioConnector[] {
+  if (sortMode === 'name') return [...rows].sort((a, b) => a.name.localeCompare(b.name))
+  if (sortMode === 'date') return [...rows]
+  return [...rows].sort((a, b) => (composioPopularScore(b) - composioPopularScore(a)) || a.name.localeCompare(b.name))
 }
 
 function sortMcpServers(rows: DirectoryMcpServerStatus[], sortMode: DirectorySortMode): DirectoryMcpServerStatus[] {
@@ -730,6 +1016,43 @@ function appLogoSrc(app: DirectoryAppInfo): string {
   return localAssetSrc(app.logoUrlDark || app.logoUrl)
 }
 
+function composioMetaLabel(connector: DirectoryComposioConnector): string {
+  if (connector.activeCount > 0) {
+    return `${connector.activeCount} connected ${connector.activeCount === 1 ? 'account' : 'accounts'}`
+  }
+  if (connector.isNoAuth) return 'No auth required'
+  if (connector.connectionStatuses.length > 0) return connector.connectionStatuses.join(', ')
+  return connector.authModes.join(', ') || 'Connection required'
+}
+
+function composioHasUsableConnection(connector: DirectoryComposioConnector): boolean {
+  return connector.isNoAuth || connector.activeCount > 0
+}
+
+function composioPrimaryActionLabel(connector: DirectoryComposioConnector): string {
+  if (connector.isNoAuth) return ''
+  if (connector.activeCount > 0) return 'Manage'
+  if (connector.totalConnections > 0) return 'Reconnect'
+  return 'Connect'
+}
+
+function composioConnectionStatusLabel(status: string): string {
+  const normalized = status.trim().toUpperCase()
+  if (normalized === 'ACTIVE') return 'Active'
+  if (normalized === 'EXPIRED') return 'Expired'
+  if (normalized === 'FAILED') return 'Failed'
+  if (normalized === 'INITIATED') return 'Pending'
+  return normalized || 'Unknown'
+}
+
+function composioConnectionStatusClass(status: string): string {
+  const normalized = status.trim().toUpperCase()
+  if (normalized === 'ACTIVE') return 'is-ok'
+  if (normalized === 'INITIATED') return 'is-warning'
+  if (normalized === 'EXPIRED' || normalized === 'FAILED') return 'is-error'
+  return 'is-muted'
+}
+
 function appTryKey(app: DirectoryAppInfo): string {
   return `app:${app.id}:`
 }
@@ -747,12 +1070,39 @@ function pluginTryKey(plugin: DirectoryPluginSummary): string {
   return `plugin:${plugin.name}:`
 }
 
+function composioTryKey(slug: string): string {
+  return `composio:${slug}:`
+}
+
 function tryPlugin(plugin: DirectoryPluginSummary): void {
   if (isTryActionInFlight.value) return
   emit('try-item', {
     kind: 'plugin',
     name: plugin.name,
     displayName: plugin.displayName,
+  })
+}
+
+function canTryComposio(connector: DirectoryComposioConnector): boolean {
+  return composioHasUsableConnection(connector)
+}
+
+function buildComposioTryPrompt(connector: DirectoryComposioConnector, connections: DirectoryComposioConnection[] = []): string {
+  const firstActive = connections.find((connection) => connection.status === 'ACTIVE' && !connection.isDisabled)
+  const accountHint = firstActive?.wordId
+    ? ` If there are multiple accounts, prefer \`${firstActive.wordId}\`.`
+    : ''
+  return `Use the Composio CLI skill with the ${connector.name} connector (${connector.slug}). Start by listing what it can do here, mention the current connection status, and suggest one safe command I can run now.${accountHint}`
+}
+
+function tryComposio(connector: DirectoryComposioConnector, connections: DirectoryComposioConnection[] = []): void {
+  if (isTryActionInFlight.value) return
+  emit('try-item', {
+    kind: 'composio',
+    name: connector.slug,
+    displayName: connector.name,
+    prompt: buildComposioTryPrompt(connector, connections),
+    attachedSkills: [{ name: 'composio-cli', path: COMPOSIO_SKILL_PATH }],
   })
 }
 
@@ -810,6 +1160,25 @@ async function loadApps(): Promise<void> {
   }
 }
 
+async function loadComposio(): Promise<void> {
+  isLoadingComposio.value = true
+  composioError.value = ''
+  try {
+    const status = await getDirectoryComposioStatus()
+    composioStatus.value = status
+    if (!status.available || !status.authenticated) {
+      composioConnectors.value = []
+      return
+    }
+    const connectors = await listDirectoryComposioConnectors(composioSearchQuery.value)
+    composioConnectors.value = connectors
+  } catch (error) {
+    composioError.value = error instanceof Error ? error.message : 'Failed to load Composio connectors'
+  } finally {
+    isLoadingComposio.value = false
+  }
+}
+
 async function loadMcps(): Promise<void> {
   if (!supportsMcps.value) return
   isLoadingMcps.value = true
@@ -835,6 +1204,7 @@ async function refreshMcpStatusesForPluginDetail(): Promise<void> {
 function refreshActiveTab(): void {
   if (activeTab.value === 'plugins') void loadPlugins()
   if (activeTab.value === 'apps') void loadApps()
+  if (activeTab.value === 'composio') void loadComposio()
   if (activeTab.value === 'mcps') void loadMcps()
 }
 
@@ -885,6 +1255,53 @@ async function openFirstMcpLoginIfNeeded(detail: DirectoryPluginDetail): Promise
 
 function closePluginDetail(): void {
   isPluginDetailOpen.value = false
+}
+
+async function openComposioDetail(slug: string): Promise<void> {
+  isComposioDetailOpen.value = true
+  isLoadingComposioDetail.value = true
+  composioDetailError.value = ''
+  selectedComposioDetail.value = null
+  try {
+    selectedComposioDetail.value = await readDirectoryComposioConnector(slug)
+  } catch (error) {
+    composioDetailError.value = error instanceof Error ? error.message : 'Failed to load Composio connector'
+  } finally {
+    isLoadingComposioDetail.value = false
+  }
+}
+
+function closeComposioDetail(): void {
+  isComposioDetailOpen.value = false
+}
+
+async function startComposioConnect(connector: DirectoryComposioConnector): Promise<void> {
+  composioActionSlug.value = connector.slug
+  try {
+    const result = await startDirectoryComposioLogin(connector.slug)
+    if (!result.redirectUrl) {
+      showToast(`No login URL returned for ${connector.name}`, 'error')
+      return
+    }
+    openExternalUrl(result.redirectUrl)
+    showToast(`Opened ${connector.name} authorization`)
+    await loadComposio()
+    if (isComposioDetailOpen.value && selectedComposioDetail.value?.connector.slug === connector.slug) {
+      await openComposioDetail(connector.slug)
+    }
+  } catch (error) {
+    showToast(error instanceof Error ? error.message : `Failed to connect ${connector.name}`, 'error')
+  } finally {
+    composioActionSlug.value = ''
+  }
+}
+
+async function runComposioPrimaryAction(connector: DirectoryComposioConnector): Promise<void> {
+  if (connector.activeCount > 0 && composioStatus.value?.webUrl) {
+    openExternalUrl(composioStatus.value.webUrl)
+    return
+  }
+  await startComposioConnect(connector)
 }
 
 async function installSelectedPlugin(): Promise<void> {
@@ -1031,7 +1448,7 @@ onMounted(async () => {
 }
 
 .directory-tabs {
-  @apply mx-auto grid w-full max-w-5xl grid-cols-4 rounded-lg border border-zinc-200 bg-zinc-100 p-1;
+  @apply mx-auto grid w-full max-w-5xl grid-cols-5 rounded-lg border border-zinc-200 bg-zinc-100 p-1;
 }
 
 .directory-tab {
@@ -1154,6 +1571,10 @@ button.directory-card {
   @apply border-rose-200 bg-rose-50 text-rose-700;
 }
 
+.directory-auth-status.is-error {
+  @apply border-rose-200 bg-rose-50 text-rose-700;
+}
+
 .directory-toast {
   @apply mx-auto w-full max-w-5xl rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700;
 }
@@ -1249,6 +1670,14 @@ button.directory-card {
   @apply max-h-56 w-full rounded-xl border border-zinc-200 object-cover;
 }
 
+.composio-status-card {
+  @apply min-h-0;
+}
+
+.composio-fallback {
+  @apply bg-sky-100 text-sky-700;
+}
+
 :global(:root.dark) .directory-title,
 :global(:root.dark) .directory-card-title,
 :global(:root.dark) .directory-modal-title,
@@ -1296,5 +1725,15 @@ button.directory-card {
 
 :global(:root.dark) .directory-auth-status.is-muted {
   @apply border-zinc-700 bg-zinc-900 text-zinc-400;
+}
+
+:global(:root.dark) .directory-auth-status.is-error,
+:global(:root.dark) .directory-error,
+:global(:root.dark) .directory-toast.is-error {
+  @apply border-rose-900/60 bg-rose-950/60 text-rose-300;
+}
+
+:global(:root.dark) .composio-fallback {
+  @apply bg-sky-950 text-sky-300;
 }
 </style>

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -228,10 +228,24 @@
       <div v-if="composioError" class="directory-error">{{ composioError }}</div>
       <div v-else-if="isLoadingComposio" class="directory-loading">Loading Composio connectors...</div>
       <div v-else-if="!composioStatus?.available" class="directory-empty">
-        Composio CLI is not installed in this environment.
+        <div class="directory-empty-copy">
+          <p class="directory-empty-text">Composio CLI is not installed in this environment.</p>
+          <div class="directory-card-actions">
+            <button class="directory-action primary" type="button" :disabled="isInstallingComposio" @click="installComposioCli">
+              {{ isInstallingComposio ? 'Installing...' : 'Install' }}
+            </button>
+          </div>
+        </div>
       </div>
       <div v-else-if="!composioStatus.authenticated" class="directory-empty">
-        Composio CLI is installed but not logged in. Run `composio login` or log in from your terminal, then refresh this tab.
+        <div class="directory-empty-copy">
+          <p class="directory-empty-text">Composio CLI is installed but not logged in.</p>
+          <div class="directory-card-actions">
+            <button class="directory-action primary" type="button" :disabled="isStartingComposioLogin" @click="startComposioCliLogin">
+              {{ isStartingComposioLogin ? 'Opening...' : 'Login' }}
+            </button>
+          </div>
+        </div>
       </div>
       <div v-else class="directory-section composio-section">
         <article class="directory-card directory-card-wide composio-status-card">
@@ -615,6 +629,7 @@ import {
   getDirectoryComposioStatus,
   getMethodCatalog,
   installDirectoryPlugin,
+  installDirectoryComposioCli,
   listDirectoryComposioConnectors,
   listDirectoryApps,
   listDirectoryMcpServers,
@@ -624,6 +639,7 @@ import {
   reloadDirectoryMcpServers,
   setDirectoryAppEnabled,
   setDirectoryPluginEnabled,
+  startDirectoryComposioCliLogin,
   startDirectoryComposioLogin,
   startDirectoryMcpLogin,
   uninstallDirectoryPlugin,
@@ -755,6 +771,8 @@ const selectedComposioDetail = ref<DirectoryComposioConnectorDetail | null>(null
 const isComposioDetailOpen = ref(false)
 const isLoadingComposioDetail = ref(false)
 const composioDetailError = ref('')
+const isInstallingComposio = ref(false)
+const isStartingComposioLogin = ref(false)
 const isPluginActionInFlight = ref(false)
 const appActionId = ref('')
 const composioActionSlug = ref('')
@@ -969,6 +987,13 @@ function composioPopularScore(connector: DirectoryComposioConnector): number {
   )
 }
 
+function composioConnectionRank(connector: DirectoryComposioConnector): number {
+  if (connector.activeCount > 0) return 0
+  if (connector.totalConnections > 0) return 1
+  if (connector.isNoAuth) return 2
+  return 3
+}
+
 function sortPlugins(rows: DirectoryPluginSummary[], sortMode: DirectorySortMode): DirectoryPluginSummary[] {
   if (sortMode === 'name') return [...rows].sort((a, b) => a.displayName.localeCompare(b.displayName))
   if (sortMode === 'date') return [...rows]
@@ -982,9 +1007,17 @@ function sortApps(rows: DirectoryAppInfo[], sortMode: DirectorySortMode): Direct
 }
 
 function sortComposioConnectors(rows: DirectoryComposioConnector[], sortMode: DirectorySortMode): DirectoryComposioConnector[] {
-  if (sortMode === 'name') return [...rows].sort((a, b) => a.name.localeCompare(b.name))
-  if (sortMode === 'date') return [...rows]
-  return [...rows].sort((a, b) => (composioPopularScore(b) - composioPopularScore(a)) || a.name.localeCompare(b.name))
+  if (sortMode === 'name') {
+    return [...rows].sort((a, b) => (
+      composioConnectionRank(a) - composioConnectionRank(b)
+    ) || a.name.localeCompare(b.name))
+  }
+  if (sortMode === 'date') {
+    return [...rows].sort((a, b) => composioConnectionRank(a) - composioConnectionRank(b))
+  }
+  return [...rows].sort((a, b) => (
+    composioConnectionRank(a) - composioConnectionRank(b)
+  ) || (composioPopularScore(b) - composioPopularScore(a)) || a.name.localeCompare(b.name))
 }
 
 function sortMcpServers(rows: DirectoryMcpServerStatus[], sortMode: DirectorySortMode): DirectoryMcpServerStatus[] {
@@ -1304,6 +1337,36 @@ async function runComposioPrimaryAction(connector: DirectoryComposioConnector): 
   await startComposioConnect(connector)
 }
 
+async function startComposioCliLogin(): Promise<void> {
+  isStartingComposioLogin.value = true
+  try {
+    const result = await startDirectoryComposioCliLogin()
+    if (!result.loginUrl) {
+      showToast('No login URL returned by Composio CLI', 'error')
+      return
+    }
+    openExternalUrl(result.loginUrl)
+    showToast('Opened Composio login')
+  } catch (error) {
+    showToast(error instanceof Error ? error.message : 'Failed to start Composio login', 'error')
+  } finally {
+    isStartingComposioLogin.value = false
+  }
+}
+
+async function installComposioCli(): Promise<void> {
+  isInstallingComposio.value = true
+  try {
+    await installDirectoryComposioCli()
+    showToast('Composio CLI installed')
+    await loadComposio()
+  } catch (error) {
+    showToast(error instanceof Error ? error.message : 'Failed to install Composio CLI', 'error')
+  } finally {
+    isInstallingComposio.value = false
+  }
+}
+
 async function installSelectedPlugin(): Promise<void> {
   if (!selectedPlugin.value) return
   isPluginActionInFlight.value = true
@@ -1564,6 +1627,14 @@ button.directory-card {
 .directory-empty,
 .directory-error {
   @apply rounded-xl border border-zinc-200 bg-white p-4 text-sm text-zinc-500;
+}
+
+.directory-empty-copy {
+  @apply flex flex-col gap-3;
+}
+
+.directory-empty-text {
+  @apply m-0;
 }
 
 .directory-error,

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -1340,13 +1340,8 @@ async function runComposioPrimaryAction(connector: DirectoryComposioConnector): 
 async function startComposioCliLogin(): Promise<void> {
   isStartingComposioLogin.value = true
   try {
-    const result = await startDirectoryComposioCliLogin()
-    if (!result.loginUrl) {
-      showToast('No login URL returned by Composio CLI', 'error')
-      return
-    }
-    openExternalUrl(result.loginUrl)
-    showToast('Opened Composio login')
+    await startDirectoryComposioCliLogin()
+    showToast('Composio CLI login started')
   } catch (error) {
     showToast(error instanceof Error ? error.message : 'Failed to start Composio login', 'error')
   } finally {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1,7 +1,7 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { mkdtemp, readFile, readdir, rename, rm, mkdir, stat, cp, lstat, readlink, symlink } from 'node:fs/promises'
-import { createReadStream, readFileSync } from 'node:fs'
+import { createReadStream, existsSync, readFileSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { request as httpRequest } from 'node:http'
 import { request as httpsRequest } from 'node:https'
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
+import Composio from '@composio/client'
 import { handleAccountRoutes } from './accountRoutes.js'
 import { buildAppServerArgs } from './appServerRuntimeConfig.js'
 import { handleReviewRoutes } from './reviewGit.js'
@@ -107,6 +108,76 @@ type ProviderModelsResponse = {
   source: 'provider'
 }
 
+type ComposioUserData = {
+  apiKey: string
+  baseUrl: string
+  webUrl: string
+  orgId: string
+  testUserId: string
+}
+
+type ComposioStatusResponse = {
+  available: boolean
+  authenticated: boolean
+  cliVersion: string
+  email: string
+  defaultOrgName: string
+  defaultOrgId: string
+  webUrl: string
+  baseUrl: string
+  testUserId: string
+}
+
+type ComposioConnectionSummary = {
+  id: string
+  wordId: string
+  alias: string
+  status: string
+  authScheme: string
+  createdAt: string
+  updatedAt: string
+  isComposioManaged: boolean
+  isDisabled: boolean
+}
+
+type ComposioConnectorSummary = {
+  slug: string
+  name: string
+  description: string
+  logoUrl: string
+  latestVersion: string
+  toolsCount: number
+  triggersCount: number
+  isNoAuth: boolean
+  enabled: boolean
+  authModes: string[]
+  activeCount: number
+  totalConnections: number
+  connectionStatuses: string[]
+}
+
+type ComposioToolSummary = {
+  slug: string
+  name: string
+  description: string
+}
+
+type ComposioConnectorDetail = {
+  connector: ComposioConnectorSummary
+  connections: ComposioConnectionSummary[]
+  tools: ComposioToolSummary[]
+  dashboardUrl: string
+}
+
+type ComposioLinkResult = {
+  status: string
+  message: string
+  connectedAccountId: string
+  redirectUrl: string
+  toolkit: string
+  projectType: string
+}
+
 const PROVIDER_MODELS_FETCH_TIMEOUT_MS = 5_000
 
 const THREAD_RESPONSE_TURN_LIMIT = 10
@@ -118,6 +189,7 @@ const API_PERF_BODY_MB_THRESHOLD_ENV_KEY = 'CODEXUI_API_PERF_BODY_MB_THRESHOLD'
 const DEFAULT_API_PERF_MS_THRESHOLD = 300
 const DEFAULT_API_PERF_BODY_MB_THRESHOLD = 1
 const MB_DIVISOR = 1024 * 1024
+const COMPOSIO_USER_DATA_PATH = join(homedir(), '.composio', 'user_data.json')
 
 type SessionRecoveredFileChange = {
   path: string
@@ -853,6 +925,328 @@ function extractThreadMessageText(threadReadPayload: unknown): string {
 
 function readNonEmptyString(value: unknown): string {
   return typeof value === 'string' && value.trim().length > 0 ? value : ''
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true
+}
+
+function readNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function resolveComposioCommand(): string | null {
+  const candidates = [
+    process.env.CODEXUI_COMPOSIO_COMMAND?.trim() ?? '',
+    join(homedir(), '.composio', 'composio'),
+    'composio',
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if ((candidate.includes('/') || candidate.includes('\\')) && !existsSync(candidate)) continue
+    const invocation = getSpawnInvocation(candidate, ['--version'])
+    const probe = spawnSync(invocation.command, invocation.args, {
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    if (!probe.error && probe.status === 0) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+function parseComposioJson<T>(stdout: string, fallback: string): T {
+  const trimmed = stdout.trim()
+  if (!trimmed) {
+    throw new Error(fallback)
+  }
+  return JSON.parse(trimmed) as T
+}
+
+async function runComposioJson<T>(args: string[], fallback: string): Promise<T> {
+  const command = resolveComposioCommand()
+  if (!command) {
+    throw new Error('Composio CLI is not installed')
+  }
+
+  const invocation = getSpawnInvocation(command, args)
+  const child = spawn(invocation.command, invocation.args, {
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  let stdout = ''
+  let stderr = ''
+
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk) => { stdout += chunk })
+  child.stderr.on('data', (chunk) => { stderr += chunk })
+
+  const exitCode = await new Promise<number>((resolveExit, reject) => {
+    child.once('error', reject)
+    child.once('close', (code) => resolveExit(code ?? 0))
+  })
+
+  if (exitCode !== 0) {
+    throw new Error(stderr.trim() || stdout.trim() || fallback)
+  }
+
+  try {
+    return parseComposioJson<T>(stdout, fallback)
+  } catch (error) {
+    const details = stderr.trim() || stdout.trim()
+    throw new Error(details || getErrorMessage(error, fallback))
+  }
+}
+
+async function readComposioUserData(): Promise<ComposioUserData | null> {
+  try {
+    const raw = await readFile(COMPOSIO_USER_DATA_PATH, 'utf8')
+    const payload = asRecord(JSON.parse(raw))
+    if (!payload) return null
+    return {
+      apiKey: readNonEmptyString(payload.api_key),
+      baseUrl: readNonEmptyString(payload.base_url),
+      webUrl: readNonEmptyString(payload.web_url),
+      orgId: readNonEmptyString(payload.org_id),
+      testUserId: readNonEmptyString(payload.test_user_id),
+    }
+  } catch {
+    return null
+  }
+}
+
+function getComposioConsumerUserIds(userData: ComposioUserData | null): string[] {
+  if (!userData?.testUserId || !userData.orgId) return []
+  const candidates = [
+    userData.testUserId.replace(/^pg-test-/u, ''),
+    userData.testUserId,
+  ]
+  const ids: string[] = []
+  for (const candidate of candidates) {
+    const normalized = candidate.trim()
+    if (!normalized) continue
+    const consumerId = `consumer-${normalized}-${userData.orgId}`
+    if (!ids.includes(consumerId)) ids.push(consumerId)
+  }
+  return ids
+}
+
+function createComposioClient(userData: ComposioUserData): Composio {
+  return new Composio({
+    apiKey: null,
+    baseURL: userData.baseUrl || 'https://backend.composio.dev',
+    defaultHeaders: {
+      'x-user-api-key': userData.apiKey,
+    },
+    logLevel: 'off',
+  })
+}
+
+function normalizeComposioConnection(value: unknown): ComposioConnectionSummary | null {
+  const record = asRecord(value)
+  if (!record) return null
+  const authConfig = asRecord(record.auth_config)
+  return {
+    id: readNonEmptyString(record.id),
+    wordId: readNonEmptyString(record.word_id),
+    alias: readNonEmptyString(record.alias),
+    status: readNonEmptyString(record.status),
+    authScheme: readNonEmptyString(record.authScheme || authConfig?.auth_scheme),
+    createdAt: readNonEmptyString(record.created_at),
+    updatedAt: readNonEmptyString(record.updated_at),
+    isComposioManaged: readBoolean(authConfig?.is_composio_managed),
+    isDisabled: readBoolean(record.is_disabled),
+  }
+}
+
+function normalizeComposioToolkit(value: unknown, connectionsBySlug: Map<string, ComposioConnectionSummary[]>): ComposioConnectorSummary | null {
+  const record = asRecord(value)
+  if (!record) return null
+  const slug = readNonEmptyString(record.slug)
+  if (!slug) return null
+  const meta = asRecord(record.meta)
+  const connectionRows = connectionsBySlug.get(slug) ?? []
+  return {
+    slug,
+    name: readNonEmptyString(record.name),
+    description: readNonEmptyString(record.description || meta?.description),
+    logoUrl: readNonEmptyString(record.logo || meta?.logo),
+    latestVersion: readNonEmptyString(record.latest_version || record.latestVersion || meta?.version),
+    toolsCount: readNumber(record.tools_count ?? meta?.tools_count),
+    triggersCount: readNumber(record.triggers_count ?? meta?.triggers_count),
+    isNoAuth: readBoolean(record.is_no_auth ?? record.no_auth ?? meta?.isNoAuth),
+    enabled: record.enabled !== false,
+    authModes: Array.isArray(record.auth_modes)
+      ? record.auth_modes.map(readNonEmptyString).filter(Boolean)
+      : Array.isArray(record.auth_schemes)
+        ? record.auth_schemes.map(readNonEmptyString).filter(Boolean)
+        : [],
+    activeCount: connectionRows.filter((row) => row.status === 'ACTIVE' && !row.isDisabled).length,
+    totalConnections: connectionRows.length,
+    connectionStatuses: [...new Set(connectionRows.map((row) => row.status).filter(Boolean))],
+  }
+}
+
+function normalizeComposioTool(value: unknown): ComposioToolSummary | null {
+  const record = asRecord(value)
+  if (!record) return null
+  const slug = readNonEmptyString(record.slug)
+  if (!slug) return null
+  return {
+    slug,
+    name: readNonEmptyString(record.name),
+    description: readNonEmptyString(record.description),
+  }
+}
+
+async function readComposioConnectionsBySlug(): Promise<Map<string, ComposioConnectionSummary[]>> {
+  const payload = asRecord(await runComposioJson<Record<string, unknown>>(['connections', 'list'], 'Failed to list Composio connections'))
+  const bySlug = new Map<string, ComposioConnectionSummary[]>()
+  for (const [slug, rawRows] of Object.entries(payload ?? {})) {
+    if (!Array.isArray(rawRows)) continue
+    const rows = rawRows.map(normalizeComposioConnection).filter((row): row is ComposioConnectionSummary => row !== null)
+    bySlug.set(slug, rows)
+  }
+  return bySlug
+}
+
+async function readComposioStatus(): Promise<ComposioStatusResponse> {
+  const cliVersion = (() => {
+    const command = resolveComposioCommand()
+    if (!command) return ''
+    const invocation = getSpawnInvocation(command, ['--version'])
+    const probe = spawnSync(invocation.command, invocation.args, {
+      encoding: 'utf8',
+      windowsHide: true,
+    })
+    return probe.status === 0 ? probe.stdout.trim() : ''
+  })()
+
+  const userData = await readComposioUserData()
+  if (!resolveComposioCommand()) {
+    return {
+      available: false,
+      authenticated: false,
+      cliVersion,
+      email: '',
+      defaultOrgName: '',
+      defaultOrgId: userData?.orgId ?? '',
+      webUrl: userData?.webUrl ?? '',
+      baseUrl: userData?.baseUrl ?? '',
+      testUserId: userData?.testUserId ?? '',
+    }
+  }
+
+  try {
+    const payload = asRecord(await runComposioJson<Record<string, unknown>>(['whoami'], 'Failed to read Composio account status'))
+    return {
+      available: true,
+      authenticated: true,
+      cliVersion,
+      email: readNonEmptyString(payload?.email),
+      defaultOrgName: readNonEmptyString(payload?.default_org_name),
+      defaultOrgId: readNonEmptyString(payload?.default_org_id) || userData?.orgId || '',
+      webUrl: userData?.webUrl || 'https://dashboard.composio.dev/',
+      baseUrl: userData?.baseUrl || 'https://backend.composio.dev',
+      testUserId: readNonEmptyString(payload?.test_user_id) || userData?.testUserId || '',
+    }
+  } catch {
+    return {
+      available: true,
+      authenticated: false,
+      cliVersion,
+      email: '',
+      defaultOrgName: '',
+      defaultOrgId: userData?.orgId ?? '',
+      webUrl: userData?.webUrl || 'https://dashboard.composio.dev/',
+      baseUrl: userData?.baseUrl || 'https://backend.composio.dev',
+      testUserId: userData?.testUserId ?? '',
+    }
+  }
+}
+
+async function listComposioConnectors(query: string): Promise<ComposioConnectorSummary[]> {
+  const userData = await readComposioUserData()
+  if (!userData?.apiKey) {
+    throw new Error('Composio user data is unavailable')
+  }
+  const client = createComposioClient(userData)
+  const trimmedQuery = query.trim()
+  const [payload, connectionsBySlug] = await Promise.all([
+    client.toolkits.list({
+      limit: 250,
+      search: trimmedQuery || undefined,
+    }),
+    readComposioConnectionsBySlug(),
+  ])
+  return (Array.isArray(payload.items) ? payload.items : [])
+    .map((item) => normalizeComposioToolkit(item, connectionsBySlug))
+    .filter((row): row is ComposioConnectorSummary => row !== null)
+}
+
+async function readComposioConnectorDetail(slug: string): Promise<ComposioConnectorDetail> {
+  const normalizedSlug = slug.trim()
+  if (!normalizedSlug) {
+    throw new Error('Missing Composio connector slug')
+  }
+  const userData = await readComposioUserData()
+  if (!userData?.apiKey) {
+    throw new Error('Composio user data is unavailable')
+  }
+  const client = createComposioClient(userData)
+  const [infoPayload, toolsPayload, connectionsPayload] = await Promise.all([
+    client.toolkits.retrieve(normalizedSlug),
+    client.tools.list({ toolkit_slug: normalizedSlug, limit: 10 }),
+    runComposioJson<{ toolkit?: string; items?: unknown[] }>(['link', normalizedSlug, '--list'], `Failed to list connections for ${normalizedSlug}`),
+  ])
+  const connections = Array.isArray(connectionsPayload.items)
+    ? connectionsPayload.items.map(normalizeComposioConnection).filter((row): row is ComposioConnectionSummary => row !== null)
+    : []
+  const connector = normalizeComposioToolkit(infoPayload, new Map([[normalizedSlug, connections]]))
+  if (!connector) {
+    throw new Error(`Unknown Composio connector: ${normalizedSlug}`)
+  }
+
+  return {
+    connector,
+    connections,
+    tools: Array.isArray(toolsPayload.items)
+      ? toolsPayload.items.map(normalizeComposioTool).filter((row): row is ComposioToolSummary => row !== null)
+      : [],
+    dashboardUrl: userData?.webUrl || 'https://dashboard.composio.dev/',
+  }
+}
+
+async function startComposioLink(slug: string): Promise<ComposioLinkResult> {
+  const normalizedSlug = slug.trim()
+  if (!normalizedSlug) {
+    throw new Error('Missing Composio connector slug')
+  }
+  const userData = await readComposioUserData()
+  if (!userData?.apiKey) {
+    throw new Error('Composio user data is unavailable')
+  }
+  const consumerUserId = getComposioConsumerUserIds(userData)[0] ?? ''
+  if (!consumerUserId) {
+    throw new Error('Composio consumer user id is unavailable')
+  }
+  const client = createComposioClient(userData)
+  const session = await client.toolRouter.session.create({ user_id: consumerUserId })
+  const payload = await client.toolRouter.session.link(session.session_id, { toolkit: normalizedSlug })
+  return {
+    status: 'pending',
+    message: 'Complete authorization by opening the URL',
+    connectedAccountId: readNonEmptyString(payload.connected_account_id),
+    redirectUrl: readNonEmptyString(payload.redirect_url),
+    toolkit: normalizedSlug,
+    projectType: 'CONSUMER',
+  }
 }
 
 function countRecoveredContentLines(value: string): number {
@@ -4022,6 +4416,46 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         res.statusCode = upstream.status
         res.setHeader('Content-Type', 'application/json; charset=utf-8')
         res.end(upstream.body)
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/composio/status') {
+        try {
+          setJson(res, 200, await readComposioStatus())
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to read Composio status') })
+        }
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/composio/connectors') {
+        try {
+          const query = url.searchParams.get('query') ?? ''
+          setJson(res, 200, { data: await listComposioConnectors(query) })
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to list Composio connectors') })
+        }
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/composio/connector') {
+        try {
+          const slug = url.searchParams.get('slug') ?? ''
+          setJson(res, 200, await readComposioConnectorDetail(slug))
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to load Composio connector') })
+        }
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/composio/link') {
+        try {
+          const payload = asRecord(await readJsonBody(req))
+          const slug = readNonEmptyString(payload?.slug)
+          setJson(res, 200, await startComposioLink(slug))
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to start Composio login') })
+        }
         return
       }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -10,7 +10,6 @@ import { tmpdir } from 'node:os'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
-import Composio from '@composio/client'
 import { handleAccountRoutes } from './accountRoutes.js'
 import { buildAppServerArgs } from './appServerRuntimeConfig.js'
 import { handleReviewRoutes } from './reviewGit.js'
@@ -176,6 +175,20 @@ type ComposioLinkResult = {
   redirectUrl: string
   toolkit: string
   projectType: string
+}
+
+type ComposioLoginResult = {
+  status: string
+  message: string
+  loginUrl: string
+  cliKey: string
+  expiresAt: string
+}
+
+type ComposioInstallResult = {
+  ok: boolean
+  command: string
+  output: string
 }
 
 const PROVIDER_MODELS_FETCH_TIMEOUT_MS = 5_000
@@ -1021,33 +1034,6 @@ async function readComposioUserData(): Promise<ComposioUserData | null> {
   }
 }
 
-function getComposioConsumerUserIds(userData: ComposioUserData | null): string[] {
-  if (!userData?.testUserId || !userData.orgId) return []
-  const candidates = [
-    userData.testUserId.replace(/^pg-test-/u, ''),
-    userData.testUserId,
-  ]
-  const ids: string[] = []
-  for (const candidate of candidates) {
-    const normalized = candidate.trim()
-    if (!normalized) continue
-    const consumerId = `consumer-${normalized}-${userData.orgId}`
-    if (!ids.includes(consumerId)) ids.push(consumerId)
-  }
-  return ids
-}
-
-function createComposioClient(userData: ComposioUserData): Composio {
-  return new Composio({
-    apiKey: null,
-    baseURL: userData.baseUrl || 'https://backend.composio.dev',
-    defaultHeaders: {
-      'x-user-api-key': userData.apiKey,
-    },
-    logLevel: 'off',
-  })
-}
-
 function normalizeComposioConnection(value: unknown): ComposioConnectionSummary | null {
   const record = asRecord(value)
   if (!record) return null
@@ -1070,23 +1056,18 @@ function normalizeComposioToolkit(value: unknown, connectionsBySlug: Map<string,
   if (!record) return null
   const slug = readNonEmptyString(record.slug)
   if (!slug) return null
-  const meta = asRecord(record.meta)
   const connectionRows = connectionsBySlug.get(slug) ?? []
   return {
     slug,
     name: readNonEmptyString(record.name),
-    description: readNonEmptyString(record.description || meta?.description),
-    logoUrl: readNonEmptyString(record.logo || meta?.logo),
-    latestVersion: readNonEmptyString(record.latest_version || record.latestVersion || meta?.version),
-    toolsCount: readNumber(record.tools_count ?? meta?.tools_count),
-    triggersCount: readNumber(record.triggers_count ?? meta?.triggers_count),
-    isNoAuth: readBoolean(record.is_no_auth ?? record.no_auth ?? meta?.isNoAuth),
+    description: readNonEmptyString(record.description),
+    logoUrl: readNonEmptyString(record.logo || record.meta && asRecord(record.meta)?.logo),
+    latestVersion: readNonEmptyString(record.latest_version || record.latestVersion),
+    toolsCount: readNumber(record.tools_count),
+    triggersCount: readNumber(record.triggers_count),
+    isNoAuth: readBoolean(record.is_no_auth),
     enabled: record.enabled !== false,
-    authModes: Array.isArray(record.auth_modes)
-      ? record.auth_modes.map(readNonEmptyString).filter(Boolean)
-      : Array.isArray(record.auth_schemes)
-        ? record.auth_schemes.map(readNonEmptyString).filter(Boolean)
-        : [],
+    authModes: Array.isArray(record.auth_modes) ? record.auth_modes.map(readNonEmptyString).filter(Boolean) : [],
     activeCount: connectionRows.filter((row) => row.status === 'ACTIVE' && !row.isDisabled).length,
     totalConnections: connectionRows.length,
     connectionStatuses: [...new Set(connectionRows.map((row) => row.status).filter(Boolean))],
@@ -1172,20 +1153,16 @@ async function readComposioStatus(): Promise<ComposioStatusResponse> {
 }
 
 async function listComposioConnectors(query: string): Promise<ComposioConnectorSummary[]> {
-  const userData = await readComposioUserData()
-  if (!userData?.apiKey) {
-    throw new Error('Composio user data is unavailable')
-  }
-  const client = createComposioClient(userData)
+  const args = ['dev', 'toolkits', 'list', '--limit', '250']
   const trimmedQuery = query.trim()
+  if (trimmedQuery) {
+    args.push('--query', trimmedQuery)
+  }
   const [payload, connectionsBySlug] = await Promise.all([
-    client.toolkits.list({
-      limit: 250,
-      search: trimmedQuery || undefined,
-    }),
+    runComposioJson<unknown[]>(args, 'Failed to list Composio toolkits'),
     readComposioConnectionsBySlug(),
   ])
-  return (Array.isArray(payload.items) ? payload.items : [])
+  return payload
     .map((item) => normalizeComposioToolkit(item, connectionsBySlug))
     .filter((row): row is ComposioConnectorSummary => row !== null)
 }
@@ -1195,16 +1172,14 @@ async function readComposioConnectorDetail(slug: string): Promise<ComposioConnec
   if (!normalizedSlug) {
     throw new Error('Missing Composio connector slug')
   }
-  const userData = await readComposioUserData()
-  if (!userData?.apiKey) {
-    throw new Error('Composio user data is unavailable')
-  }
-  const client = createComposioClient(userData)
-  const [infoPayload, toolsPayload, connectionsPayload] = await Promise.all([
-    client.toolkits.retrieve(normalizedSlug),
-    client.tools.list({ toolkit_slug: normalizedSlug, limit: 10 }),
+
+  const [infoPayload, toolsPayload, connectionsPayload, userData] = await Promise.all([
+    runComposioJson<Record<string, unknown>>(['dev', 'toolkits', 'info', normalizedSlug], `Failed to load Composio toolkit ${normalizedSlug}`),
+    runComposioJson<unknown[]>(['tools', 'list', normalizedSlug, '--limit', '10'], `Failed to list tools for ${normalizedSlug}`),
     runComposioJson<{ toolkit?: string; items?: unknown[] }>(['link', normalizedSlug, '--list'], `Failed to list connections for ${normalizedSlug}`),
+    readComposioUserData(),
   ])
+
   const connections = Array.isArray(connectionsPayload.items)
     ? connectionsPayload.items.map(normalizeComposioConnection).filter((row): row is ComposioConnectionSummary => row !== null)
     : []
@@ -1216,8 +1191,8 @@ async function readComposioConnectorDetail(slug: string): Promise<ComposioConnec
   return {
     connector,
     connections,
-    tools: Array.isArray(toolsPayload.items)
-      ? toolsPayload.items.map(normalizeComposioTool).filter((row): row is ComposioToolSummary => row !== null)
+    tools: Array.isArray(toolsPayload)
+      ? toolsPayload.map(normalizeComposioTool).filter((row): row is ComposioToolSummary => row !== null)
       : [],
     dashboardUrl: userData?.webUrl || 'https://dashboard.composio.dev/',
   }
@@ -1228,24 +1203,54 @@ async function startComposioLink(slug: string): Promise<ComposioLinkResult> {
   if (!normalizedSlug) {
     throw new Error('Missing Composio connector slug')
   }
-  const userData = await readComposioUserData()
-  if (!userData?.apiKey) {
-    throw new Error('Composio user data is unavailable')
-  }
-  const consumerUserId = getComposioConsumerUserIds(userData)[0] ?? ''
-  if (!consumerUserId) {
-    throw new Error('Composio consumer user id is unavailable')
-  }
-  const client = createComposioClient(userData)
-  const session = await client.toolRouter.session.create({ user_id: consumerUserId })
-  const payload = await client.toolRouter.session.link(session.session_id, { toolkit: normalizedSlug })
+  const payload = asRecord(await runComposioJson<Record<string, unknown>>(['link', normalizedSlug, '--no-wait'], `Failed to start Composio link for ${normalizedSlug}`))
   return {
-    status: 'pending',
-    message: 'Complete authorization by opening the URL',
-    connectedAccountId: readNonEmptyString(payload.connected_account_id),
-    redirectUrl: readNonEmptyString(payload.redirect_url),
-    toolkit: normalizedSlug,
-    projectType: 'CONSUMER',
+    status: readNonEmptyString(payload?.status),
+    message: readNonEmptyString(payload?.message),
+    connectedAccountId: readNonEmptyString(payload?.connected_account_id),
+    redirectUrl: readNonEmptyString(payload?.redirect_url),
+    toolkit: readNonEmptyString(payload?.toolkit),
+    projectType: readNonEmptyString(payload?.project_type),
+  }
+}
+
+async function startComposioLogin(): Promise<ComposioLoginResult> {
+  const payload = asRecord(await runComposioJson<Record<string, unknown>>(
+    ['login', '--no-wait', '--no-skill-install', '-y'],
+    'Failed to start Composio login',
+  ))
+  return {
+    status: readNonEmptyString(payload?.status),
+    message: readNonEmptyString(payload?.message),
+    loginUrl: readNonEmptyString(payload?.login_url),
+    cliKey: readNonEmptyString(payload?.cli_key),
+    expiresAt: readNonEmptyString(payload?.expires_at),
+  }
+}
+
+async function installComposioCli(): Promise<ComposioInstallResult> {
+  const homeBin = join(homedir(), '.npm-global', 'bin')
+  const command = 'npm'
+  const args = ['install', '-g', '@composio/cli@latest']
+  const invocation = getSpawnInvocation(command, args)
+  const env = {
+    ...process.env,
+    npm_config_prefix: process.env.npm_config_prefix?.trim() || join(homedir(), '.npm-global'),
+    PATH: process.env.PATH ? `${homeBin}:${process.env.PATH}` : homeBin,
+  }
+  const result = spawnSync(invocation.command, invocation.args, {
+    encoding: 'utf8',
+    env,
+    windowsHide: true,
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+  if (result.error || result.status !== 0) {
+    throw new Error(output || result.error?.message || 'Failed to install Composio CLI')
+  }
+  return {
+    ok: true,
+    command: `${command} ${args.join(' ')}`,
+    output,
   }
 }
 
@@ -4455,6 +4460,24 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           setJson(res, 200, await startComposioLink(slug))
         } catch (error) {
           setJson(res, 500, { error: getErrorMessage(error, 'Failed to start Composio login') })
+        }
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/composio/login') {
+        try {
+          setJson(res, 200, await startComposioLogin())
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to start Composio CLI login') })
+        }
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/composio/install') {
+        try {
+          setJson(res, 200, await installComposioCli())
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to install Composio CLI') })
         }
         return
       }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1215,16 +1215,25 @@ async function startComposioLink(slug: string): Promise<ComposioLinkResult> {
 }
 
 async function startComposioLogin(): Promise<ComposioLoginResult> {
-  const payload = asRecord(await runComposioJson<Record<string, unknown>>(
-    ['login', '--no-wait', '--no-skill-install', '-y'],
-    'Failed to start Composio login',
-  ))
+  const command = resolveComposioCommand()
+  if (!command) {
+    throw new Error('Composio CLI is not installed')
+  }
+  const invocation = getSpawnInvocation(command, ['login', '-y'])
+  const proc = spawn(invocation.command, invocation.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  proc.unref()
   return {
-    status: readNonEmptyString(payload?.status),
-    message: readNonEmptyString(payload?.message),
-    loginUrl: readNonEmptyString(payload?.login_url),
-    cliKey: readNonEmptyString(payload?.cli_key),
-    expiresAt: readNonEmptyString(payload?.expires_at),
+    status: 'started',
+    message: 'Composio CLI login started',
+    loginUrl: '',
+    cliKey: '',
+    expiresAt: '',
   }
 }
 

--- a/tests.md
+++ b/tests.md
@@ -3191,7 +3191,7 @@ Playwright browser runtime profiler captures route timing, Codex API network cou
 ### Codex.app-style Plugins Directory
 
 #### Feature/Change Name
-The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MCPs, and Skills tabs.
+The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Composio, MCPs, and Skills tabs.
 
 #### Prerequisites/Setup
 1. Dev server running at `http://127.0.0.1:4173`
@@ -3200,7 +3200,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 
 #### Steps
 1. Open `http://127.0.0.1:4173/#/skills`
-2. Verify the page title is `Skills & Apps` and the tab row contains `Plugins`, `Apps`, `MCPs`, and `Skills`
+2. Verify the page title is `Skills & Apps` and the tab row contains `Plugins`, `Apps`, `Composio`, `MCPs`, and `Skills`
 3. On `Plugins`, verify plugin cards load, the default sort is `Popular`, and `A-Z`, `Date`, and search controls work
 4. Open a plugin card when one is available and verify description, capabilities, included apps/skills/MCPs, and install/uninstall or enable/disable actions are visible
 5. For an installed plugin with bundled MCP servers, such as Cloudflare, verify each MCP row shows auth status (`Logged in`, `Bearer token`, `Login required`, `Auth unsupported`, or `Status unknown`)
@@ -3215,9 +3215,14 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 14. Install a plugin whose install response includes `appsNeedingAuth`, and verify the first required app login/manage URL opens automatically
 15. Switch Apps sorting to `A-Z` and verify apps reorder alphabetically; switch to `Date` and verify app-server catalog order is restored; switch back to `Popular` and verify casual-user relevant apps are prioritized and capped to 100 when no search is active
 16. Search Apps and verify matching results are not capped to the Popular top 100 list
-17. Switch to `MCPs` and verify MCP server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
-18. Verify MCPs also support `Popular`, `A-Z`, `Date`, and search
-19. Switch to `Skills` and verify existing Skills Hub search, install, uninstall, sync, and enable/disable behavior still works
+17. Switch to `Composio` and verify the workspace summary card shows the current Composio CLI login state, or a clear not-installed / not-authenticated message appears
+18. Verify Composio connector cards show real connector details such as tool counts, trigger counts, auth mode, and connection state instead of only aggregate totals
+19. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
+20. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
+21. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
+22. Switch to `MCPs` and verify MCP server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
+23. Verify MCPs also support `Popular`, `A-Z`, `Date`, and search
+24. Switch to `Skills` and verify existing Skills Hub search, install, uninstall, sync, and enable/disable behavior still works
 
 #### Expected Results
 - The directory tabs render without a full-page error
@@ -3226,6 +3231,9 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, MC
 - App and plugin enable/disable actions update their local card state after a successful config write
 - Plugin detail shows bundled MCP login state and can launch MCP OAuth for `notLoggedIn` servers
 - Disconnected apps are labeled `Login`; connected apps are labeled `Manage`
+- The Composio tab reuses the authenticated local Composio CLI state and does not require a separate app-specific login
+- Composio connector cards and detail views show concrete connector details, connection rows, and useful tool samples
+- Connected or no-auth Composio connectors expose `Try it!`, creating a new chat with the `composio-cli` skill attached
 - Plugin install opens the first required app login/manage page before falling back to bundled MCP OAuth login
 - Connected and enabled apps, plus installed/enabled plugins/skills, expose `Try it!`, creating a new chat with an auto-submitted test prompt
 - Repeated `Try it!` clicks during startup are ignored until the first request resolves, so duplicate threads are not created


### PR DESCRIPTION
## Summary
- add a native Composio directory tab with connector detail and try-from-chat actions
- add server-side Composio status/list/detail/login/install endpoints backed by the local CLI state
- add explicit install/login empty-state actions and update directory test docs

## Testing
- pnpm run build
- pnpm run build:frontend
- curl /codex-api/composio/status
- curl /codex-api/composio/connectors
- curl /codex-api/composio/connector?slug=gmail
- curl -X POST /codex-api/composio/link
