### PR TITLE
Discover terminal quick commands from project files

### DIFF
--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -348,7 +348,7 @@ export type ThreadTerminalAttachInput = {
 export type ThreadTerminalQuickCommand = {
   label: string
   value: string
-  source: 'package' | 'script'
+  source: 'package' | 'script' | 'make'
 }
 
 export type AccountsListResult = {
@@ -1104,7 +1104,7 @@ export async function getThreadTerminalQuickCommands(cwd: string): Promise<Threa
     const label = readString(record?.label)
     const value = readString(record?.value)
     const source = readString(record?.source)
-    if (!label || !value || (source !== 'package' && source !== 'script')) return []
+    if (!label || !value || (source !== 'package' && source !== 'script' && source !== 'make')) return []
     return [{ label, value, source }]
   })
 }

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -345,6 +345,12 @@ export type ThreadTerminalAttachInput = {
   newSession?: boolean
 }
 
+export type ThreadTerminalQuickCommand = {
+  label: string
+  value: string
+  source: 'package' | 'script'
+}
+
 export type AccountsListResult = {
   activeAccountId: string | null
   accounts: UiAccountEntry[]
@@ -1087,6 +1093,20 @@ export async function getThreadTerminalStatus(): Promise<{ available: boolean, r
     available: readBoolean(record?.available) ?? false,
     reason: readString(record?.reason) || null,
   }
+}
+
+export async function getThreadTerminalQuickCommands(cwd: string): Promise<ThreadTerminalQuickCommand[]> {
+  const payload = await fetchTerminalJson(`/codex-api/thread-terminal/quick-commands?cwd=${encodeURIComponent(cwd)}`)
+  const payloadRecord = asRecord(payload)
+  const rows: unknown[] = Array.isArray(payloadRecord?.commands) ? payloadRecord.commands : []
+  return rows.flatMap((row: unknown) => {
+    const record = asRecord(row)
+    const label = readString(record?.label)
+    const value = readString(record?.value)
+    const source = readString(record?.source)
+    if (!label || !value || (source !== 'package' && source !== 'script')) return []
+    return [{ label, value, source }]
+  })
 }
 
 export async function sendThreadTerminalInput(sessionId: string, data: string): Promise<void> {

--- a/src/components/content/ThreadTerminalPanel.vue
+++ b/src/components/content/ThreadTerminalPanel.vue
@@ -59,10 +59,12 @@ import { useUiLanguage } from '../../composables/useUiLanguage'
 import {
   attachThreadTerminal,
   closeThreadTerminal,
+  getThreadTerminalQuickCommands,
   resizeThreadTerminal,
   sendThreadTerminalInput,
   subscribeCodexNotifications,
   type RpcNotification,
+  type ThreadTerminalQuickCommand,
 } from '../../api/codexGateway'
 
 const props = defineProps<{
@@ -99,31 +101,29 @@ type QuickCommand = {
   custom?: boolean
   usageCount: number
   lastUsedAt: number
-  builtInIndex?: number
+  sourceIndex?: number
 }
 
 const QUICK_COMMAND_STORAGE_KEY = 'codex-web-local.terminal-quick-commands.v1'
 const TERMINAL_TABS_STORAGE_KEY = 'codex-web-local.terminal-tabs.v1'
 const ADD_QUICK_COMMAND_VALUE = '__add_quick_command__'
 const MAX_VISIBLE_QUICK_COMMANDS = 5
-const BUILT_IN_QUICK_COMMANDS: QuickCommand[] = [
-  { label: 'npm run dev', value: 'npm run dev', usageCount: 0, lastUsedAt: 0, builtInIndex: 0 },
-  { label: 'pnpm run dev', value: 'pnpm run dev', usageCount: 0, lastUsedAt: 0, builtInIndex: 1 },
-  { label: 'pnpm run test:unit', value: 'pnpm run test:unit', usageCount: 0, lastUsedAt: 0, builtInIndex: 2 },
-  { label: 'pnpm run build', value: 'pnpm run build', usageCount: 0, lastUsedAt: 0, builtInIndex: 3 },
-]
 
 const storedQuickCommands = ref<QuickCommand[]>(loadStoredQuickCommands())
+const projectQuickCommands = ref<ThreadTerminalQuickCommand[]>([])
 
 const activeTab = computed(() => tabs.value.find((tab) => tab.id === activeSessionId.value) ?? null)
 const quickCommands = computed<QuickCommand[]>(() => {
   const storedByValue = new Map(storedQuickCommands.value.map((command) => [command.value, command]))
   const combined = [
-    ...BUILT_IN_QUICK_COMMANDS.map((command) => ({
-      ...command,
+    ...projectQuickCommands.value.map((command, index) => ({
+      label: command.label,
+      value: command.value,
+      usageCount: 0,
+      lastUsedAt: 0,
       ...(storedByValue.get(command.value) ?? {}),
       custom: false,
-      builtInIndex: command.builtInIndex,
+      sourceIndex: index,
     })),
     ...storedQuickCommands.value.filter((command) => command.custom === true),
   ]
@@ -136,6 +136,7 @@ onMounted(() => {
   restoreSavedTabs()
   createTerminal()
   unsubscribeNotifications = subscribeCodexNotifications(handleNotification)
+  void refreshProjectQuickCommands()
   void attachToThread(false)
 })
 
@@ -157,6 +158,7 @@ watch(
   () => [props.threadId, props.cwd] as const,
   () => {
     restoreSavedTabs()
+    void refreshProjectQuickCommands()
     void attachToThread(false)
   },
 )
@@ -467,6 +469,19 @@ function normalizeQuickCommandValue(value: string): string {
   return value.trim().replace(/\s+/g, ' ')
 }
 
+async function refreshProjectQuickCommands(): Promise<void> {
+  const cwd = props.cwd.trim()
+  if (!cwd) {
+    projectQuickCommands.value = []
+    return
+  }
+  try {
+    projectQuickCommands.value = await getThreadTerminalQuickCommands(cwd)
+  } catch {
+    projectQuickCommands.value = []
+  }
+}
+
 function runQuickCommand(command: string, custom: boolean): void {
   const value = normalizeQuickCommandValue(command)
   if (!value) return
@@ -485,14 +500,15 @@ function recordQuickCommandUse(value: string, custom: boolean): void {
   const normalized = normalizeQuickCommandValue(value)
   if (!normalized) return
   const existing = storedQuickCommands.value.find((command) => command.value === normalized)
-  const builtIn = BUILT_IN_QUICK_COMMANDS.find((command) => command.value === normalized)
+  const projectCommandIndex = projectQuickCommands.value.findIndex((command) => command.value === normalized)
+  const projectCommand = projectCommandIndex >= 0 ? projectQuickCommands.value[projectCommandIndex] : null
   const nextCommand: QuickCommand = {
-    label: existing?.label || builtIn?.label || normalized,
+    label: existing?.label || projectCommand?.label || normalized,
     value: normalized,
-    custom: existing?.custom === true || (!builtIn && custom),
+    custom: existing?.custom === true || (!projectCommand && custom),
     usageCount: (existing?.usageCount ?? 0) + 1,
     lastUsedAt: Date.now(),
-    builtInIndex: builtIn?.builtInIndex,
+    sourceIndex: projectCommandIndex >= 0 ? projectCommandIndex : undefined,
   }
   const next = [
     ...storedQuickCommands.value.filter((command) => command.value !== normalized),
@@ -505,9 +521,9 @@ function recordQuickCommandUse(value: string, custom: boolean): void {
 function compareQuickCommands(first: QuickCommand, second: QuickCommand): number {
   if (second.usageCount !== first.usageCount) return second.usageCount - first.usageCount
   if (second.lastUsedAt !== first.lastUsedAt) return second.lastUsedAt - first.lastUsedAt
-  const firstBuiltIn = typeof first.builtInIndex === 'number' ? first.builtInIndex : Number.MAX_SAFE_INTEGER
-  const secondBuiltIn = typeof second.builtInIndex === 'number' ? second.builtInIndex : Number.MAX_SAFE_INTEGER
-  return firstBuiltIn - secondBuiltIn
+  const firstSource = typeof first.sourceIndex === 'number' ? first.sourceIndex : Number.MAX_SAFE_INTEGER
+  const secondSource = typeof second.sourceIndex === 'number' ? second.sourceIndex : Number.MAX_SAFE_INTEGER
+  return firstSource - secondSource
 }
 
 function loadStoredQuickCommands(): QuickCommand[] {
@@ -517,22 +533,20 @@ function loadStoredQuickCommands(): QuickCommand[] {
     if (!raw) return []
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) return []
-    const seen = new Set(BUILT_IN_QUICK_COMMANDS.map((command) => command.value))
+    const seen = new Set<string>()
     const commands: QuickCommand[] = []
     for (const row of parsed) {
       const record = asRecord(row)
       const value = normalizeQuickCommandValue(readString(record?.value))
       if (!value) continue
-      const builtIn = BUILT_IN_QUICK_COMMANDS.find((command) => command.value === value)
-      if (seen.has(value) && !builtIn) continue
+      if (seen.has(value)) continue
       seen.add(value)
       commands.push({
-        label: readString(record?.label) || builtIn?.label || value,
+        label: readString(record?.label) || value,
         value,
-        custom: !builtIn,
+        custom: record?.custom !== false,
         usageCount: readPositiveInteger(record?.usageCount),
         lastUsedAt: readPositiveInteger(record?.lastUsedAt),
-        builtInIndex: builtIn?.builtInIndex,
       })
     }
     return commands

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -992,6 +992,81 @@ function readNonEmptyString(value: unknown): string {
   return typeof value === 'string' && value.trim().length > 0 ? value : ''
 }
 
+type TerminalQuickCommand = {
+  label: string
+  value: string
+  source: 'package' | 'script'
+}
+
+async function listTerminalQuickCommands(cwd: string): Promise<TerminalQuickCommand[]> {
+  const normalizedCwd = isAbsolute(cwd) ? cwd : resolve(cwd)
+  const info = await stat(normalizedCwd)
+  if (!info.isDirectory()) {
+    throw new Error('Terminal cwd is not a directory')
+  }
+
+  const commands: TerminalQuickCommand[] = []
+  const seen = new Set<string>()
+  const addCommand = (command: TerminalQuickCommand) => {
+    if (!command.value || seen.has(command.value)) return
+    seen.add(command.value)
+    commands.push(command)
+  }
+
+  await addPackageJsonCommands(normalizedCwd, addCommand)
+  await addScriptsDirectoryCommands(normalizedCwd, addCommand)
+  return commands
+}
+
+async function addPackageJsonCommands(
+  cwd: string,
+  addCommand: (command: TerminalQuickCommand) => void,
+): Promise<void> {
+  try {
+    const raw = await readFile(join(cwd, 'package.json'), 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+    const record = asRecord(parsed)
+    const scripts = asRecord(record?.scripts)
+    if (!scripts) return
+    for (const scriptName of Object.keys(scripts)) {
+      if (typeof scripts[scriptName] !== 'string') continue
+      addCommand({
+        label: `npm run ${scriptName}`,
+        value: `npm run ${quoteShellTokenIfNeeded(scriptName)}`,
+        source: 'package',
+      })
+    }
+  } catch {
+    // A project without package.json simply has no package quick commands.
+  }
+}
+
+async function addScriptsDirectoryCommands(
+  cwd: string,
+  addCommand: (command: TerminalQuickCommand) => void,
+): Promise<void> {
+  try {
+    const scriptsDir = join(cwd, 'scripts')
+    const entries = await readdir(scriptsDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isFile()) continue
+      if (!entry.name.endsWith('.sh') && !entry.name.endsWith('.cmd')) continue
+      const value = `./scripts/${quoteShellTokenIfNeeded(entry.name)}`
+      addCommand({
+        label: value,
+        value,
+        source: 'script',
+      })
+    }
+  } catch {
+    // A project without scripts/ simply has no script-file quick commands.
+  }
+}
+
+function quoteShellTokenIfNeeded(value: string): string {
+  return /^[A-Za-z0-9_./:@-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`
+}
+
 function readBoolean(value: unknown): boolean {
   return value === true
 }
@@ -4224,6 +4299,20 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'GET' && url.pathname === '/codex-api/thread-terminal/status') {
         setJson(res, 200, terminalManager.getAvailability())
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-terminal/quick-commands') {
+        const cwd = url.searchParams.get('cwd')?.trim() ?? ''
+        if (!cwd) {
+          setJson(res, 400, { error: 'Missing cwd' })
+          return
+        }
+        try {
+          setJson(res, 200, { commands: await listTerminalQuickCommands(cwd) })
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to load terminal quick commands') })
+        }
         return
       }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -995,7 +995,7 @@ function readNonEmptyString(value: unknown): string {
 type TerminalQuickCommand = {
   label: string
   value: string
-  source: 'package' | 'script'
+  source: 'package' | 'script' | 'make'
 }
 
 async function listTerminalQuickCommands(cwd: string): Promise<TerminalQuickCommand[]> {
@@ -1014,6 +1014,8 @@ async function listTerminalQuickCommands(cwd: string): Promise<TerminalQuickComm
   }
 
   await addPackageJsonCommands(normalizedCwd, addCommand)
+  await addMakefileCommands(normalizedCwd, addCommand)
+  await addRootScriptCommands(normalizedCwd, addCommand)
   await addScriptsDirectoryCommands(normalizedCwd, addCommand)
   return commands
 }
@@ -1028,11 +1030,13 @@ async function addPackageJsonCommands(
     const record = asRecord(parsed)
     const scripts = asRecord(record?.scripts)
     if (!scripts) return
+    const packageManager = resolvePackageManager(cwd)
     for (const scriptName of Object.keys(scripts)) {
       if (typeof scripts[scriptName] !== 'string') continue
+      const value = formatPackageScriptCommand(packageManager, scriptName)
       addCommand({
-        label: `npm run ${scriptName}`,
-        value: `npm run ${quoteShellTokenIfNeeded(scriptName)}`,
+        label: value,
+        value,
         source: 'package',
       })
     }
@@ -1041,17 +1045,61 @@ async function addPackageJsonCommands(
   }
 }
 
+async function addMakefileCommands(
+  cwd: string,
+  addCommand: (command: TerminalQuickCommand) => void,
+): Promise<void> {
+  const makefilePath = existsSync(join(cwd, 'Makefile'))
+    ? join(cwd, 'Makefile')
+    : existsSync(join(cwd, 'makefile'))
+      ? join(cwd, 'makefile')
+      : ''
+  if (!makefilePath) return
+
+  try {
+    const raw = await readFile(makefilePath, 'utf8')
+    for (const line of raw.split(/\r?\n/)) {
+      const match = /^([A-Za-z0-9_.@%/+~-][A-Za-z0-9_.@%/+~-]*)\s*:(?![=])/.exec(line)
+      if (!match) continue
+      const target = match[1]
+      if (!target || target.startsWith('.')) continue
+      const value = `make ${quoteShellTokenIfNeeded(target)}`
+      addCommand({
+        label: value,
+        value,
+        source: 'make',
+      })
+    }
+  } catch {
+    // Ignore unreadable Makefiles for quick-command discovery.
+  }
+}
+
+async function addRootScriptCommands(
+  cwd: string,
+  addCommand: (command: TerminalQuickCommand) => void,
+): Promise<void> {
+  await addScriptFileCommands(cwd, '.', addCommand)
+}
+
 async function addScriptsDirectoryCommands(
   cwd: string,
   addCommand: (command: TerminalQuickCommand) => void,
 ): Promise<void> {
+  await addScriptFileCommands(join(cwd, 'scripts'), './scripts', addCommand)
+}
+
+async function addScriptFileCommands(
+  directory: string,
+  commandPrefix: string,
+  addCommand: (command: TerminalQuickCommand) => void,
+): Promise<void> {
   try {
-    const scriptsDir = join(cwd, 'scripts')
-    const entries = await readdir(scriptsDir, { withFileTypes: true })
+    const entries = await readdir(directory, { withFileTypes: true })
     for (const entry of entries) {
       if (!entry.isFile()) continue
       if (!entry.name.endsWith('.sh') && !entry.name.endsWith('.cmd')) continue
-      const value = `./scripts/${quoteShellTokenIfNeeded(entry.name)}`
+      const value = `${commandPrefix}/${quoteShellTokenIfNeeded(entry.name)}`
       addCommand({
         label: value,
         value,
@@ -1059,8 +1107,23 @@ async function addScriptsDirectoryCommands(
       })
     }
   } catch {
-    // A project without scripts/ simply has no script-file quick commands.
+    // A project without script files simply has no script-file quick commands.
   }
+}
+
+function resolvePackageManager(cwd: string): 'npm' | 'pnpm' | 'yarn' | 'bun' {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(cwd, 'bun.lock')) || existsSync(join(cwd, 'bun.lockb'))) return 'bun'
+  return 'npm'
+}
+
+function formatPackageScriptCommand(packageManager: 'npm' | 'pnpm' | 'yarn' | 'bun', scriptName: string): string {
+  const quoted = quoteShellTokenIfNeeded(scriptName)
+  if (packageManager === 'npm') return `npm run ${quoted}`
+  if (packageManager === 'pnpm') return `pnpm run ${quoted}`
+  if (packageManager === 'bun') return `bun run ${quoted}`
+  return `yarn ${quoted}`
 }
 
 function quoteShellTokenIfNeeded(value: string): string {

--- a/tests.md
+++ b/tests.md
@@ -3693,3 +3693,35 @@ The thread overflow menu includes a `Copy path` item that copies the selected th
 
 #### Rollback/Cleanup
 - Restore any previous clipboard contents manually if needed
+
+---
+
+### Terminal quick commands from project files
+
+#### Feature/Change Name
+Terminal quick commands are discovered from the current project instead of using a static built-in npm list.
+
+#### Prerequisites/Setup
+1. Dev server running at `http://127.0.0.1:5174` or the active Vite dev URL
+2. Open a thread or new chat whose working directory has a `package.json` with scripts
+3. Optionally create executable candidates under `scripts/`, such as `scripts/check.sh` or `scripts/build.cmd`
+
+#### Steps
+1. Open the terminal panel for that project
+2. Open the `Run...` dropdown
+3. Verify each `package.json` script appears as `npm run <script>`
+4. Verify `scripts/*.sh` and `scripts/*.cmd` files appear as `./scripts/<file>`
+5. Select one discovered command and confirm it is sent to the terminal
+6. Use `Add command...` to add a custom command
+7. Reopen the dropdown after running commands multiple times
+
+#### Expected Results
+- The dropdown is based on the current project `cwd`
+- Static defaults like `npm run dev` do not appear unless they exist in that project's `package.json`
+- Script-file commands are listed after package scripts
+- Only the top five commands are shown, sorted by most-used and then most-recent usage
+- Custom commands still work and are included in the same usage sorting
+
+#### Rollback/Cleanup
+- Remove any temporary files created under `scripts/`
+- Remove custom quick commands from browser local storage if needed

--- a/tests.md
+++ b/tests.md
@@ -3704,24 +3704,30 @@ Terminal quick commands are discovered from the current project instead of using
 #### Prerequisites/Setup
 1. Dev server running at `http://127.0.0.1:5174` or the active Vite dev URL
 2. Open a thread or new chat whose working directory has a `package.json` with scripts
-3. Optionally create executable candidates under `scripts/`, such as `scripts/check.sh` or `scripts/build.cmd`
+3. Optionally create executable candidates under the project root and `scripts/`, such as `check.sh`, `scripts/check.sh`, or `scripts/build.cmd`
+4. Optionally add `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, or `bun.lockb` to verify package-manager detection
+5. Optionally add a `Makefile` with simple targets such as `test:` or `build:`
 
 #### Steps
 1. Open the terminal panel for that project
 2. Open the `Run...` dropdown
-3. Verify each `package.json` script appears as `npm run <script>`
-4. Verify `scripts/*.sh` and `scripts/*.cmd` files appear as `./scripts/<file>`
-5. Select one discovered command and confirm it is sent to the terminal
-6. Use `Add command...` to add a custom command
-7. Reopen the dropdown after running commands multiple times
+3. Verify each `package.json` script appears with the detected package manager, such as `pnpm run <script>`, `yarn <script>`, `bun run <script>`, or `npm run <script>`
+4. Verify simple `Makefile` targets appear as `make <target>`
+5. Verify root-level `*.sh` / `*.cmd` files appear as `./<file>`
+6. Verify `scripts/*.sh` and `scripts/*.cmd` files appear as `./scripts/<file>`
+7. Select one discovered command and confirm it is sent to the terminal
+8. Use `Add command...` to add a custom command
+9. Reopen the dropdown after running commands multiple times
 
 #### Expected Results
 - The dropdown is based on the current project `cwd`
 - Static defaults like `npm run dev` do not appear unless they exist in that project's `package.json`
-- Script-file commands are listed after package scripts
+- Package script commands use the lockfile-preferred package manager
+- Make targets are listed after package scripts
+- Root and `scripts/` script-file commands are listed after Make targets
 - Only the top five commands are shown, sorted by most-used and then most-recent usage
 - Custom commands still work and are included in the same usage sorting
 
 #### Rollback/Cleanup
-- Remove any temporary files created under `scripts/`
+- Remove any temporary files created under the project root or `scripts/`
 - Remove custom quick commands from browser local storage if needed


### PR DESCRIPTION
## Summary
- discover terminal quick commands from package.json scripts instead of static defaults
- prefer pnpm/yarn/bun/npm based on lockfiles
- include Makefile targets and root/scripts shell or cmd files

## Tests
- pnpm run test:unit
- pnpm run build
- runtime smoke against /codex-api/thread-terminal/quick-commands with package scripts, Makefile, root scripts, and scripts/ files