### PR TITLE
feat: page Composio connectors with cursor

### DIFF
--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -231,6 +231,12 @@ export type DirectoryComposioInstallResult = {
   output: string
 }
 
+type DirectoryComposioConnectorPage = {
+  data: DirectoryComposioConnector[]
+  nextCursor: string | null
+  total: number
+}
+
 type ProviderModelsResponse = {
   data?: unknown
 }
@@ -1969,16 +1975,26 @@ export async function getDirectoryComposioStatus(): Promise<DirectoryComposioSta
   return await response.json() as DirectoryComposioStatus
 }
 
-export async function listDirectoryComposioConnectors(query = ''): Promise<DirectoryComposioConnector[]> {
+export async function listDirectoryComposioConnectors(
+  query = '',
+  cursor: string | null = null,
+  limit = 50,
+): Promise<DirectoryComposioConnectorPage> {
   const params = new URLSearchParams()
   if (query.trim()) params.set('query', query.trim())
+  if (cursor) params.set('cursor', cursor)
+  if (limit && Number.isFinite(limit)) params.set('limit', String(Math.max(1, Math.floor(limit))))
   const suffix = params.toString()
   const response = await fetch(`/codex-api/composio/connectors${suffix ? `?${suffix}` : ''}`)
   if (!response.ok) {
     throw new Error(`Failed to list Composio connectors (${response.status})`)
   }
-  const payload = await response.json() as { data?: DirectoryComposioConnector[] }
-  return Array.isArray(payload.data) ? payload.data : []
+  const payload = await response.json() as DirectoryComposioConnectorPage | { data?: DirectoryComposioConnector[]; nextCursor?: string | null; total?: number }
+  return {
+    data: Array.isArray(payload.data) ? payload.data : [],
+    nextCursor: typeof payload.nextCursor === 'string' && payload.nextCursor.length > 0 ? payload.nextCursor : null,
+    total: typeof payload.total === 'number' && Number.isFinite(payload.total) ? Math.max(0, Math.floor(payload.total)) : 0,
+  }
 }
 
 export async function readDirectoryComposioConnector(slug: string): Promise<DirectoryComposioConnectorDetail> {

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -264,11 +264,13 @@
           <p class="directory-card-description">
             {{ composioWorkspaceSummary }}
           </p>
-          <div class="directory-chip-row">
-            <span v-if="composioStatus.defaultOrgName" class="directory-chip">{{ composioStatus.defaultOrgName }}</span>
-            <span v-if="composioStatus.cliVersion" class="directory-chip">CLI {{ composioStatus.cliVersion }}</span>
-            <span v-if="composioConnectors.length" class="directory-chip">{{ composioConnectors.length }} connectors</span>
-          </div>
+            <div class="directory-chip-row">
+              <span v-if="composioStatus.defaultOrgName" class="directory-chip">{{ composioStatus.defaultOrgName }}</span>
+              <span v-if="composioStatus.cliVersion" class="directory-chip">CLI {{ composioStatus.cliVersion }}</span>
+              <span v-if="composioConnectors.length" class="directory-chip">
+                Showing {{ composioConnectors.length }}{{ composioTotal ? ` / ${composioTotal}` : '' }} connectors
+              </span>
+            </div>
           <div class="directory-card-actions">
             <button class="directory-action-link" type="button" @click="openExternalUrl(composioStatus.webUrl)">
               Open dashboard
@@ -321,6 +323,16 @@
               </button>
             </div>
           </article>
+        </div>
+        <div v-if="hasMoreComposioConnectors" class="directory-section-actions">
+          <button
+            class="directory-action"
+            type="button"
+            :disabled="isLoadingComposio"
+            @click="loadMoreComposio"
+          >
+            {{ isLoadingComposio ? 'Loading...' : 'Load more' }}
+          </button>
         </div>
       </div>
     </section>
@@ -641,6 +653,7 @@ import SkillsHub from './SkillsHub.vue'
 type DirectoryTab = 'plugins' | 'apps' | 'composio' | 'skills'
 type DirectorySortMode = 'popular' | 'name' | 'date'
 const COMPOSIO_SKILL_PATH = '/Users/igor/.codex/skills/shared_skills/composio-cli/SKILL.md'
+const COMPOSIO_PAGE_LIMIT = 50
 
 const POPULAR_LIMIT = 100
 const POPULAR_APP_NAME_BONUSES: Array<[RegExp, number]> = [
@@ -726,6 +739,8 @@ const plugins = ref<DirectoryPluginSummary[]>([])
 const apps = ref<DirectoryAppInfo[]>([])
 const composioStatus = ref<DirectoryComposioStatus | null>(null)
 const composioConnectors = ref<DirectoryComposioConnector[]>([])
+const composioNextCursor = ref<string | null>(null)
+const composioTotal = ref(0)
 const mcpServers = ref<DirectoryMcpServerStatus[]>([])
 const pluginSortMode = ref<DirectorySortMode>('popular')
 const appSortMode = ref<DirectorySortMode>('popular')
@@ -795,8 +810,9 @@ const selectedPluginScreenshots = computed(() => {
 })
 const visiblePlugins = computed(() => limitPopularRows(sortPlugins(filterPlugins(plugins.value, pluginSearchQuery.value), pluginSortMode.value), pluginSortMode.value, pluginSearchQuery.value))
 const visibleApps = computed(() => limitPopularApps(sortApps(filterApps(apps.value, appSearchQuery.value), appSortMode.value), appSortMode.value, appSearchQuery.value))
-const visibleComposioConnectors = computed(() => limitPopularRows(sortComposioConnectors(filterComposioConnectors(composioConnectors.value, composioSearchQuery.value), composioSortMode.value), composioSortMode.value, composioSearchQuery.value))
+const visibleComposioConnectors = computed(() => sortComposioConnectors(filterComposioConnectors(composioConnectors.value, composioSearchQuery.value), composioSortMode.value))
 const visibleMcpServers = computed(() => sortMcpServers(mcpServers.value, 'popular'))
+const hasMoreComposioConnectors = computed(() => composioNextCursor.value !== null)
 const mcpStatusByName = computed(() => new Map(mcpServers.value.map((server) => [server.name, server])))
 const composioWorkspaceSummary = computed(() => {
   const status = composioStatus.value
@@ -1172,7 +1188,7 @@ async function loadApps(): Promise<void> {
   }
 }
 
-async function loadComposio(): Promise<void> {
+async function loadComposio(append = false): Promise<void> {
   if (isLoadingComposio.value) {
     isComposioLoadQueued = true
     return
@@ -1185,12 +1201,20 @@ async function loadComposio(): Promise<void> {
     composioStatus.value = status
     if (!status.available || !status.authenticated) {
       composioConnectors.value = []
+      composioNextCursor.value = null
+      composioTotal.value = 0
       return
     }
-    const connectors = await listDirectoryComposioConnectors(composioSearchQuery.value)
-    composioConnectors.value = connectors
+    const cursor = append ? composioNextCursor.value : null
+    const page = await listDirectoryComposioConnectors(composioSearchQuery.value, cursor, COMPOSIO_PAGE_LIMIT)
+    composioConnectors.value = append ? [...composioConnectors.value, ...page.data] : page.data
+    composioNextCursor.value = page.nextCursor
+    composioTotal.value = page.total
   } catch (error) {
     composioError.value = error instanceof Error ? error.message : 'Failed to load Composio connectors'
+    composioConnectors.value = []
+    composioNextCursor.value = null
+    composioTotal.value = 0
   } finally {
     isLoadingComposio.value = false
     if (isComposioLoadQueued) {
@@ -1198,6 +1222,11 @@ async function loadComposio(): Promise<void> {
       void loadComposio()
     }
   }
+}
+
+async function loadMoreComposio(): Promise<void> {
+  if (!hasMoreComposioConnectors.value || isLoadingComposio.value) return
+  await loadComposio(true)
 }
 
 async function loadMcps(): Promise<void> {
@@ -1451,6 +1480,9 @@ function toggleMcpExpanded(name: string): void {
 watch(activeTab, () => refreshActiveTab())
 watch(composioSearchQuery, () => {
   if (activeTab.value !== 'composio') return
+  composioConnectors.value = []
+  composioNextCursor.value = null
+  composioTotal.value = 0
   if (composioSearchTimer) {
     clearTimeout(composioSearchTimer)
   }

--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -762,6 +762,8 @@ const mcpLoginServerName = ref('')
 const expandedMcpNames = ref<Set<string>>(new Set())
 const toast = ref<{ text: string; type: 'success' | 'error' } | null>(null)
 let toastTimer: ReturnType<typeof setTimeout> | null = null
+let composioSearchTimer: ReturnType<typeof setTimeout> | null = null
+let isComposioLoadQueued = false
 
 const activeCopy = computed(() => tabs.find((tab) => tab.id === activeTab.value) ?? tabs[0])
 const supportsPlugins = computed(() =>
@@ -1171,6 +1173,11 @@ async function loadApps(): Promise<void> {
 }
 
 async function loadComposio(): Promise<void> {
+  if (isLoadingComposio.value) {
+    isComposioLoadQueued = true
+    return
+  }
+
   isLoadingComposio.value = true
   composioError.value = ''
   try {
@@ -1186,6 +1193,10 @@ async function loadComposio(): Promise<void> {
     composioError.value = error instanceof Error ? error.message : 'Failed to load Composio connectors'
   } finally {
     isLoadingComposio.value = false
+    if (isComposioLoadQueued) {
+      isComposioLoadQueued = false
+      void loadComposio()
+    }
   }
 }
 
@@ -1438,6 +1449,15 @@ function toggleMcpExpanded(name: string): void {
 }
 
 watch(activeTab, () => refreshActiveTab())
+watch(composioSearchQuery, () => {
+  if (activeTab.value !== 'composio') return
+  if (composioSearchTimer) {
+    clearTimeout(composioSearchTimer)
+  }
+  composioSearchTimer = setTimeout(() => {
+    void loadComposio()
+  }, 250)
+})
 watch(() => props.cwd, () => {
   if (activeTab.value === 'plugins') void loadPlugins()
 })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1144,7 +1144,8 @@ async function readComposioStatus(): Promise<ComposioStatusResponse> {
 }
 
 async function listComposioConnectors(query: string): Promise<ComposioConnectorSummary[]> {
-  const args = ['dev', 'toolkits', 'list', '--limit', '250']
+  const limit = query.trim().length > 0 ? '50' : '250'
+  const args = ['dev', 'toolkits', 'list', '--limit', limit]
   const trimmedQuery = query.trim()
   if (trimmedQuery) {
     args.push('--query', trimmedQuery)

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -182,6 +182,14 @@ type ComposioInstallResult = {
   output: string
 }
 
+type ComposioConnectorPage = {
+  data: ComposioConnectorSummary[]
+  nextCursor: string | null
+  total: number
+}
+
+const COMPOSIO_CONNECTORS_PAGE_LIMIT_MAX = 1000
+
 const PROVIDER_MODELS_FETCH_TIMEOUT_MS = 5_000
 
 const THREAD_RESPONSE_TURN_LIMIT = 10
@@ -1143,9 +1151,8 @@ async function readComposioStatus(): Promise<ComposioStatusResponse> {
   }
 }
 
-async function listComposioConnectors(query: string): Promise<ComposioConnectorSummary[]> {
-  const limit = query.trim().length > 0 ? '50' : '250'
-  const args = ['dev', 'toolkits', 'list', '--limit', limit]
+async function listComposioConnectors(query: string, cursor: string | null = null, limit = 50): Promise<ComposioConnectorPage> {
+  const args = ['dev', 'toolkits', 'list', '--limit', String(COMPOSIO_CONNECTORS_PAGE_LIMIT_MAX)]
   const trimmedQuery = query.trim()
   if (trimmedQuery) {
     args.push('--query', trimmedQuery)
@@ -1154,9 +1161,30 @@ async function listComposioConnectors(query: string): Promise<ComposioConnectorS
     runComposioJson<unknown[]>(args, 'Failed to list Composio toolkits'),
     readComposioConnectionsBySlug(),
   ])
-  return payload
+  const allRows = payload
     .map((item) => normalizeComposioToolkit(item, connectionsBySlug))
     .filter((row): row is ComposioConnectorSummary => row !== null)
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(COMPOSIO_CONNECTORS_PAGE_LIMIT_MAX, Math.floor(limit))) : 50
+  const safeCursor = parseComposioCursor(cursor, allRows.length)
+  return {
+    data: allRows.slice(safeCursor, safeCursor + safeLimit),
+    nextCursor: safeCursor + safeLimit < allRows.length ? String(safeCursor + safeLimit) : null,
+    total: allRows.length,
+  }
+}
+
+function parseComposioCursor(cursor: string | null | undefined, maxLength: number): number {
+  const trimmed = cursor?.trim() ?? ''
+  const parsed = Number.parseInt(trimmed, 10)
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) return 0
+  if (parsed >= maxLength) return maxLength
+  return parsed
+}
+
+function parseComposioLimit(rawLimit: string | null): number {
+  const parsed = Number.parseInt((rawLimit ?? '').trim(), 10)
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) return 50
+  return Math.max(1, Math.min(COMPOSIO_CONNECTORS_PAGE_LIMIT_MAX, parsed))
 }
 
 async function readComposioConnectorDetail(slug: string): Promise<ComposioConnectorDetail> {
@@ -4402,7 +4430,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       if (req.method === 'GET' && url.pathname === '/codex-api/composio/connectors') {
         try {
           const query = url.searchParams.get('query') ?? ''
-          setJson(res, 200, { data: await listComposioConnectors(query) })
+          const cursor = url.searchParams.get('cursor')?.trim() ?? null
+          const limit = parseComposioLimit(url.searchParams.get('limit'))
+          setJson(res, 200, await listComposioConnectors(query, cursor, limit))
         } catch (error) {
           setJson(res, 500, { error: getErrorMessage(error, 'Failed to list Composio connectors') })
         }

--- a/tests.md
+++ b/tests.md
@@ -3213,17 +3213,19 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Co
 16. Search Apps and verify matching results are not capped to the Popular top 100 list
 17. Switch to `Composio` and verify the workspace summary card shows the current Composio CLI login state, or a clear not-installed / not-authenticated message appears
 18. Verify Composio connector cards show real connector details such as tool counts, trigger counts, auth mode, and connection state instead of only aggregate totals
-19. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
-20. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
-21. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
-22. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
-23. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
-24. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
-25. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
-26. Verify the `MCPs(count)` section does not show its own search or sort controls
-27. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
-28. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
-29. In dark theme, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
+19. In Composio search, type `instagram` and verify the Instagram connector appears in the results
+20. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
+21. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
+22. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
+23. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
+24. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
+25. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
+26. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
+27. Verify the `MCPs(count)` section does not show its own search or sort controls
+28. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
+29. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
+30. Verify both light and dark themes render Composio cards and status/detail actions with readable contrast
+31. In dark mode, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
 
 #### Expected Results
 - The directory tabs render without a full-page error

--- a/tests.md
+++ b/tests.md
@@ -3217,15 +3217,17 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Co
 20. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
 21. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
 22. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
-23. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
-24. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
-25. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
-26. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
-27. Verify the `MCPs(count)` section does not show its own search or sort controls
-28. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
-29. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
-30. Verify both light and dark themes render Composio cards and status/detail actions with readable contrast
-31. In dark mode, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
+23. On Composio, verify that if more than one page exists, `Load more` appears and appends additional connectors while keeping prior results visible
+24. In Composio search, verify the page state resets (the list returns to the first result page and stale pagination is cleared)
+25. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
+26. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
+27. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
+28. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
+29. Verify the `MCPs(count)` section does not show its own search or sort controls
+30. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
+31. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
+32. Verify both light and dark themes render Composio cards and status/detail actions with readable contrast
+33. In dark mode, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
 
 #### Expected Results
 - The directory tabs render without a full-page error
@@ -3237,6 +3239,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Co
 - The Composio tab reuses the authenticated local Composio CLI state and does not require a separate app-specific login
 - Composio connector cards and detail views show concrete connector details, connection rows, and useful tool samples
 - Connected or no-auth Composio connectors expose `Try it!`, creating a new chat with the `composio-cli` skill attached
+- Composio pagination supports page-by-page loading with a clear `Load more` path and cursor-based page continuation
 - Plugin install opens the first required app login/manage page before falling back to bundled MCP OAuth login
 - Connected and enabled apps, plus installed/enabled plugins/skills, expose `Try it!`, creating a new chat with an auto-submitted test prompt
 - Repeated `Try it!` clicks during startup are ignored until the first request resolves, so duplicate threads are not created


### PR DESCRIPTION
Add cursor-based pagination for Composio connectors in Skills & Apps Composio tab, passing query/cursor/limit through gateway and server, add load-more UX, and update manual test steps.