### PR TITLE
fix(skills): add PR acceptance metadata

### DIFF
--- a/.agents/skills/github-pr-acceptance/SKILL.md
+++ b/.agents/skills/github-pr-acceptance/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: github-pr-acceptance
+description: Use when the user explicitly asks to accept or merge a GitHub pull request and the PR must show as merged on GitHub, not only in local git history.
+---
+
 # GitHub PR Acceptance
 
 ## When To Use


### PR DESCRIPTION
## Summary
- add YAML metadata to the GitHub PR acceptance skill so skill discovery can identify it by name and description

## Validation
- `git diff --check main..HEAD`
- `node -e "const fs=require('fs'); const s=fs.readFileSync('.agents/skills/github-pr-acceptance/SKILL.md','utf8'); if(!s.startsWith('---\nname: github-pr-acceptance\n')) throw new Error('missing expected front matter'); if(!s.includes('\n---\n\n# GitHub PR Acceptance')) throw new Error('front matter not closed before heading'); console.log('front matter ok')"`