### PR TITLE
Preserve selected model per thread across refresh

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -570,13 +570,22 @@
                       </div>
                       <p class="new-thread-open-folder-label">{{ t('Current folder') }}</p>
                       <div class="new-thread-open-folder-current">
-                        <p class="new-thread-open-folder-path" :title="existingFolderBrowsePath || t('Unavailable')">
-                          {{ existingFolderBrowsePath || t('Unavailable') }}
-                        </p>
+                        <input
+                          ref="existingFolderPathInputRef"
+                          v-model="existingFolderPathDraft"
+                          class="new-thread-open-folder-path"
+                          type="text"
+                          :placeholder="t('Current folder')"
+                          :title="existingFolderPathDraft || t('Unavailable')"
+                          :disabled="isExistingFolderLoading || isOpeningExistingFolder"
+                          @blur="onExistingFolderPathBlur"
+                          @keydown.enter.prevent="onSubmitExistingFolderPath"
+                          @keydown.esc.prevent="onCloseExistingFolderPanel"
+                        />
                         <button
                           class="new-thread-folder-action new-thread-folder-action-primary"
                           type="button"
-                          :disabled="!existingFolderBrowsePath || !!existingFolderError || isExistingFolderLoading || isOpeningExistingFolder"
+                          :disabled="!resolvedExistingFolderPath || isExistingFolderLoading || isOpeningExistingFolder"
                           @click="onConfirmExistingFolder()"
                         >
                           {{ isOpeningExistingFolder ? t('Opening…') : t('Open') }}
@@ -1192,7 +1201,9 @@ const createFolderDraft = ref('')
 const createFolderError = ref('')
 const isCreatingFolder = ref(false)
 const isExistingFolderPickerOpen = ref(false)
+const existingFolderPathInputRef = ref<HTMLInputElement | null>(null)
 const existingFolderFilterInputRef = ref<HTMLInputElement | null>(null)
+const existingFolderPathDraft = ref('')
 const existingFolderBrowsePath = ref('')
 const existingFolderParentPath = ref('')
 const existingFolderEntries = ref<LocalDirectoryEntry[]>([])
@@ -1443,6 +1454,11 @@ const isCreateFolderNameValid = computed(() => {
 })
 const canCreateFolder = computed(() => {
   return isCreateFolderNameValid.value && createFolderParentPath.value.trim().length > 0 && !existingFolderError.value
+})
+const resolvedExistingFolderPath = computed(() => {
+  const draftedPath = normalizePathForUi(existingFolderPathDraft.value).trim()
+  if (draftedPath) return draftedPath
+  return existingFolderBrowsePath.value.trim()
 })
 const createFolderSubmitLabel = computed(() => {
   if (isCreatingFolder.value) return 'Creating…'
@@ -2417,7 +2433,7 @@ async function onOpenExistingFolder(): Promise<void> {
   existingFolderFilter.value = ''
   await loadExistingFolderListing(startPath)
   if (!existingFolderError.value) {
-    void nextTick(() => existingFolderFilterInputRef.value?.focus())
+    void nextTick(() => existingFolderPathInputRef.value?.focus())
   }
 }
 
@@ -2427,6 +2443,7 @@ function onCloseExistingFolderPanel(): void {
   isExistingFolderLoading.value = false
   existingFolderError.value = ''
   existingFolderFilter.value = ''
+  existingFolderPathDraft.value = ''
   onCloseCreateFolderPanel()
 }
 
@@ -2443,13 +2460,32 @@ function onToggleHiddenFolders(): void {
 }
 
 function onRetryExistingFolderBrowse(): void {
-  const currentPath = existingFolderBrowsePath.value.trim()
+  const currentPath = resolvedExistingFolderPath.value
   if (!isExistingFolderPickerOpen.value || !currentPath || isExistingFolderLoading.value) return
   void loadExistingFolderListing(currentPath)
 }
 
-async function onConfirmExistingFolder(path = existingFolderBrowsePath.value): Promise<void> {
-  const targetPath = path.trim()
+function onExistingFolderPathBlur(): void {
+  if (!isExistingFolderPickerOpen.value || isExistingFolderLoading.value || isOpeningExistingFolder.value) return
+  const draftedPath = resolvedExistingFolderPath.value
+  const currentPath = existingFolderBrowsePath.value.trim()
+  if (!draftedPath || draftedPath === currentPath) return
+  void loadExistingFolderListing(draftedPath)
+}
+
+function onSubmitExistingFolderPath(): void {
+  const draftedPath = resolvedExistingFolderPath.value
+  const currentPath = existingFolderBrowsePath.value.trim()
+  if (!draftedPath) return
+  if (draftedPath !== currentPath) {
+    void loadExistingFolderListing(draftedPath)
+    return
+  }
+  void onConfirmExistingFolder(draftedPath)
+}
+
+async function onConfirmExistingFolder(path = resolvedExistingFolderPath.value): Promise<void> {
+  const targetPath = normalizePathForUi(path).trim()
   if (!targetPath) return
 
   existingFolderError.value = ''
@@ -2630,13 +2666,16 @@ async function loadWorkspaceRootOptionsState(): Promise<void> {
 
 async function loadExistingFolderListing(path: string): Promise<void> {
   const requestId = ++existingFolderBrowseRequestId
-  existingFolderBrowsePath.value = normalizePathForUi(path).trim()
+  const normalizedRequestedPath = normalizePathForUi(path).trim()
+  existingFolderPathDraft.value = normalizedRequestedPath
+  existingFolderBrowsePath.value = normalizedRequestedPath
   existingFolderError.value = ''
   isExistingFolderLoading.value = true
 
   try {
     const listing = await listLocalDirectories(path, { showHidden: showHiddenFolders.value })
     if (requestId !== existingFolderBrowseRequestId) return
+    existingFolderPathDraft.value = listing.path
     existingFolderBrowsePath.value = listing.path
     existingFolderParentPath.value = listing.parentPath
     existingFolderEntries.value = listing.entries
@@ -3822,7 +3861,7 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .new-thread-open-folder-path {
-  @apply m-0 min-w-0 flex-1 rounded-xl bg-zinc-100 px-3 py-2 font-mono text-xs text-zinc-700 break-all;
+  @apply min-w-0 flex-1 rounded-xl border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-700 outline-none transition focus:border-zinc-400;
 }
 
 .new-thread-open-folder-actions {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1735,6 +1735,10 @@ export function useDesktopState() {
 
   function pruneThreadScopedState(flatThreads: UiThread[]): void {
     const activeThreadIds = new Set(flatThreads.map((thread) => thread.id))
+    const currentThreadId = selectedThreadId.value.trim()
+    if (currentThreadId) {
+      activeThreadIds.add(currentThreadId)
+    }
     const nextSelectedModelMap = pruneThreadContextStateMap(selectedModelIdByContext.value, activeThreadIds)
     if (nextSelectedModelMap !== selectedModelIdByContext.value) {
       selectedModelIdByContext.value = nextSelectedModelMap

--- a/tests.md
+++ b/tests.md
@@ -3565,3 +3565,35 @@ The composer control row shows a `Prompt` dropdown next to `Skills`, both menus 
 
 #### Rollback/Cleanup
 - Delete any temporary verification prompt created during the test
+
+---
+
+### Editable current folder path in the folder picker
+
+#### Feature/Change Name
+The `Select folder` dialog now lets the user edit the current folder path directly, reload that folder on `Enter` or blur, and open the typed path without first clicking a child row.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Open the home/new-thread route
+3. Have at least two accessible local directories available for navigation
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open the `Select folder` dialog from the new-thread folder chooser
+2. Confirm the `Current folder` field is an editable text input instead of static text
+3. Type a different absolute path and press `Enter`
+4. Confirm the folder list reloads for the typed path
+5. Edit the path again, click outside the input, and confirm blur also reloads the listing
+6. Type a valid absolute path and click `Open`
+7. Reopen the dialog, switch to dark theme, and confirm the editable current-folder input remains readable and focusable
+
+#### Expected Results
+- The current-folder path can be typed into directly
+- Pressing `Enter` on a changed path reloads the folder listing for that path
+- Blurring a changed path also reloads the folder listing for that path
+- Clicking `Open` uses the typed path when it is valid
+- The input remains readable and has visible focus treatment in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Return the chooser to the original folder if the test changed the selected project path


### PR DESCRIPTION
## Summary
- Preserve current selected thread ID when pruning thread-scoped model state so selected-thread model preference survives partial thread list updates
- Keep new-thread current-folder path editable in the folder picker with blur/enter reload and open support
- Update tests.md with manual verification steps including light/dark theme checks

## Verification
- Model selection on thread persisted after page refresh in light and dark themes (manual Playwright verification completed).