### PR TITLE
Keep projectless chats visible after refresh

### DIFF
--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -731,3 +731,11 @@ After each feature implementation session that uses this skill:
 - Duplicate slugs retry as `slug-2`, `slug-3`, and so on for up to 100 attempts.
 - Both the workspace root and date directory are created recursively and verified as real directories, not symlinks.
 - The app-server start payload for projectless chats uses the created directory as `cwd` and `outputDirectory`, with `workspaceRoot` set to `~/Documents/Codex`.
+
+## Findings: Projectless Chats Sidebar Visibility (2026-04-28)
+
+- Codex.app keeps projectless chats separate from Projects; when there are no projectless chats, the sidebar Chats section renders `No chats` even if many project threads exist.
+- Web parity needs two filters working together:
+  - workspace-root/project filtering must preserve projectless thread groups from `thread/list`, otherwise they disappear after the optimistic row is replaced by server state
+  - the rendered Projects section must still hide those projectless groups, while the Chats section lists them
+- A projectless thread cwd under `~/Documents/Codex/YYYY-MM-DD/<slug>` should remain in the sidebar Chats section after title generation and thread-list refreshes.

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -966,7 +966,7 @@ const globalThreads = computed<UiThread[]>(() => {
 })
 
 const chatThreads = computed(() => {
-  const rows = globalThreads.value.slice()
+  const rows = globalThreads.value.filter((thread) => isProjectlessChatPath(thread.cwd))
   const timestampKey = chatSortMode.value === 'created' ? 'createdAtIso' : 'updatedAtIso'
   return rows
     .sort((first, second) => {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -55,7 +55,7 @@ import type {
   UiTokenUsageBreakdown,
   UiThread,
 } from '../types/codex'
-import { normalizePathForUi, toProjectName } from '../pathUtils.js'
+import { isProjectlessChatPath, normalizePathForUi, toProjectName } from '../pathUtils.js'
 
 function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
   return groups.flatMap((group) => group.threads)
@@ -3627,7 +3627,10 @@ export function useDesktopState() {
     const allowedProjectNames = new Set(
       rootsState.order.map((rootPath) => toProjectNameFromWorkspaceRoot(rootPath)),
     )
-    return groups.filter((group) => allowedProjectNames.has(group.projectName))
+    return groups.filter((group) => {
+      if (allowedProjectNames.has(group.projectName)) return true
+      return group.threads.some((thread) => isProjectlessChatPath(thread.cwd))
+    })
   }
 
   function applyThreadGroups(groups: UiProjectGroup[], rootsState: WorkspaceRootsState | null): void {

--- a/tests.md
+++ b/tests.md
@@ -63,6 +63,7 @@ This file tracks manual regression and feature verification steps.
 - Sending the first message creates a real directory under `~/Documents/Codex/<YYYY-MM-DD>/`.
 - Folder names are derived from the prompt using lowercase alphanumeric tokens, with suffixes for duplicates.
 - Projectless chat rows appear in the `Chats` section and do not create a separate project group from the generated folder name.
+- Short projectless prompts such as `hi` remain visible in `Chats` after the thread list refreshes and workspace-root filtering runs.
 - If the selected model returns `requires a newer version of Codex`, the turn retries with `gpt-5.4-mini` instead of leaving the new chat failed on 5.5.
 - Light and dark theme composer surfaces remain readable and unchanged apart from the folder behavior.
 


### PR DESCRIPTION
## Summary\n- Preserve projectless thread groups through workspace-root filtering so Chats rows survive thread-list refreshes\n- Keep the Chats shelf limited to projectless chats while Projects stays project-only\n- Document parity finding and manual regression coverage\n\n## Verification\n- pnpm run build:frontend\n- Playwright exact `hi` flow on http://127.0.0.1:5175: active row stayed in Chats after delayed refresh and did not appear in Projects\n\nScreenshots:\n- Codex.app reference: output/playwright/chat-disappears-codex-reference.png\n- Web before: output/playwright/chat-disappears-web-after.png\n- Web after: output/playwright/chat-disappears-web-after-fixed.png