### PR TITLE
[codex] Refresh ChatGPT auth tokens for external auth

### DIFF
--- a/src/server/codexAppServerBridge.authRefresh.test.ts
+++ b/src/server/codexAppServerBridge.authRefresh.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { refreshChatgptAuthTokensForExternalAuth } from './codexAppServerBridge'
+
+const originalCodexHome = process.env.CODEX_HOME
+const originalRefreshUrlOverride = process.env.CODEX_REFRESH_TOKEN_URL_OVERRIDE
+const tempDirs: string[] = []
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (typeof value === 'string') {
+    process.env[key] = value
+    return
+  }
+  delete process.env[key]
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64')
+    .replace(/=/gu, '')
+    .replace(/\+/gu, '-')
+    .replace(/\//gu, '_')
+}
+
+function unsignedJwt(payload: unknown): string {
+  return `${base64UrlJson({ alg: 'none', typ: 'JWT' })}.${base64UrlJson(payload)}.signature`
+}
+
+async function createCodexHome(auth: unknown): Promise<string> {
+  const codexHome = await mkdtemp(join(tmpdir(), 'codexui-auth-refresh-'))
+  tempDirs.push(codexHome)
+  await writeFile(join(codexHome, 'auth.json'), JSON.stringify(auth, null, 2), 'utf8')
+  process.env.CODEX_HOME = codexHome
+  return codexHome
+}
+
+afterEach(async () => {
+  restoreEnvValue('CODEX_HOME', originalCodexHome)
+  restoreEnvValue('CODEX_REFRESH_TOKEN_URL_OVERRIDE', originalRefreshUrlOverride)
+  vi.unstubAllGlobals()
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('ChatGPT auth token refresh', () => {
+  it('refreshes external ChatGPT auth tokens and persists auth.json', async () => {
+    const codexHome = await createCodexHome({
+      auth_mode: 'chatgpt',
+      tokens: {
+        access_token: 'expired-access-token',
+        refresh_token: 'refresh-old',
+        id_token: 'id-old',
+        account_id: 'acct-old',
+      },
+    })
+    process.env.CODEX_REFRESH_TOKEN_URL_OVERRIDE = 'https://example.test/oauth/token'
+    const accessToken = unsignedJwt({
+      'https://api.openai.com/auth': {
+        chatgpt_account_id: 'acct-new',
+        chatgpt_plan_type: 'pro',
+      },
+    })
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      access_token: accessToken,
+      refresh_token: 'refresh-new',
+      id_token: 'id-new',
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await refreshChatgptAuthTokensForExternalAuth({
+      reason: 'unauthorized',
+      previousAccountId: 'acct-old',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe('https://example.test/oauth/token')
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toEqual({ 'Content-Type': 'application/x-www-form-urlencoded' })
+    const body = new URLSearchParams(String(init?.body ?? ''))
+    expect(body.get('grant_type')).toBe('refresh_token')
+    expect(body.get('refresh_token')).toBe('refresh-old')
+    expect(body.get('client_id')).toBe('app_EMoamEEZ73f0CkXaXp7hrann')
+    expect(result).toEqual({
+      accessToken,
+      chatgptAccountId: 'acct-new',
+      chatgptPlanType: 'pro',
+    })
+
+    const updatedAuth = JSON.parse(await readFile(join(codexHome, 'auth.json'), 'utf8')) as {
+      auth_mode?: string
+      last_refresh?: number
+      tokens?: Record<string, string>
+    }
+    expect(updatedAuth.auth_mode).toBe('chatgpt')
+    expect(typeof updatedAuth.last_refresh).toBe('number')
+    expect(updatedAuth.tokens?.access_token).toBe(accessToken)
+    expect(updatedAuth.tokens?.refresh_token).toBe('refresh-new')
+    expect(updatedAuth.tokens?.id_token).toBe('id-new')
+    expect(updatedAuth.tokens?.account_id).toBe('acct-new')
+  })
+
+  it('asks for sign-in when auth.json has no ChatGPT refresh token', async () => {
+    await createCodexHome({
+      auth_mode: 'chatgpt',
+      tokens: {
+        access_token: 'expired-access-token',
+        account_id: 'acct-old',
+      },
+    })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(refreshChatgptAuthTokensForExternalAuth()).rejects.toThrow(
+      'No ChatGPT refresh token is available. Please sign in again.',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -80,6 +80,17 @@ type PendingServerRequest = {
   receivedAtIso: string
 }
 
+type ChatgptAuthTokensRefreshParams = {
+  reason?: string
+  previousAccountId?: string | null
+}
+
+type ChatgptAuthTokensRefreshResponse = {
+  accessToken: string
+  chatgptAccountId: string
+  chatgptPlanType: string | null
+}
+
 type ThreadSearchDocument = {
   id: string
   title: string
@@ -2520,9 +2531,145 @@ function getCodexAuthPath(): string {
 }
 
 type CodexAuth = {
+  auth_mode?: string
+  last_refresh?: number
   tokens?: {
     access_token?: string
+    refresh_token?: string
+    id_token?: string
     account_id?: string
+  }
+}
+
+const CODEX_CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+const DEFAULT_CODEX_REFRESH_TOKEN_URL = 'https://auth.openai.com/oauth/token'
+
+function decodeBase64UrlJson(value: string): Record<string, unknown> | null {
+  try {
+    const padded = `${value}${'='.repeat((4 - (value.length % 4)) % 4)}`
+    const decoded = Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
+    const parsed = JSON.parse(decoded) as unknown
+    return asRecord(parsed)
+  } catch {
+    return null
+  }
+}
+
+function decodeJwtPayload(token: string | undefined): Record<string, unknown> | null {
+  if (!token) return null
+  const parts = token.split('.')
+  if (parts.length < 2) return null
+  return decodeBase64UrlJson(parts[1] ?? '')
+}
+
+function extractChatgptTokenMetadata(accessToken: string | undefined): {
+  chatgptAccountId: string | null
+  chatgptPlanType: string | null
+} {
+  const payload = decodeJwtPayload(accessToken)
+  const auth = asRecord(payload?.['https://api.openai.com/auth'])
+  return {
+    chatgptAccountId: readNonEmptyString(auth?.chatgpt_account_id) || null,
+    chatgptPlanType: readNonEmptyString(auth?.chatgpt_plan_type) || null,
+  }
+}
+
+function readTokenErrorMessage(payload: unknown, fallback: string): string {
+  const record = asRecord(payload)
+  const message = readNonEmptyString(record?.message)
+  if (message) return message
+  const error = record?.error
+  if (typeof error === 'string' && error.trim().length > 0) return error.trim()
+  const nestedError = asRecord(error)
+  return readNonEmptyString(nestedError?.message)
+    || readNonEmptyString(nestedError?.error_description)
+    || readNonEmptyString(record?.error_description)
+    || fallback
+}
+
+function readTokenResponseString(payload: Record<string, unknown> | null, ...keys: string[]): string | null {
+  if (!payload) return null
+  for (const key of keys) {
+    const value = readNonEmptyString(payload[key])
+    if (value) return value
+  }
+  return null
+}
+
+export async function refreshChatgptAuthTokensForExternalAuth(
+  params: ChatgptAuthTokensRefreshParams = {},
+): Promise<ChatgptAuthTokensRefreshResponse> {
+  const authPath = getCodexAuthPath()
+  const raw = await readFile(authPath, 'utf8')
+  const auth = JSON.parse(raw) as CodexAuth
+  const currentRefreshToken = auth.tokens?.refresh_token?.trim() ?? ''
+  if (!currentRefreshToken) {
+    throw new Error('No ChatGPT refresh token is available. Please sign in again.')
+  }
+
+  const refreshUrl = process.env.CODEX_REFRESH_TOKEN_URL_OVERRIDE?.trim() || DEFAULT_CODEX_REFRESH_TOKEN_URL
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: currentRefreshToken,
+    client_id: CODEX_CHATGPT_CLIENT_ID,
+  })
+
+  const response = await fetch(refreshUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+    signal: AbortSignal.timeout(25_000),
+  })
+
+  const text = await response.text()
+  let payload: Record<string, unknown> | null = null
+  try {
+    payload = asRecord(JSON.parse(text))
+  } catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    throw new Error(readTokenErrorMessage(payload, `ChatGPT token refresh failed with HTTP ${String(response.status)}`))
+  }
+
+  const accessToken = readTokenResponseString(payload, 'access_token', 'accessToken')
+  if (!accessToken) {
+    throw new Error('ChatGPT token refresh response did not include an access token.')
+  }
+
+  const nextRefreshToken = readTokenResponseString(payload, 'refresh_token', 'refreshToken') ?? currentRefreshToken
+  const nextIdToken = readTokenResponseString(payload, 'id_token', 'idToken') ?? auth.tokens?.id_token
+  const metadata = extractChatgptTokenMetadata(accessToken)
+  const chatgptAccountId =
+    metadata.chatgptAccountId
+    || readTokenResponseString(payload, 'chatgpt_account_id', 'chatgptAccountId')
+    || readNonEmptyString(params.previousAccountId)
+    || readNonEmptyString(auth.tokens?.account_id)
+  if (!chatgptAccountId) {
+    throw new Error('ChatGPT token refresh response did not include account metadata.')
+  }
+
+  const nextAuth: CodexAuth = {
+    ...auth,
+    auth_mode: auth.auth_mode || 'chatgpt',
+    last_refresh: Date.now(),
+    tokens: {
+      ...auth.tokens,
+      access_token: accessToken,
+      refresh_token: nextRefreshToken,
+      account_id: chatgptAccountId,
+      ...(nextIdToken ? { id_token: nextIdToken } : {}),
+    },
+  }
+  await writeFile(authPath, JSON.stringify(nextAuth, null, 2), { encoding: 'utf8', mode: 0o600 })
+
+  return {
+    accessToken,
+    chatgptAccountId,
+    chatgptPlanType: metadata.chatgptPlanType,
   }
 }
 
@@ -3448,6 +3595,7 @@ class AppServerProcess {
   private readonly lastThreadReadSnapshotByThreadId = new Map<string, unknown>()
   private readonly capturedItemsByThreadId = new Map<string, Map<string, CapturedItem>>()
   private readonly liveStateCache = new Map<string, { data: unknown; turnCount: number; sessionSize: number }>()
+  private chatgptAuthRefreshPromise: Promise<ChatgptAuthTokensRefreshResponse> | null = null
 
 
   private getCodexCommand(): string {
@@ -3776,7 +3924,49 @@ class AppServerProcess {
     })
   }
 
+  private async refreshChatgptAuthTokens(params: ChatgptAuthTokensRefreshParams): Promise<ChatgptAuthTokensRefreshResponse> {
+    if (!this.chatgptAuthRefreshPromise) {
+      this.chatgptAuthRefreshPromise = refreshChatgptAuthTokensForExternalAuth(params).finally(() => {
+        this.chatgptAuthRefreshPromise = null
+      })
+    }
+    return await this.chatgptAuthRefreshPromise
+  }
+
+  private async handleChatgptAuthTokensRefreshRequest(requestId: number, params: unknown): Promise<void> {
+    const requestParams = asRecord(params)
+    const previousAccountId = readNonEmptyString(requestParams?.previousAccountId ?? requestParams?.previous_account_id)
+    try {
+      const result = await this.refreshChatgptAuthTokens({
+        reason: readNonEmptyString(requestParams?.reason) || undefined,
+        previousAccountId: previousAccountId || undefined,
+      })
+      this.sendServerRequestReply(requestId, { result })
+      this.emitNotification({
+        method: 'server/request/resolved',
+        params: {
+          id: requestId,
+          method: 'account/chatgptAuthTokens/refresh',
+          mode: 'automatic',
+          resolvedAtIso: new Date().toISOString(),
+        },
+      })
+    } catch (error) {
+      this.sendServerRequestReply(requestId, {
+        error: {
+          code: -32001,
+          message: getErrorMessage(error, 'Failed to refresh ChatGPT auth tokens'),
+        },
+      })
+    }
+  }
+
   private handleServerRequest(requestId: number, method: string, params: unknown): void {
+    if (method === 'account/chatgptAuthTokens/refresh') {
+      void this.handleChatgptAuthTokensRefreshRequest(requestId, params)
+      return
+    }
+
     const pendingRequest: PendingServerRequest = {
       id: requestId,
       method,

--- a/tests.md
+++ b/tests.md
@@ -3826,3 +3826,31 @@ Queued messages are saved through the backend, survive page refresh, and can be 
 
 #### Rollback/Cleanup
 - Delete any queued test messages that should not be sent
+
+---
+
+### ChatGPT auth tokens refresh for external auth
+
+#### Feature/Change Name
+Codex app-server `account/chatgptAuthTokens/refresh` requests are handled automatically from `auth.json` so expired ChatGPT access tokens can be refreshed without a manual relogin.
+
+#### Prerequisites/Setup
+1. App server is running from this repository
+2. `$CODEX_HOME/auth.json` contains ChatGPT auth with a valid `refresh_token`
+3. The current ChatGPT `access_token` is expired or close enough to expiry that Codex app-server asks for token refresh
+
+#### Steps
+1. Open the app with the ChatGPT-authenticated account selected
+2. Trigger an account operation such as loading account rate limits or starting a normal Codex turn
+3. Watch the server logs for an `account/chatgptAuthTokens/refresh` server request
+4. Reopen `$CODEX_HOME/auth.json`
+5. Repeat the same account operation after the refresh completes
+
+#### Expected Results
+- The refresh request is answered automatically and does not appear as a manual pending request in the UI
+- `auth.json` is updated with the fresh `access_token` and any rotated `refresh_token` or `id_token`
+- The account operation succeeds without showing `token_expired`
+- If no refresh token is available, the operation fails with a sign-in-again message instead of silently looping
+
+#### Rollback/Cleanup
+- None, unless a test-only `$CODEX_HOME` was used


### PR DESCRIPTION
## Summary
- Handle Codex app-server `account/chatgptAuthTokens/refresh` requests automatically instead of leaving them as generic manual server requests.
- Refresh ChatGPT auth from `auth.json` using the stored refresh token, persist rotated tokens, and reply with the fresh access token/account metadata.
- Add unit coverage for successful refresh persistence and missing-refresh-token sign-in fallback.
- Document the manual regression path in `tests.md`.

## Root cause
When ChatGPT access tokens expired, app-server could ask external clients to refresh tokens, but CodexUI did not answer that server request. The stale access token stayed in `auth.json`, so account/rate-limit calls surfaced `token_expired` until a manual relogin.

## Validation
- `pnpm exec vitest run src/server/codexAppServerBridge.authRefresh.test.ts`
- `pnpm run test:unit`
- `pnpm run build`
- `git diff --check`