### PR TITLE
Recognize bare filenames as chat file links

### DIFF
--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -1408,6 +1408,9 @@ function isFilePath(value: string): boolean {
   const looksLikeRelative = value.startsWith('./') || value.startsWith('../') || value.startsWith('~/')
   if (looksLikeUnixAbsolute || looksLikeWindowsAbsolute || looksLikeRelative) return true
 
+  const looksLikeBareFilename = /^[A-Za-z0-9._@() -]+\.[A-Za-z0-9]{1,12}$/u.test(value)
+  if (looksLikeBareFilename) return true
+
   // Bare relative paths should look like actual path segments, not arbitrary prose containing "/".
   return /^[A-Za-z0-9._@() -]+(?:[\\/][A-Za-z0-9._@() -]+)+$/u.test(value)
 }

--- a/tests.md
+++ b/tests.md
@@ -1999,6 +1999,30 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Remove test file if it was created only for this verification.
 
+### Feature: Backticked bare filenames render as file links
+
+#### Prerequisites
+- App is running from this repository.
+- An active thread is open with a project `cwd`.
+- Optional: file exists at `<project cwd>/redroid_mainactivity.png`.
+- Verify once in light theme and once in dark theme.
+
+#### Steps
+1. Send this exact message:
+   `redroid_mainactivity.png`
+2. In the rendered message, confirm it appears as one clickable file link.
+3. Click the link and confirm it opens local browse for `<project cwd>/redroid_mainactivity.png`.
+4. Switch between light and dark theme and confirm the file-link chip remains readable.
+
+#### Expected Results
+- The backticked bare filename renders as `a.message-file-link`, not inline code.
+- The link href resolves through `/codex-local-browse` using the current project `cwd`.
+- The title contains the resolved file path, and the visible text is `redroid_mainactivity.png`.
+- Light and dark themes both show the link with readable contrast.
+
+#### Rollback/Cleanup
+- Remove `<project cwd>/redroid_mainactivity.png` if it was created only for this verification.
+
 ---
 
 ### Fix: Codex.app "New Worktree" Button Missing After Account Switch (CDP Injection)


### PR DESCRIPTION
## Summary
- Treat conservative bare filenames with extensions as file references in chat parsing
- Add manual regression coverage for backticked bare filename file links

## Testing
- Parser sanity check for redroid_mainactivity.png, qwe.txt, slash paths, URL exclusion, prose exclusion, and trailing slash exclusion
- pnpm run build:frontend could not complete in this worktree because node_modules is absent; a temporary shared dependency symlink reached TypeScript but was missing vitest, @xterm/*, and node-pty-prebuilt-multiarch