### PR TITLE
Show skill sources and combine prompts in composer

### DIFF
--- a/src/components/content/ComposerSearchDropdown.vue
+++ b/src/components/content/ComposerSearchDropdown.vue
@@ -88,7 +88,7 @@
                 </span>
               </button>
               <button
-                v-if="allowRemove"
+                v-if="allowRemove && opt.removable"
                 class="search-dropdown-option-remove"
                 type="button"
                 :aria-label="`${removeLabel} ${opt.label}`"
@@ -117,7 +117,8 @@ export type SearchDropdownOption = {
   description?: string
   badge?: string
   badgeLabel?: string
-  badgeTone?: 'repo' | 'system' | 'plugin' | 'composio' | 'user'
+  badgeTone?: 'repo' | 'system' | 'plugin' | 'composio' | 'user' | 'prompt'
+  removable?: boolean
 }
 
 const props = defineProps<{
@@ -366,6 +367,10 @@ onBeforeUnmount(() => {
   @apply border-emerald-200 bg-emerald-50 text-emerald-700;
 }
 
+.search-dropdown-option-badge.is-prompt {
+  @apply border-violet-200 bg-violet-50 text-violet-700;
+}
+
 .search-dropdown-option-copy {
   @apply flex min-w-0 flex-1 flex-col overflow-hidden pr-1;
 }
@@ -459,6 +464,10 @@ onBeforeUnmount(() => {
 
 :global(:root.dark) .search-dropdown-option-badge.is-user {
   @apply border-emerald-900/70 bg-emerald-950 text-emerald-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-prompt {
+  @apply border-violet-900/70 bg-violet-950 text-violet-300;
 }
 
 :global(:root.dark) .search-dropdown-option-type {

--- a/src/components/content/ComposerSearchDropdown.vue
+++ b/src/components/content/ComposerSearchDropdown.vue
@@ -70,8 +70,20 @@
                 @click="onSelect(opt)"
               >
                 <span class="search-dropdown-option-check">{{ selected.has(opt.value) ? '✓' : '' }}</span>
+                <span
+                  v-if="opt.badge"
+                  class="search-dropdown-option-badge"
+                  :class="opt.badgeTone ? `is-${opt.badgeTone}` : ''"
+                  :title="opt.badgeLabel || opt.badge"
+                  aria-hidden="true"
+                >
+                  {{ opt.badge }}
+                </span>
                 <span class="search-dropdown-option-copy">
-                  <span class="search-dropdown-option-label">{{ opt.label }}</span>
+                  <span class="search-dropdown-option-label-row">
+                    <span class="search-dropdown-option-label">{{ opt.label }}</span>
+                    <span v-if="opt.badgeLabel" class="search-dropdown-option-type">{{ opt.badgeLabel }}</span>
+                  </span>
                   <span v-if="opt.description" class="search-dropdown-option-desc">{{ opt.description }}</span>
                 </span>
               </button>
@@ -103,6 +115,9 @@ export type SearchDropdownOption = {
   value: string
   label: string
   description?: string
+  badge?: string
+  badgeLabel?: string
+  badgeTone?: 'repo' | 'system' | 'plugin' | 'composio' | 'user'
 }
 
 const props = defineProps<{
@@ -327,12 +342,44 @@ onBeforeUnmount(() => {
   @apply mt-0.5 w-4 shrink-0 text-center text-[10px] leading-4 text-emerald-600;
 }
 
+.search-dropdown-option-badge {
+  @apply mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-[9px] font-semibold leading-none text-zinc-600;
+}
+
+.search-dropdown-option-badge.is-repo {
+  @apply border-sky-200 bg-sky-50 text-sky-700;
+}
+
+.search-dropdown-option-badge.is-system {
+  @apply border-zinc-300 bg-zinc-100 text-zinc-700;
+}
+
+.search-dropdown-option-badge.is-plugin {
+  @apply border-amber-200 bg-amber-50 text-amber-700;
+}
+
+.search-dropdown-option-badge.is-composio {
+  @apply border-cyan-200 bg-cyan-50 text-cyan-700;
+}
+
+.search-dropdown-option-badge.is-user {
+  @apply border-emerald-200 bg-emerald-50 text-emerald-700;
+}
+
 .search-dropdown-option-copy {
   @apply flex min-w-0 flex-1 flex-col overflow-hidden pr-1;
 }
 
+.search-dropdown-option-label-row {
+  @apply flex min-w-0 items-center gap-2;
+}
+
 .search-dropdown-option-label {
   @apply block min-w-0 truncate text-sm font-medium text-zinc-800;
+}
+
+.search-dropdown-option-type {
+  @apply shrink-0 text-[10px] font-medium uppercase tracking-wide text-zinc-400;
 }
 
 .search-dropdown-option-desc {
@@ -388,6 +435,34 @@ onBeforeUnmount(() => {
 
 :global(:root.dark) .search-dropdown-option-label {
   @apply text-zinc-100;
+}
+
+:global(:root.dark) .search-dropdown-option-badge {
+  @apply border-zinc-700 bg-zinc-800 text-zinc-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-repo {
+  @apply border-sky-900/70 bg-sky-950 text-sky-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-system {
+  @apply border-zinc-600 bg-zinc-800 text-zinc-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-plugin {
+  @apply border-amber-900/70 bg-amber-950 text-amber-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-composio {
+  @apply border-cyan-900/70 bg-cyan-950 text-cyan-300;
+}
+
+:global(:root.dark) .search-dropdown-option-badge.is-user {
+  @apply border-emerald-900/70 bg-emerald-950 text-emerald-300;
+}
+
+:global(:root.dark) .search-dropdown-option-type {
+  @apply text-zinc-500;
 }
 
 :global(:root.dark) .search-dropdown-option-desc {

--- a/src/components/content/ComposerSearchDropdown.vue
+++ b/src/components/content/ComposerSearchDropdown.vue
@@ -117,7 +117,7 @@ export type SearchDropdownOption = {
   description?: string
   badge?: string
   badgeLabel?: string
-  badgeTone?: 'repo' | 'system' | 'plugin' | 'composio' | 'user' | 'prompt'
+  badgeTone?: 'repo' | 'system' | 'plugin' | 'user' | 'prompt'
   removable?: boolean
 }
 
@@ -359,10 +359,6 @@ onBeforeUnmount(() => {
   @apply border-amber-200 bg-amber-50 text-amber-700;
 }
 
-.search-dropdown-option-badge.is-composio {
-  @apply border-cyan-200 bg-cyan-50 text-cyan-700;
-}
-
 .search-dropdown-option-badge.is-user {
   @apply border-emerald-200 bg-emerald-50 text-emerald-700;
 }
@@ -456,10 +452,6 @@ onBeforeUnmount(() => {
 
 :global(:root.dark) .search-dropdown-option-badge.is-plugin {
   @apply border-amber-900/70 bg-amber-950 text-amber-300;
-}
-
-:global(:root.dark) .search-dropdown-option-badge.is-composio {
-  @apply border-cyan-900/70 bg-cyan-950 text-cyan-300;
 }
 
 :global(:root.dark) .search-dropdown-option-badge.is-user {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -252,25 +252,13 @@
             :options="skillDropdownOptions"
             :selected-values="selectedSkillPaths"
             :placeholder="t('Skills')"
-            :search-placeholder="t('Search skills...')"
-            open-direction="up"
-            :disabled="disabled || !activeThreadId || isTurnInProgress"
-            @toggle="onSkillDropdownToggle"
-          />
-
-          <ComposerSearchDropdown
-            class="thread-composer-control"
-            :options="promptDropdownOptions"
-            :selected-values="[]"
-            :placeholder="t('Prompt')"
-            :display-label-override="t('Prompt')"
-            :search-placeholder="t('Search prompt...')"
+            :search-placeholder="t('Search skills and prompts...')"
             :create-label="t('Add new prompt')"
             :allow-remove="true"
             :remove-label="t('Remove prompt')"
             open-direction="up"
             :disabled="disabled || !activeThreadId || isTurnInProgress"
-            @toggle="onPromptDropdownToggle"
+            @toggle="onSkillDropdownToggle"
             @create="onCreatePrompt"
             @remove="onRemovePrompt"
           />
@@ -414,7 +402,7 @@ import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
 type SkillSourceBadge = {
   badge: string
   badgeLabel: string
-  badgeTone: 'repo' | 'system' | 'plugin' | 'composio' | 'user'
+  badgeTone: 'repo' | 'system' | 'plugin' | 'composio' | 'user' | 'prompt'
 }
 
 type SkillItem = { name: string; displayName?: string; description: string; path: string; scope?: string; enabled?: boolean }
@@ -500,6 +488,7 @@ type AttachmentBatchStats = {
 
 const CONTEXT_WINDOW_BASELINE_TOKENS = 12000
 const PASTED_TEXT_FILE_THRESHOLD = 2000
+const PROMPT_OPTION_PREFIX = 'prompt:'
 
 const draft = ref('')
 const selectedImages = ref<SelectedImage[]>([])
@@ -591,24 +580,29 @@ const isPlanModeWaitingForModel = computed(() =>
 
 const selectedSkillPaths = computed(() => selectedSkills.value.map((s) => s.path))
 const skillDropdownOptions = computed(() =>
-  (props.skills ?? []).map((s) => {
-    const source = skillSourceBadge(s)
-    return {
-      value: s.path,
-      label: s.name,
-      description: s.description,
-      badge: source.badge,
-      badgeLabel: source.badgeLabel,
-      badgeTone: source.badgeTone,
-    }
-  }),
-)
-const promptDropdownOptions = computed(() =>
-  savedPrompts.value.map((prompt) => ({
-    value: prompt.path,
-    label: prompt.name,
-    description: prompt.description,
-  })),
+  [
+    ...(props.skills ?? []).map((s) => {
+      const source = skillSourceBadge(s)
+      return {
+        value: s.path,
+        label: s.name,
+        description: s.description,
+        badge: source.badge,
+        badgeLabel: source.badgeLabel,
+        badgeTone: source.badgeTone,
+        removable: false,
+      }
+    }),
+    ...savedPrompts.value.map((prompt) => ({
+      value: promptOptionValue(prompt.path),
+      label: prompt.name,
+      description: prompt.description,
+      badge: 'T',
+      badgeLabel: 'Prompt',
+      badgeTone: 'prompt' as const,
+      removable: true,
+    })),
+  ],
 )
 
 const canSubmit = computed(() => {
@@ -1618,6 +1612,14 @@ async function reloadPrompts(): Promise<void> {
   savedPrompts.value = await getComposerPrompts()
 }
 
+function promptOptionValue(path: string): string {
+  return `${PROMPT_OPTION_PREFIX}${path}`
+}
+
+function promptPathFromOptionValue(value: string): string | null {
+  return value.startsWith(PROMPT_OPTION_PREFIX) ? value.slice(PROMPT_OPTION_PREFIX.length) : null
+}
+
 async function onCreatePrompt(): Promise<void> {
   const name = window.prompt(t('Prompt name'))?.trim() ?? ''
   if (!name) return
@@ -1630,10 +1632,11 @@ async function onCreatePrompt(): Promise<void> {
 }
 
 async function onRemovePrompt(path: string): Promise<void> {
-  const target = savedPrompts.value.find((prompt) => prompt.path === path)
+  const promptPath = promptPathFromOptionValue(path) ?? path
+  const target = savedPrompts.value.find((prompt) => prompt.path === promptPath)
   const confirmed = window.confirm(target ? `${t('Remove prompt')} "${target.name}"?` : t('Remove prompt'))
   if (!confirmed) return
-  const removed = await removeComposerPrompt(path)
+  const removed = await removeComposerPrompt(promptPath)
   if (!removed) return
   await reloadPrompts()
 }
@@ -1705,6 +1708,12 @@ function skillSourceBadge(skill: SkillItem): SkillSourceBadge {
 }
 
 function onSkillDropdownToggle(path: string, checked: boolean): void {
+  const promptPath = promptPathFromOptionValue(path)
+  if (promptPath) {
+    onPromptDropdownToggle(promptPath)
+    return
+  }
+
   if (checked) {
     const skill = (props.skills ?? []).find((s) => s.path === path)
     if (skill && !selectedSkills.value.some((s) => s.path === path)) {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -411,7 +411,13 @@ import IconTablerPlayerStopFilled from '../icons/IconTablerPlayerStopFilled.vue'
 import ComposerDropdown from './ComposerDropdown.vue'
 import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
 
-type SkillItem = { name: string; displayName?: string; description: string; path: string }
+type SkillSourceBadge = {
+  badge: string
+  badgeLabel: string
+  badgeTone: 'repo' | 'system' | 'plugin' | 'composio' | 'user'
+}
+
+type SkillItem = { name: string; displayName?: string; description: string; path: string; scope?: string; enabled?: boolean }
 
 const props = defineProps<{
   activeThreadId: string
@@ -585,11 +591,17 @@ const isPlanModeWaitingForModel = computed(() =>
 
 const selectedSkillPaths = computed(() => selectedSkills.value.map((s) => s.path))
 const skillDropdownOptions = computed(() =>
-  (props.skills ?? []).map((s) => ({
-    value: s.path,
-    label: s.name,
-    description: s.description,
-  })),
+  (props.skills ?? []).map((s) => {
+    const source = skillSourceBadge(s)
+    return {
+      value: s.path,
+      label: s.name,
+      description: s.description,
+      badge: source.badge,
+      badgeLabel: source.badgeLabel,
+      badgeTone: source.badgeTone,
+    }
+  }),
 )
 const promptDropdownOptions = computed(() =>
   savedPrompts.value.map((prompt) => ({
@@ -1672,6 +1684,24 @@ function getMentionBadgeClass(path: string): string {
 function isMarkdownFile(path: string): boolean {
   const ext = getFileExtension(path)
   return ext === 'md' || ext === 'mdx'
+}
+
+function skillSourceBadge(skill: SkillItem): SkillSourceBadge {
+  const path = skill.path.toLowerCase()
+  const name = skill.name.toLowerCase()
+  if (name.includes('composio') || path.includes('/composio-cli/')) {
+    return { badge: 'C', badgeLabel: 'Composio', badgeTone: 'composio' }
+  }
+  if (path.includes('/plugins/cache/')) {
+    return { badge: 'P', badgeLabel: 'Plugin', badgeTone: 'plugin' }
+  }
+  if (skill.scope === 'repo') {
+    return { badge: 'R', badgeLabel: 'Repo', badgeTone: 'repo' }
+  }
+  if (skill.scope === 'system') {
+    return { badge: 'S', badgeLabel: 'System', badgeTone: 'system' }
+  }
+  return { badge: 'U', badgeLabel: 'User', badgeTone: 'user' }
 }
 
 function onSkillDropdownToggle(path: string, checked: boolean): void {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -402,7 +402,7 @@ import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
 type SkillSourceBadge = {
   badge: string
   badgeLabel: string
-  badgeTone: 'repo' | 'system' | 'plugin' | 'composio' | 'user' | 'prompt'
+  badgeTone: 'repo' | 'system' | 'plugin' | 'user' | 'prompt'
 }
 
 type SkillItem = { name: string; displayName?: string; description: string; path: string; scope?: string; enabled?: boolean }
@@ -1691,10 +1691,6 @@ function isMarkdownFile(path: string): boolean {
 
 function skillSourceBadge(skill: SkillItem): SkillSourceBadge {
   const path = skill.path.toLowerCase()
-  const name = skill.name.toLowerCase()
-  if (name.includes('composio') || path.includes('/composio-cli/')) {
-    return { badge: 'C', badgeLabel: 'Composio', badgeTone: 'composio' }
-  }
   if (path.includes('/plugins/cache/')) {
     return { badge: 'P', badgeLabel: 'Plugin', badgeTone: 'plugin' }
   }

--- a/src/composables/useUiLanguage.ts
+++ b/src/composables/useUiLanguage.ts
@@ -109,6 +109,7 @@ const zhCN: Record<string, string> = {
   'Search models...': '搜索模型...',
   'Skills': '技能',
   'Search skills...': '搜索技能...',
+  'Search skills and prompts...': '搜索技能和提示词...',
   'Thinking': '思考强度',
   'Saving thread before stop is available': '线程保存后才能停止',
   'Stop': '停止',

--- a/tests.md
+++ b/tests.md
@@ -3588,10 +3588,10 @@ The home route shows a dismissible first-launch card that introduces Plugins and
 
 ---
 
-### Composer prompt dropdown add/remove flow
+### Composer prompts inside Skills dropdown
 
 #### Feature/Change Name
-The composer control row shows a `Prompt` dropdown next to `Skills`, both menus use the wider card-style popup layout, skills are attached only through the dropdown, and saved prompts can be created, inserted into the draft, and removed with an inline `×` action.
+The composer control row uses one `Skills` dropdown for both skills and saved prompts. The `+` action creates a prompt, prompt rows can be inserted or removed from the same menu, and there is no separate `Prompt` control.
 
 #### Prerequisites/Setup
 1. Dev server running at `http://127.0.0.1:4173`
@@ -3599,23 +3599,24 @@ The composer control row shows a `Prompt` dropdown next to `Skills`, both menus 
 3. Light theme and dark theme both available from the appearance switcher
 
 #### Steps
-1. In light theme, open the composer controls and confirm `Skills` and `Prompt` appear as separate controls
+1. In light theme, open the composer controls and confirm `Skills` appears and no separate `Prompt` control is present
 2. Open `Skills` and verify the popup matches the wider card-like layout with large stacked label/description rows
-3. Confirm each Skills row has a compact source marker, such as `R` for repo, `U` for user, `S` for system, `P` for plugin, or `C` for Composio
-4. Type `/` into the composer and verify no slash skill picker appears
-5. Open `Prompt`, click `Add new prompt`, enter a unique name such as `ui-test-prompt`, and enter sample content such as `Prompt dropdown smoke test`
-6. Reopen `Prompt` and click the new prompt entry
-7. Confirm the prompt text is inserted into the composer draft
-8. Reopen `Prompt`, click the `×` button for `ui-test-prompt`, and confirm the removal dialog
-9. Confirm the prompt disappears from the dropdown
-10. Switch to dark theme and repeat the visibility check for the `Skills` and `Prompt` dropdown contents
+3. Confirm skill rows have compact source markers, such as `R` for repo, `U` for user, `S` for system, `P` for plugin, or `C` for Composio
+4. Click the `+` action in the `Skills` dropdown, enter a unique prompt name such as `ui-test-prompt`, and enter sample content such as `Prompt dropdown smoke test`
+5. Reopen `Skills` and confirm the new prompt appears with a `Prompt` marker and an inline `×` remove action
+6. Click the prompt row and confirm the prompt text is inserted into the composer draft without toggling a skill
+7. Reopen `Skills`, click the `×` button for `ui-test-prompt`, and confirm the removal dialog
+8. Confirm the prompt disappears from the dropdown while skill rows remain available
+9. Type `/` into the composer and verify no slash skill picker appears
+10. Switch to dark theme and repeat the visibility check for the combined `Skills` dropdown contents
 
 #### Expected Results
-- The composer shows `Skills` and `Prompt` as separate dropdown controls in the same row
-- The `Skills` and `Prompt` popups use the wider rounded layout with vertically stacked label/description rows
+- The composer shows one `Skills` dropdown for skills and prompts; no standalone `Prompt` dropdown is rendered
+- The combined `Skills` popup uses the wider rounded layout with vertically stacked label/description rows
 - Skill rows show readable source markers that distinguish repo, user, system, plugin-provided, and Composio skills
+- Prompt rows show a readable `Prompt` marker and are the only rows with an inline remove action
 - Typing `/` in the composer does not open a skill picker
-- `Add new prompt` creates a markdown file in the Codex prompt store and adds it to the dropdown immediately
+- The `+` action creates a markdown file in the Codex prompt store and adds it to the `Skills` dropdown immediately
 - Selecting a saved prompt appends its content into the draft without sending the message
 - Clicking `×` removes only the targeted prompt and updates the dropdown immediately
 - Light theme and dark theme both keep the new control, menu, and remove action readable and usable

--- a/tests.md
+++ b/tests.md
@@ -3601,17 +3601,19 @@ The composer control row shows a `Prompt` dropdown next to `Skills`, both menus 
 #### Steps
 1. In light theme, open the composer controls and confirm `Skills` and `Prompt` appear as separate controls
 2. Open `Skills` and verify the popup matches the wider card-like layout with large stacked label/description rows
-3. Type `/` into the composer and verify no slash skill picker appears
-4. Open `Prompt`, click `Add new prompt`, enter a unique name such as `ui-test-prompt`, and enter sample content such as `Prompt dropdown smoke test`
-5. Reopen `Prompt` and click the new prompt entry
-6. Confirm the prompt text is inserted into the composer draft
-7. Reopen `Prompt`, click the `×` button for `ui-test-prompt`, and confirm the removal dialog
-8. Confirm the prompt disappears from the dropdown
-9. Switch to dark theme and repeat the visibility check for the `Skills` and `Prompt` dropdown contents
+3. Confirm each Skills row has a compact source marker, such as `R` for repo, `U` for user, `S` for system, `P` for plugin, or `C` for Composio
+4. Type `/` into the composer and verify no slash skill picker appears
+5. Open `Prompt`, click `Add new prompt`, enter a unique name such as `ui-test-prompt`, and enter sample content such as `Prompt dropdown smoke test`
+6. Reopen `Prompt` and click the new prompt entry
+7. Confirm the prompt text is inserted into the composer draft
+8. Reopen `Prompt`, click the `×` button for `ui-test-prompt`, and confirm the removal dialog
+9. Confirm the prompt disappears from the dropdown
+10. Switch to dark theme and repeat the visibility check for the `Skills` and `Prompt` dropdown contents
 
 #### Expected Results
 - The composer shows `Skills` and `Prompt` as separate dropdown controls in the same row
 - The `Skills` and `Prompt` popups use the wider rounded layout with vertically stacked label/description rows
+- Skill rows show readable source markers that distinguish repo, user, system, plugin-provided, and Composio skills
 - Typing `/` in the composer does not open a skill picker
 - `Add new prompt` creates a markdown file in the Codex prompt store and adds it to the dropdown immediately
 - Selecting a saved prompt appends its content into the draft without sending the message

--- a/tests.md
+++ b/tests.md
@@ -3601,7 +3601,7 @@ The composer control row uses one `Skills` dropdown for both skills and saved pr
 #### Steps
 1. In light theme, open the composer controls and confirm `Skills` appears and no separate `Prompt` control is present
 2. Open `Skills` and verify the popup matches the wider card-like layout with large stacked label/description rows
-3. Confirm skill rows have compact source markers, such as `R` for repo, `U` for user, `S` for system, `P` for plugin, or `C` for Composio
+3. Confirm skill rows have compact source markers, such as `R` for repo, `U` for user, `S` for system, or `P` for plugin
 4. Click the `+` action in the `Skills` dropdown, enter a unique prompt name such as `ui-test-prompt`, and enter sample content such as `Prompt dropdown smoke test`
 5. Reopen `Skills` and confirm the new prompt appears with a `Prompt` marker and an inline `×` remove action
 6. Click the prompt row and confirm the prompt text is inserted into the composer draft without toggling a skill
@@ -3613,7 +3613,7 @@ The composer control row uses one `Skills` dropdown for both skills and saved pr
 #### Expected Results
 - The composer shows one `Skills` dropdown for skills and prompts; no standalone `Prompt` dropdown is rendered
 - The combined `Skills` popup uses the wider rounded layout with vertically stacked label/description rows
-- Skill rows show readable source markers that distinguish repo, user, system, plugin-provided, and Composio skills
+- Skill rows show readable source markers that distinguish repo, user, system, and plugin-provided skills
 - Prompt rows show a readable `Prompt` marker and are the only rows with an inline remove action
 - Typing `/` in the composer does not open a skill picker
 - The `+` action creates a markdown file in the Codex prompt store and adds it to the `Skills` dropdown immediately


### PR DESCRIPTION
## Summary
- add source badges to composer skill dropdown rows
- move saved prompts into the Skills dropdown and use the Skills plus action to create prompts
- remove the standalone Prompt dropdown and the special Composio skill badge

## Testing
- pnpm run -s build:frontend
- Playwright verified combined Skills/Prompts flow in light and dark themes
- Playwright verified Composio search no longer shows a dedicated Composio marker