### PR TITLE
Add permanent project worktree action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexapp",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "A lightweight web interface for Codex that runs on top of the Codex app-server, allowing remote access from any browser",
   "type": "module",
   "license": "MIT",

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,6 +69,8 @@
             @select="onSelectThread"
             @archive="onArchiveThread" @start-new-thread="onStartNewThread" @rename-project="onRenameProject"
             @browse-thread-files="onBrowseThreadFiles"
+            @browse-project-files="onBrowseProjectFiles"
+            @create-project-worktree="onCreateProjectWorktree"
             @rename-thread="onRenameThread"
             @fork-thread="onForkThread"
             @remove-project="onRemoveProject" @reorder-project="onReorderProject"
@@ -867,6 +869,7 @@ import { useUiLanguage } from './composables/useUiLanguage'
 import {
   checkoutGitBranch,
   configureTelegramBot,
+  createPermanentWorktree,
   createWorktree,
   createProjectlessThreadDirectory,
   getGitBranchState,
@@ -2034,6 +2037,55 @@ function onBrowseThreadFiles(threadId: string): void {
   }
   if (!targetCwd || typeof window === 'undefined') return
   window.open(`/codex-local-browse${encodeURI(targetCwd)}`, '_blank', 'noopener,noreferrer')
+}
+
+function getProjectCwd(projectName: string): string {
+  const projectGroup = projectGroups.value.find((group) => group.projectName === projectName)
+  return resolvePreferredLocalCwd(projectName, projectGroup?.threads[0]?.cwd?.trim() ?? '')
+}
+
+function getProjectDisplayNameForWorktree(projectName: string): string {
+  return (projectDisplayNameById.value[projectName] ?? projectName).trim() || projectName
+}
+
+function onBrowseProjectFiles(projectName: string): void {
+  const targetCwd = getProjectCwd(projectName)
+  if (!targetCwd || typeof window === 'undefined') return
+  window.open(`/codex-local-browse${encodeURI(targetCwd)}`, '_blank', 'noopener,noreferrer')
+}
+
+async function onCreateProjectWorktree(projectName: string): Promise<void> {
+  const sourceCwd = getProjectCwd(projectName)
+  if (!sourceCwd || typeof window === 'undefined') return
+
+  const suggestedName = `${getProjectDisplayNameForWorktree(projectName)}-`
+  const worktreeName = window.prompt('New worktree folder name', suggestedName)
+  if (worktreeName === null) return
+
+  const normalizedWorktreeName = worktreeName.trim()
+  if (!normalizedWorktreeName) return
+
+  try {
+    const created = await createPermanentWorktree(sourceCwd, normalizedWorktreeName)
+    const normalizedPath = await openProjectRoot(created.cwd, {
+      createIfMissing: false,
+      label: '',
+    })
+    if (!normalizedPath) return
+
+    newThreadCwd.value = normalizedPath
+    newThreadRuntime.value = 'local'
+    pinProjectToTop(getPathLeafName(normalizedPath))
+    await loadWorkspaceRootOptionsState()
+    await refreshDefaultProjectName()
+    if (isMobile.value) setSidebarCollapsed(true)
+    if (!isHomeRoute.value) {
+      await router.push({ name: 'home' })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to create worktree.'
+    window.alert(message)
+  }
 }
 
 function onStartNewThreadFromToolbar(): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2048,6 +2048,15 @@ function getProjectDisplayNameForWorktree(projectName: string): string {
   return (projectDisplayNameById.value[projectName] ?? projectName).trim() || projectName
 }
 
+function toWorktreeFolderNameDraft(projectName: string): string {
+  const displayName = getProjectDisplayNameForWorktree(projectName)
+  const sanitized = displayName
+    .replace(/[\\/]+/gu, '-')
+    .replace(/[\u0000-\u001f]+/gu, '')
+    .trim()
+  return sanitized || 'worktree'
+}
+
 function onBrowseProjectFiles(projectName: string): void {
   const targetCwd = getProjectCwd(projectName)
   if (!targetCwd || typeof window === 'undefined') return
@@ -2058,12 +2067,16 @@ async function onCreateProjectWorktree(projectName: string): Promise<void> {
   const sourceCwd = getProjectCwd(projectName)
   if (!sourceCwd || typeof window === 'undefined') return
 
-  const suggestedName = `${getProjectDisplayNameForWorktree(projectName)}-`
+  const suggestedName = `${toWorktreeFolderNameDraft(projectName)}-`
   const worktreeName = window.prompt('New worktree folder name', suggestedName)
   if (worktreeName === null) return
 
   const normalizedWorktreeName = worktreeName.trim()
   if (!normalizedWorktreeName) return
+  if (normalizedWorktreeName.includes('/') || normalizedWorktreeName.includes('\\') || normalizedWorktreeName === '.' || normalizedWorktreeName === '..') {
+    window.alert('Worktree name must be a single folder name.')
+    return
+  }
 
   try {
     const created = await createPermanentWorktree(sourceCwd, normalizedWorktreeName)

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -2269,6 +2269,26 @@ export async function createWorktree(sourceCwd: string, baseBranch?: string): Pr
   }
 }
 
+export async function createPermanentWorktree(sourceCwd: string, worktreeName: string): Promise<WorktreeCreateResult> {
+  const response = await fetch('/codex-api/worktree/create-permanent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sourceCwd,
+      worktreeName,
+    }),
+  })
+  const payload = (await response.json()) as { data?: WorktreeCreateResult; error?: string }
+  if (!response.ok || !payload.data) {
+    throw new Error(payload.error || 'Failed to create worktree')
+  }
+  return {
+    ...payload.data,
+    cwd: normalizePathForUi(payload.data.cwd),
+    gitRoot: normalizePathForUi(payload.data.gitRoot),
+  }
+}
+
 export async function getWorktreeBranchOptions(sourceCwd: string): Promise<WorktreeBranchOption[]> {
   const normalizedSourceCwd = sourceCwd.trim()
   if (!normalizedSourceCwd) return []

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -254,6 +254,7 @@
             role="button"
             tabindex="0"
             @click="toggleProjectCollapse(group.projectName)"
+            @contextmenu.prevent="openProjectContextMenu(group.projectName)"
             @keydown="onProjectHeaderKeyDown($event, group.projectName)"
             @keydown.enter.prevent="toggleProjectCollapse(group.projectName)"
             @keydown.space.prevent="toggleProjectCollapse(group.projectName)"
@@ -296,8 +297,14 @@
                     @click.stop
                   >
                     <template v-if="projectMenuMode === 'actions'">
+                      <button class="project-menu-item" type="button" @click="onBrowseProjectFiles(group.projectName)">
+                        Browse files
+                      </button>
+                      <button class="project-menu-item" type="button" @click="onCreateProjectWorktree(group.projectName)">
+                        New worktree
+                      </button>
                       <button class="project-menu-item" type="button" @click="openRenameProjectMenu(group.projectName)">
-                        Edit name
+                        Rename project
                       </button>
                       <button
                         class="project-menu-item project-menu-item-danger"
@@ -709,6 +716,8 @@ const emit = defineEmits<{
   archive: [threadId: string]
   'start-new-thread': [projectName: string]
   'browse-thread-files': [threadId: string]
+  'browse-project-files': [projectName: string]
+  'create-project-worktree': [projectName: string]
   'rename-project': [payload: { projectName: string; displayName: string }]
   'rename-thread': [payload: { threadId: string; title: string }]
   'remove-project': [projectName: string]
@@ -1428,6 +1437,17 @@ function toggleProjectMenu(projectName: string): void {
   })
 }
 
+function openProjectContextMenu(projectName: string): void {
+  closeThreadMenu()
+  isOrganizeMenuOpen.value = false
+  openProjectMenuId.value = projectName
+  projectMenuMode.value = 'actions'
+  projectRenameDraft.value = getProjectDisplayName(projectName)
+  nextTick(() => {
+    updateProjectMenuDirection(projectName)
+  })
+}
+
 function openRenameProjectMenu(projectName: string): void {
   closeThreadMenu()
   openProjectMenuId.value = projectName
@@ -1436,6 +1456,16 @@ function openRenameProjectMenu(projectName: string): void {
   nextTick(() => {
     updateProjectMenuDirection(projectName)
   })
+}
+
+function onBrowseProjectFiles(projectName: string): void {
+  emit('browse-project-files', projectName)
+  closeProjectMenu()
+}
+
+function onCreateProjectWorktree(projectName: string): void {
+  emit('create-project-worktree', projectName)
+  closeProjectMenu()
 }
 
 function onProjectNameInput(projectName: string): void {
@@ -1585,7 +1615,7 @@ function updateProjectMenuDirection(projectName: string): void {
 
   projectMenuDirectionById.value = {
     ...projectMenuDirectionById.value,
-    [projectName]: resolveMenuDirection(menuWrapElement, 112),
+    [projectName]: resolveMenuDirection(menuWrapElement, 176),
   }
 }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -5543,6 +5543,74 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'POST' && url.pathname === '/codex-api/worktree/create-permanent') {
+        const payload = asRecord(await readJsonBody(req))
+        const rawSourceCwd = typeof payload?.sourceCwd === 'string' ? payload.sourceCwd.trim() : ''
+        const rawWorktreeName = typeof payload?.worktreeName === 'string' ? payload.worktreeName.trim() : ''
+        if (!rawSourceCwd) {
+          setJson(res, 400, { error: 'Missing sourceCwd' })
+          return
+        }
+        if (!rawWorktreeName) {
+          setJson(res, 400, { error: 'Missing worktreeName' })
+          return
+        }
+        if (rawWorktreeName.includes('/') || rawWorktreeName.includes('\\') || rawWorktreeName === '.' || rawWorktreeName === '..') {
+          setJson(res, 400, { error: 'Worktree name must be a single folder name' })
+          return
+        }
+
+        const sourceCwd = isAbsolute(rawSourceCwd) ? rawSourceCwd : resolve(rawSourceCwd)
+        try {
+          const sourceInfo = await stat(sourceCwd)
+          if (!sourceInfo.isDirectory()) {
+            setJson(res, 400, { error: 'sourceCwd is not a directory' })
+            return
+          }
+        } catch {
+          setJson(res, 404, { error: 'sourceCwd does not exist' })
+          return
+        }
+
+        try {
+          let gitRoot = ''
+          try {
+            gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd: sourceCwd })
+          } catch (error) {
+            if (!isNotGitRepositoryError(error)) throw error
+            await runCommand('git', ['init'], { cwd: sourceCwd })
+            gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd: sourceCwd })
+          }
+          const worktreeCwd = join(dirname(gitRoot), rawWorktreeName)
+          try {
+            await stat(worktreeCwd)
+            setJson(res, 409, { error: 'Worktree folder already exists' })
+            return
+          } catch {
+            // Expected for a new worktree path.
+          }
+
+          try {
+            await runCommand('git', ['worktree', 'add', worktreeCwd, 'HEAD'], { cwd: gitRoot })
+          } catch (error) {
+            if (!isMissingHeadError(error)) throw error
+            await ensureRepoHasInitialCommit(gitRoot)
+            await runCommand('git', ['worktree', 'add', worktreeCwd, 'HEAD'], { cwd: gitRoot })
+          }
+
+          setJson(res, 200, {
+            data: {
+              cwd: worktreeCwd,
+              branch: null,
+              gitRoot,
+            },
+          })
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to create worktree') })
+        }
+        return
+      }
+
       if (req.method === 'GET' && url.pathname === '/codex-api/worktree/branches') {
         const rawSourceCwd = (url.searchParams.get('sourceCwd') ?? '').trim()
         if (!rawSourceCwd) {

--- a/tests.md
+++ b/tests.md
@@ -3883,3 +3883,40 @@ Codex app-server `account/chatgptAuthTokens/refresh` requests are handled automa
 
 #### Rollback/Cleanup
 - None, unless a test-only `$CODEX_HOME` was used
+
+---
+
+### Project menu permanent worktree action
+
+#### Feature/Change Name
+Project rows open the same action menu from right-click and the dots button, and can create a permanent sibling Git worktree as a new project.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Sidebar has at least one Git-backed project
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, click the project row dots button.
+2. Verify the menu shows `Browse files`, `New worktree`, `Rename project`, and `Remove`.
+3. Close the menu, then right-click the same project row.
+4. Verify the same menu opens.
+5. Click `Browse files` and confirm the local file browser opens for the project cwd.
+6. Reopen the project menu, click `Rename project`, and confirm the inline project name input still works.
+7. Reopen the project menu, click `New worktree`, and confirm the prompt is prefilled with `<project name>-`.
+8. Enter a unique folder name such as `<project name>-manual-test`.
+9. Confirm a Git worktree is created at `../<worktree name>` relative to the source repo root.
+10. Confirm the new worktree is added as a project and the app opens the new-chat composer with that cwd selected.
+11. Rename the project to include a slash, reopen `New worktree`, and confirm the suggested folder name replaces the slash with `-`.
+12. Switch to dark theme and repeat steps 1-4, verifying menu contrast and danger styling remain readable.
+
+#### Expected Results
+- Right-click and dots button expose the same project action menu.
+- `Browse files`, `Rename project`, and `Remove` remain available from that menu.
+- `New worktree` creates a permanent sibling worktree folder, registers it as a project, and opens a new chat for it.
+- Invalid path separator characters are not used in the default worktree folder suggestion.
+- Menu text, hover states, and the remove action remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Remove the test worktree with `git -C <source-repo-root> worktree remove ../<worktree name>`.
+- Remove the temporary project from the sidebar if it remains listed.


### PR DESCRIPTION
## Summary
- Add a project-row menu action for permanent sibling Git worktrees
- Make right-click on project rows open the same menu as the dots button
- Register the created worktree as a project and route to a new chat for it
- Validate and sanitize worktree folder names

## Verification
- pnpm run build
- API smoke against http://127.0.0.1:5176
- Invalid name returns 400
- Permanent worktree creation returns 200
- Project registration REGISTERED=true
- Worktree status count 0
- Cleanup CLEANUP_OK=true