### PR TITLE
fix: open Composio no-browser login in new tab

### DIFF
--- a/src/components/content/DirectoryHub.vue
+++ b/src/components/content/DirectoryHub.vue
@@ -1359,10 +1359,22 @@ async function runComposioPrimaryAction(connector: DirectoryComposioConnector): 
 
 async function startComposioCliLogin(): Promise<void> {
   isStartingComposioLogin.value = true
+  const loginTab = window.open('about:blank', '_blank')
+  if (loginTab) {
+    loginTab.opener = null
+  }
   try {
-    await startDirectoryComposioCliLogin()
+    const result = await startDirectoryComposioCliLogin()
+    if (result.loginUrl && loginTab) {
+      loginTab.location.href = result.loginUrl
+    } else if (result.loginUrl) {
+      openExternalUrl(result.loginUrl)
+    } else {
+      loginTab?.close()
+    }
     showToast('Composio CLI login started')
   } catch (error) {
+    loginTab?.close()
     showToast(error instanceof Error ? error.message : 'Failed to start Composio login', 'error')
   } finally {
     isStartingComposioLogin.value = false

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1430,20 +1430,54 @@ async function startComposioLogin(): Promise<ComposioLoginResult> {
   if (!command) {
     throw new Error('Composio CLI is not installed')
   }
-  const invocation = getSpawnInvocation(command, ['login', '-y'])
+  const invocation = getSpawnInvocation(command, ['login', '--no-browser', '-y'])
   const proc = spawn(invocation.command, invocation.args, {
     cwd: process.cwd(),
     env: process.env,
     detached: true,
-    stdio: 'ignore',
+    stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
   })
   proc.unref()
+
+  let stdout = ''
+  let stderr = ''
+  proc.stdout.setEncoding('utf8')
+  proc.stderr.setEncoding('utf8')
+  proc.stderr.on('data', (chunk) => { stderr += chunk })
+
+  const loginUrl = await new Promise<string>((resolveLoginUrl, reject) => {
+    const timeout = setTimeout(() => {
+      proc.kill('SIGTERM')
+      reject(new Error(stderr.trim() || stdout.trim() || 'Timed out waiting for Composio CLI login URL'))
+    }, 10_000)
+    const finish = (url: string) => {
+      clearTimeout(timeout)
+      proc.stdout.destroy()
+      proc.stderr.destroy()
+      resolveLoginUrl(url)
+    }
+    proc.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    proc.once('close', (code) => {
+      clearTimeout(timeout)
+      reject(new Error(stderr.trim() || stdout.trim() || `Composio CLI login exited with code ${code ?? 0}`))
+    })
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk
+      const url = stdout.match(/https?:\/\/\S+/)?.[0] ?? ''
+      if (url) finish(url)
+    })
+  })
+
+  const cliKey = loginUrl ? (new URL(loginUrl).searchParams.get('cliKey') ?? '') : ''
   return {
     status: 'started',
-    message: 'Composio CLI login started',
-    loginUrl: '',
-    cliKey: '',
+    message: 'Composio CLI login URL created',
+    loginUrl,
+    cliKey,
     expiresAt: '',
   }
 }

--- a/tests.md
+++ b/tests.md
@@ -3240,22 +3240,23 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Co
 16. Search Apps and verify matching results are not capped to the Popular top 100 list
 17. Switch to `Composio` and verify the workspace summary card shows the current Composio CLI login state, or a clear not-installed / not-authenticated message appears
 18. If Composio CLI is not installed, click `Install` and verify the app installs the CLI to `~/.composio/composio` using the official Composio installer
-19. Verify Composio connector cards show real connector details such as tool counts, trigger counts, auth mode, and connection state instead of only aggregate totals
-20. In Composio search, type `instagram` and verify the Instagram connector appears in the results
-21. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
-22. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
-23. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
-24. On Composio, verify that if more than one page exists, `Load more` appears and appends additional connectors while keeping prior results visible
-25. In Composio search, verify the page state resets (the list returns to the first result page and stale pagination is cleared)
-26. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
-27. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
-28. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
-29. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
-30. Verify the `MCPs(count)` section does not show its own search or sort controls
-31. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
-32. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
-33. Verify both light and dark themes render Composio cards and status/detail actions with readable contrast
-34. In dark mode, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
+19. If Composio CLI is installed but not authenticated, click `Login` and verify the app opens a new tab, starts `composio login --no-browser -y`, captures the returned auth URL, and navigates the new tab to that URL
+20. Verify Composio connector cards show real connector details such as tool counts, trigger counts, auth mode, and connection state instead of only aggregate totals
+21. In Composio search, type `instagram` and verify the Instagram connector appears in the results
+22. Open a disconnected Composio connector and click `Connect` or `Reconnect`; verify the returned `connect.composio.dev` authorization URL opens
+23. Open a connected Composio connector and verify connection rows show account identifiers and statuses such as `Active` or `Expired`
+24. Click `Try it!` on a connected or no-auth Composio connector and verify a new thread opens with a Composio-specific prompt and the `composio-cli` skill attached
+25. On Composio, verify that if more than one page exists, `Load more` appears and appends additional connectors while keeping prior results visible
+26. In Composio search, verify the page state resets (the list returns to the first result page and stale pagination is cleared)
+27. Switch to `Skills` and verify the view shows an `MCPs(count)` collapsible section immediately before the `Installed skills (count)` section
+28. Expand `MCPs(count)` and verify server cards show auth status and tool/resource counts, or the unavailable/empty state appears without breaking the page
+29. Click header `Refresh` while on `Skills` and verify MCP state reloads (it should perform MCP reload behavior on this tab instead of using a separate `Reload MCPs` button)
+30. Verify no separate `Reload MCPs` button is shown in the header or inside the MCP section body
+31. Verify the `MCPs(count)` section does not show its own search or sort controls
+32. Verify MCP cards use the same visual card/grid layout pattern as Installed skills cards (avatar circle, title row, badge, secondary text)
+33. Verify the `Installed skills (count)` section below MCPs still supports the existing Skills Hub behavior
+34. Verify both light and dark themes render Composio cards and status/detail actions with readable contrast
+35. In dark mode, verify MCP cards use the same dark card surface styling as Installed skills cards (not a light/white card)
 
 #### Expected Results
 - The directory tabs render without a full-page error
@@ -3266,6 +3267,7 @@ The `#/skills` route shows a full Skills & Apps directory with Plugins, Apps, Co
 - Disconnected apps are labeled `Login`; connected apps are labeled `Manage`
 - The Composio tab reuses the authenticated local Composio CLI state and does not require a separate app-specific login
 - The Composio install action uses the official installer and produces a working `~/.composio/composio` binary
+- The Composio login action opens a new tab from the click, starts the CLI in non-browser mode with `composio login --no-browser -y`, then navigates that tab to the returned auth URL
 - Composio connector cards and detail views show concrete connector details, connection rows, and useful tool samples
 - Connected or no-auth Composio connectors expose `Try it!`, creating a new chat with the `composio-cli` skill attached
 - Composio pagination supports page-by-page loading with a clear `Load more` path and cursor-based page continuation


### PR DESCRIPTION
Update the Composio CLI login flow so the Login button opens a new tab immediately, starts `composio login --no-browser -y`, captures the returned auth URL while keeping the CLI process alive, and navigates the new tab to that URL.\n\nVerification:\n- Playwright click produced two pages and the popup navigated to dashboard.composio.dev\n- Restored local Composio auth and confirmed authenticated status\n- pnpm run -s build:frontend