### PR TITLE
Persist queued messages through backend state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -789,6 +789,7 @@
                     @edit="onEditQueuedMessage"
                     @steer="steerQueuedMessage"
                     @delete="removeQueuedMessage"
+                    @reorder="onReorderQueuedMessage"
                   />
                   <ThreadTerminalPanel
                     v-if="selectedThreadTerminalOpen && selectedThreadId && composerCwd"
@@ -1093,6 +1094,7 @@ const {
   interruptSelectedThreadTurn,
   selectedThreadQueuedMessages,
   removeQueuedMessage,
+  reorderQueuedMessage,
   steerQueuedMessage,
   setSelectedCollaborationMode,
   readModelIdForThread,
@@ -2750,6 +2752,10 @@ function collapsePathSegments(rawSegments: readonly string[]): string[] {
     segments.push(segment)
   }
   return segments
+}
+
+function onReorderQueuedMessage(payload: { draggedId: string; targetId: string }): void {
+  reorderQueuedMessage(payload.draggedId, payload.targetId)
 }
 
 function onSelectModel(modelId: string): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2898,7 +2898,8 @@ function loadDarkModePref(): 'system' | 'light' | 'dark' {
 function loadInProgressSendModePref(): 'steer' | 'queue' {
   if (typeof window === 'undefined') return 'steer'
   const v = window.localStorage.getItem(IN_PROGRESS_SEND_MODE_KEY)
-  return v === 'queue' ? 'queue' : 'steer'
+  if (v === 'steer' || v === 'queue') return v
+  return 'queue'
 }
 
 function loadChatWidthPref(): ChatWidthMode {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -269,6 +269,17 @@ export type WorkspaceRootsState = {
   active: string[]
 }
 
+export type StoredQueuedMessage = {
+  id: string
+  text: string
+  imageUrls: string[]
+  skills: Array<{ name: string; path: string }>
+  fileAttachments: Array<{ label: string; path: string; fsPath: string }>
+  collaborationMode: CollaborationModeKind
+}
+
+export type ThreadQueueState = Record<string, StoredQueuedMessage[]>
+
 export type ComposerFileSuggestion = {
   path: string
 }
@@ -2144,6 +2155,62 @@ function normalizeWorkspaceRootsState(payload: unknown): WorkspaceRootsState {
   }
 }
 
+function normalizeStoredQueuedMessage(value: unknown): StoredQueuedMessage | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const id = typeof record.id === 'string' ? record.id.trim() : ''
+  if (!id) return null
+
+  const imageUrls = Array.isArray(record.imageUrls)
+    ? record.imageUrls.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : []
+  const skills = Array.isArray(record.skills)
+    ? record.skills.flatMap((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+      const itemRecord = item as Record<string, unknown>
+      const name = typeof itemRecord.name === 'string' ? itemRecord.name.trim() : ''
+      const path = typeof itemRecord.path === 'string' ? itemRecord.path.trim() : ''
+      return name && path ? [{ name, path }] : []
+    })
+    : []
+  const fileAttachments = Array.isArray(record.fileAttachments)
+    ? record.fileAttachments.flatMap((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+      const itemRecord = item as Record<string, unknown>
+      const label = typeof itemRecord.label === 'string' ? itemRecord.label.trim() : ''
+      const path = typeof itemRecord.path === 'string' ? itemRecord.path.trim() : ''
+      const fsPath = typeof itemRecord.fsPath === 'string' ? itemRecord.fsPath.trim() : ''
+      return label && path && fsPath ? [{ label, path, fsPath }] : []
+    })
+    : []
+
+  return {
+    id,
+    text: typeof record.text === 'string' ? record.text : '',
+    imageUrls,
+    skills,
+    fileAttachments,
+    collaborationMode: record.collaborationMode === 'plan' ? 'plan' : 'default',
+  }
+}
+
+function normalizeThreadQueueState(value: unknown): ThreadQueueState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const state: ThreadQueueState = {}
+  for (const [threadId, rawMessages] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedThreadId = threadId.trim()
+    if (!normalizedThreadId || !Array.isArray(rawMessages)) continue
+    const messages = rawMessages.flatMap((item) => {
+      const message = normalizeStoredQueuedMessage(item)
+      return message ? [message] : []
+    })
+    if (messages.length > 0) {
+      state[normalizedThreadId] = messages
+    }
+  }
+  return state
+}
+
 export async function getWorkspaceRootsState(): Promise<WorkspaceRootsState> {
   const response = await fetch('/codex-api/workspace-roots-state')
   const payload = (await response.json()) as unknown
@@ -2155,6 +2222,30 @@ export async function getWorkspaceRootsState(): Promise<WorkspaceRootsState> {
       ? (payload as Record<string, unknown>)
       : {}
   return normalizeWorkspaceRootsState(envelope.data)
+}
+
+export async function getThreadQueueState(): Promise<ThreadQueueState> {
+  const response = await fetch('/codex-api/thread-queue-state')
+  const payload = (await response.json()) as unknown
+  if (!response.ok) {
+    throw new Error('Failed to load thread queue state')
+  }
+  const envelope =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  return normalizeThreadQueueState(envelope.data)
+}
+
+export async function setThreadQueueState(nextState: ThreadQueueState): Promise<void> {
+  const response = await fetch('/codex-api/thread-queue-state', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(normalizeThreadQueueState(nextState)),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to save thread queue state')
+  }
 }
 
 export async function createWorktree(sourceCwd: string, baseBranch?: string): Promise<WorktreeCreateResult> {

--- a/src/components/content/QueuedMessages.vue
+++ b/src/components/content/QueuedMessages.vue
@@ -1,7 +1,31 @@
 <template>
   <div v-if="messages.length > 0" class="queued-messages">
     <div class="queued-messages-inner">
-    <div v-for="msg in messages" :key="msg.id" class="queued-row">
+    <div
+      v-for="msg in messages"
+      :key="msg.id"
+      class="queued-row"
+      :class="{
+        'is-dragging': draggedMessageId === msg.id,
+        'is-drop-target': dropTargetMessageId === msg.id && draggedMessageId !== msg.id,
+      }"
+      draggable="true"
+      @dragstart="onDragStart($event, msg.id)"
+      @dragover.prevent="onDragOver(msg.id)"
+      @dragleave="onDragLeave(msg.id)"
+      @drop.prevent="onDrop(msg.id)"
+      @dragend="resetDragState"
+    >
+      <button
+        class="queued-row-drag"
+        type="button"
+        :aria-label="t('Drag to reorder queued message')"
+        :title="t('Drag to reorder queued message')"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="currentColor" d="M9 5.5A1.5 1.5 0 1 1 6 5.5a1.5 1.5 0 0 1 3 0m0 6.5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1.5 8A1.5 1.5 0 1 0 7.5 17a1.5 1.5 0 0 0 0 3m10-13A1.5 1.5 0 1 0 17.5 4a1.5 1.5 0 0 0 0 3m1.5 5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m-1.5 8a1.5 1.5 0 1 0 0-3a1.5 1.5 0 0 0 0 3" />
+        </svg>
+      </button>
       <svg class="queued-row-icon" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
         <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
           d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
@@ -23,6 +47,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 
 type QueuedMessageRow = {
@@ -37,13 +62,48 @@ defineProps<{
   messages: QueuedMessageRow[]
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   edit: [messageId: string]
   steer: [messageId: string]
   delete: [messageId: string]
+  reorder: [payload: { draggedId: string; targetId: string }]
 }>()
 
 const { t } = useUiLanguage()
+const draggedMessageId = ref('')
+const dropTargetMessageId = ref('')
+
+function onDragStart(event: DragEvent, messageId: string): void {
+  draggedMessageId.value = messageId
+  dropTargetMessageId.value = ''
+  event.dataTransfer?.setData('text/plain', messageId)
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+  }
+}
+
+function onDragOver(messageId: string): void {
+  if (!draggedMessageId.value || draggedMessageId.value === messageId) return
+  dropTargetMessageId.value = messageId
+}
+
+function onDragLeave(messageId: string): void {
+  if (dropTargetMessageId.value === messageId) {
+    dropTargetMessageId.value = ''
+  }
+}
+
+function onDrop(targetId: string): void {
+  const draggedId = draggedMessageId.value
+  resetDragState()
+  if (!draggedId || draggedId === targetId) return
+  emit('reorder', { draggedId, targetId })
+}
+
+function resetDragState(): void {
+  draggedMessageId.value = ''
+  dropTargetMessageId.value = ''
+}
 
 function getMessagePreview(message: QueuedMessageRow): string {
   const text = message.text.trim()
@@ -74,7 +134,19 @@ function getMessagePreview(message: QueuedMessageRow): string {
 }
 
 .queued-row {
-  @apply flex min-w-0 items-center gap-2 rounded-lg py-1 text-sm;
+  @apply flex min-w-0 items-center gap-2 rounded-lg py-1 text-sm transition;
+}
+
+.queued-row.is-dragging {
+  @apply opacity-50;
+}
+
+.queued-row.is-drop-target {
+  @apply bg-zinc-200/70;
+}
+
+.queued-row-drag {
+  @apply inline-flex h-6 w-6 shrink-0 cursor-grab items-center justify-center rounded-md border-0 bg-transparent text-zinc-400 transition hover:bg-zinc-200 hover:text-zinc-700 active:cursor-grabbing;
 }
 
 .queued-row-icon {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4985,6 +4985,25 @@ export function useDesktopState() {
       : omitKey(queuedMessagesByThreadId.value, threadId)
   }
 
+  function reorderQueuedMessage(draggedId: string, targetId: string): void {
+    const threadId = selectedThreadId.value
+    if (!threadId) return
+    const queue = queuedMessagesByThreadId.value[threadId]
+    if (!queue) return
+
+    const fromIndex = queue.findIndex((m) => m.id === draggedId)
+    const toIndex = queue.findIndex((m) => m.id === targetId)
+    if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return
+
+    const next = [...queue]
+    const [moved] = next.splice(fromIndex, 1)
+    next.splice(toIndex, 0, moved)
+    queuedMessagesByThreadId.value = {
+      ...queuedMessagesByThreadId.value,
+      [threadId]: next,
+    }
+  }
+
   function steerQueuedMessage(messageId: string): void {
     const threadId = selectedThreadId.value
     if (!threadId) return
@@ -5049,6 +5068,7 @@ export function useDesktopState() {
     interruptSelectedThreadTurn,
     selectedThreadQueuedMessages,
     removeQueuedMessage,
+    reorderQueuedMessage,
     steerQueuedMessage,
     setSelectedCollaborationMode,
     readModelIdForThread,

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -18,8 +18,10 @@ import {
   revertThreadFileChanges,
   rollbackThread,
   getThreadGroupsPage,
+  getThreadQueueState,
   getWorkspaceRootsState,
   setCodexSpeedMode,
+  setThreadQueueState,
   setWorkspaceRootsState,
   getThreadTitleCache,
   persistThreadTitle,
@@ -31,6 +33,7 @@ import {
   startThreadTurn,
   type RpcNotification,
   type SkillInfo,
+  type ThreadQueueState,
   type WorkspaceRootsState,
 } from '../api/codexGateway'
 import { normalizeFileChangeStatus, toUiFileChanges } from '../api/normalizers/v2'
@@ -1053,6 +1056,7 @@ export function useDesktopState() {
   }
   const queuedMessagesByThreadId = ref<Record<string, QueuedMessage[]>>({})
   const queueProcessingByThreadId = ref<Record<string, boolean>>({})
+  let hasLoadedPersistedQueueState = false
   const eventUnreadByThreadId = ref<Record<string, boolean>>({})
   const availableModelIds = ref<string[]>([])
   const availableCollaborationModes = ref<CollaborationModeOption[]>([
@@ -1788,6 +1792,11 @@ export function useDesktopState() {
     )
     threadListedByServerById.value = pruneThreadStateMap(threadListedByServerById.value, activeThreadIds)
     persistedUserMessageByThreadId.value = pruneThreadStateMap(persistedUserMessageByThreadId.value, activeThreadIds)
+    const nextQueuedMessages = pruneThreadStateMap(queuedMessagesByThreadId.value, activeThreadIds)
+    if (nextQueuedMessages !== queuedMessagesByThreadId.value) {
+      queuedMessagesByThreadId.value = nextQueuedMessages
+      persistQueueState()
+    }
     threadTokenUsageByThreadId.value = pruneThreadStateMap(threadTokenUsageByThreadId.value, activeThreadIds)
     eventUnreadByThreadId.value = pruneThreadStateMap(eventUnreadByThreadId.value, activeThreadIds)
     inProgressById.value = pruneThreadStateMap(inProgressById.value, activeThreadIds)
@@ -3654,6 +3663,43 @@ export function useDesktopState() {
     applyThreadFlags()
   }
 
+  function normalizeQueueStateForPersistence(state: Record<string, QueuedMessage[]>): ThreadQueueState {
+    const next: ThreadQueueState = {}
+    for (const [threadId, queue] of Object.entries(state)) {
+      const normalizedThreadId = threadId.trim()
+      if (!normalizedThreadId || queue.length === 0) continue
+      next[normalizedThreadId] = queue.map((message) => ({
+        id: message.id,
+        text: message.text,
+        imageUrls: [...message.imageUrls],
+        skills: message.skills.map((skill) => ({ name: skill.name, path: skill.path })),
+        fileAttachments: message.fileAttachments.map((attachment) => ({
+          label: attachment.label,
+          path: attachment.path,
+          fsPath: attachment.fsPath,
+        })),
+        collaborationMode: message.collaborationMode,
+      }))
+    }
+    return next
+  }
+
+  function persistQueueState(): void {
+    void setThreadQueueState(normalizeQueueStateForPersistence(queuedMessagesByThreadId.value)).catch(() => {
+      // Queue persistence is best-effort; keep the current in-memory queue usable.
+    })
+  }
+
+  async function loadPersistedQueueStateIfNeeded(): Promise<void> {
+    if (hasLoadedPersistedQueueState) return
+    hasLoadedPersistedQueueState = true
+    try {
+      queuedMessagesByThreadId.value = await getThreadQueueState()
+    } catch {
+      // Backend queue state is optional during startup.
+    }
+  }
+
   function mergeThreadGroupPages(previous: UiProjectGroup[], incoming: UiProjectGroup[]): UiProjectGroup[] {
     if (previous.length === 0) return incoming
     if (incoming.length === 0) return previous
@@ -3954,6 +4000,7 @@ export function useDesktopState() {
     const awaitAncillaryRefreshes = options.awaitAncillaryRefreshes === true
 
     try {
+      await loadPersistedQueueStateIfNeeded()
       await loadThreads()
       if (includeSelectedThreadMessages) {
         await loadMessages(selectedThreadId.value)
@@ -4193,6 +4240,7 @@ export function useDesktopState() {
         ...queuedMessagesByThreadId.value,
         [threadId]: nextQueue,
       }
+      persistQueueState()
       return
     }
 
@@ -4465,6 +4513,7 @@ export function useDesktopState() {
     queuedMessagesByThreadId.value = rest.length > 0
       ? { ...queuedMessagesByThreadId.value, [threadId]: rest }
       : omitKey(queuedMessagesByThreadId.value, threadId)
+    persistQueueState()
     isSendingMessage.value = true
     error.value = ''
     shouldAutoScrollOnNextAgentEvent = true
@@ -4964,6 +5013,7 @@ export function useDesktopState() {
     persistedUserMessageByThreadId.value = {}
     queuedMessagesByThreadId.value = {}
     queueProcessingByThreadId.value = {}
+    persistQueueState()
     codexRateLimit.value = null
     threadTokenUsageByThreadId.value = {}
   }
@@ -4983,6 +5033,7 @@ export function useDesktopState() {
     queuedMessagesByThreadId.value = next.length > 0
       ? { ...queuedMessagesByThreadId.value, [threadId]: next }
       : omitKey(queuedMessagesByThreadId.value, threadId)
+    persistQueueState()
   }
 
   function reorderQueuedMessage(draggedId: string, targetId: string): void {
@@ -5002,6 +5053,7 @@ export function useDesktopState() {
       ...queuedMessagesByThreadId.value,
       [threadId]: next,
     }
+    persistQueueState()
   }
 
   function steerQueuedMessage(messageId: string): void {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2860,6 +2860,106 @@ async function writePinnedThreadIds(threadIds: string[]): Promise<void> {
 }
 
 const FIRST_LAUNCH_PLUGINS_CARD_DISMISSED_KEY = 'first-launch-plugins-card-dismissed'
+const THREAD_QUEUE_STATE_KEY = 'thread-queue-state'
+
+type StoredQueuedMessage = {
+  id: string
+  text: string
+  imageUrls: string[]
+  skills: Array<{ name: string; path: string }>
+  fileAttachments: Array<{ label: string; path: string; fsPath: string }>
+  collaborationMode: 'default' | 'plan'
+}
+
+type ThreadQueueState = Record<string, StoredQueuedMessage[]>
+
+function normalizeStoredQueuedMessage(value: unknown): StoredQueuedMessage | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  const id = typeof record.id === 'string' ? record.id.trim() : ''
+  if (!id) return null
+
+  const normalizeNamedPathItems = (items: unknown): Array<{ name: string; path: string }> => {
+    if (!Array.isArray(items)) return []
+    return items.flatMap((item) => {
+      const itemRecord = asRecord(item)
+      if (!itemRecord) return []
+      const name = typeof itemRecord.name === 'string' ? itemRecord.name.trim() : ''
+      const path = typeof itemRecord.path === 'string' ? itemRecord.path.trim() : ''
+      return name && path ? [{ name, path }] : []
+    })
+  }
+
+  const normalizeFileAttachments = (items: unknown): Array<{ label: string; path: string; fsPath: string }> => {
+    if (!Array.isArray(items)) return []
+    return items.flatMap((item) => {
+      const itemRecord = asRecord(item)
+      if (!itemRecord) return []
+      const label = typeof itemRecord.label === 'string' ? itemRecord.label.trim() : ''
+      const path = typeof itemRecord.path === 'string' ? itemRecord.path.trim() : ''
+      const fsPath = typeof itemRecord.fsPath === 'string' ? itemRecord.fsPath.trim() : ''
+      return label && path && fsPath ? [{ label, path, fsPath }] : []
+    })
+  }
+
+  return {
+    id,
+    text: typeof record.text === 'string' ? record.text : '',
+    imageUrls: normalizeStringArray(record.imageUrls),
+    skills: normalizeNamedPathItems(record.skills),
+    fileAttachments: normalizeFileAttachments(record.fileAttachments),
+    collaborationMode: record.collaborationMode === 'plan' ? 'plan' : 'default',
+  }
+}
+
+function normalizeThreadQueueState(value: unknown): ThreadQueueState {
+  const record = asRecord(value)
+  if (!record) return {}
+
+  const state: ThreadQueueState = {}
+  for (const [threadId, rawMessages] of Object.entries(record)) {
+    const normalizedThreadId = threadId.trim()
+    if (!normalizedThreadId || !Array.isArray(rawMessages)) continue
+    const messages = rawMessages.flatMap((item) => {
+      const message = normalizeStoredQueuedMessage(item)
+      return message ? [message] : []
+    })
+    if (messages.length > 0) {
+      state[normalizedThreadId] = messages
+    }
+  }
+  return state
+}
+
+async function readThreadQueueState(): Promise<ThreadQueueState> {
+  const statePath = getCodexGlobalStatePath()
+  try {
+    const raw = await readFile(statePath, 'utf8')
+    const payload = asRecord(JSON.parse(raw)) ?? {}
+    return normalizeThreadQueueState(payload[THREAD_QUEUE_STATE_KEY])
+  } catch {
+    return {}
+  }
+}
+
+async function writeThreadQueueState(nextState: ThreadQueueState): Promise<void> {
+  const statePath = getCodexGlobalStatePath()
+  let payload: Record<string, unknown> = {}
+  try {
+    const raw = await readFile(statePath, 'utf8')
+    payload = asRecord(JSON.parse(raw)) ?? {}
+  } catch {
+    payload = {}
+  }
+  const normalized = normalizeThreadQueueState(nextState)
+  if (Object.keys(normalized).length > 0) {
+    payload[THREAD_QUEUE_STATE_KEY] = normalized
+  } else {
+    delete payload[THREAD_QUEUE_STATE_KEY]
+  }
+  await writeFile(statePath, JSON.stringify(payload), 'utf8')
+}
 
 async function readFirstLaunchPluginsCardDismissed(): Promise<boolean> {
   const statePath = getCodexGlobalStatePath()
@@ -4887,6 +4987,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'GET' && url.pathname === '/codex-api/thread-queue-state') {
+        const state = await readThreadQueueState()
+        setJson(res, 200, { data: state })
+        return
+      }
+
       if (req.method === 'GET' && url.pathname === '/codex-api/home-directory') {
         setJson(res, 200, { data: { path: homedir() } })
         return
@@ -5169,6 +5275,18 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           active: normalizeStringArray(record.active),
         }
         await writeWorkspaceRootsState(nextState)
+        setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'PUT' && url.pathname === '/codex-api/thread-queue-state') {
+        const payload = await readJsonBody(req)
+        const record = asRecord(payload)
+        if (!record) {
+          setJson(res, 400, { error: 'Invalid body: expected object' })
+          return
+        }
+        await writeThreadQueueState(normalizeThreadQueueState(record))
         setJson(res, 200, { ok: true })
         return
       }

--- a/tests.md
+++ b/tests.md
@@ -3763,10 +3763,10 @@ When a turn is already running, the in-progress message path defaults to `Queue`
 
 ---
 
-### Drag reorder queued messages
+### Backend-persisted queued messages and drag reorder
 
 #### Feature/Change Name
-Queued messages can be reordered by dragging a queued row before another queued row.
+Queued messages are saved through the backend, survive page refresh, and can be reordered by dragging a queued row before another queued row.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
@@ -3776,13 +3776,18 @@ Queued messages can be reordered by dragging a queued row before another queued 
 
 #### Steps
 1. In light theme, confirm each queued row has a drag handle at the start of the row
-2. Drag the third queued message onto the first queued message
-3. Confirm the third message moves to the first position and the remaining queued messages keep their relative order
-4. Let the active turn finish and confirm the next sent queued message is the first reordered item
-5. Queue at least two more messages, switch to dark theme, and repeat the drag reorder check
+2. Refresh the page and reopen the same thread
+3. Confirm all queued rows are still visible in the same order
+4. Drag the third queued message onto the first queued message
+5. Confirm the third message moves to the first position and the remaining queued messages keep their relative order
+6. Refresh again and confirm the reordered queue order is preserved
+7. Let the active turn finish and confirm the next sent queued message is the first reordered item
+8. Queue at least two more messages, switch to dark theme, and repeat the drag reorder check
 
 #### Expected Results
+- Queued rows survive a page refresh because they are restored from backend state
 - Dragging a queued row onto another queued row immediately reorders the queue
+- The reordered queue order survives page refresh
 - The reordered queue order controls which message sends next after the active turn finishes
 - Edit, Steer, and Delete actions still operate on the correct queued row after reordering
 - Drag handle, hover/drop target, and row text remain readable in both light theme and dark theme

--- a/tests.md
+++ b/tests.md
@@ -3731,3 +3731,32 @@ Terminal quick commands are discovered from the current project instead of using
 #### Rollback/Cleanup
 - Remove any temporary files created under the project root or `scripts/`
 - Remove custom quick commands from browser local storage if needed
+
+---
+
+### Queue mode is default for in-progress messages
+
+#### Feature/Change Name
+When a turn is already running, the in-progress message path defaults to `Queue` for new sessions and existing users without a saved preference.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Open any existing thread with message composer enabled
+3. Start from a clean setting state by clearing localStorage key `codex-web-local.in-progress-send-mode` if present
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. Open a thread and ensure no previous turn is running
+2. Confirm settings shows `When busy` line labeled as `Queue`
+3. Send a message that triggers an in-progress response
+4. While the response is running, submit a second message and observe submit mode label / destination behavior
+5. Open the queue list and confirm the second message is queued
+6. Switch to dark theme and repeat step 4 using another thread
+
+#### Expected Results
+- The in-progress setting defaults to `Queue` when no saved preference exists
+- A second message sent during an active turn is queued, not used as steer
+- Queue order and queued item actions remain functional in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Clear the queue by sending/steering queued items or deleting queued rows

--- a/tests.md
+++ b/tests.md
@@ -3760,3 +3760,32 @@ When a turn is already running, the in-progress message path defaults to `Queue`
 
 #### Rollback/Cleanup
 - Clear the queue by sending/steering queued items or deleting queued rows
+
+---
+
+### Drag reorder queued messages
+
+#### Feature/Change Name
+Queued messages can be reordered by dragging a queued row before another queued row.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Open a thread where a turn is actively running
+3. Queue at least three messages while the turn is running
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, confirm each queued row has a drag handle at the start of the row
+2. Drag the third queued message onto the first queued message
+3. Confirm the third message moves to the first position and the remaining queued messages keep their relative order
+4. Let the active turn finish and confirm the next sent queued message is the first reordered item
+5. Queue at least two more messages, switch to dark theme, and repeat the drag reorder check
+
+#### Expected Results
+- Dragging a queued row onto another queued row immediately reorders the queue
+- The reordered queue order controls which message sends next after the active turn finishes
+- Edit, Steer, and Delete actions still operate on the correct queued row after reordering
+- Drag handle, hover/drop target, and row text remain readable in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Delete any queued test messages that should not be sent


### PR DESCRIPTION
## Summary
- Default in-progress sends to Queue when no preference is saved
- Add drag reorder support for queued messages
- Persist queued messages through backend global state and hydrate them after refresh

## Verification
- pnpm exec vue-tsc --noEmit
- pnpm run build
- Playwright TestChat refresh check: queued messages 1, 2, 3 remained visible after refresh