### PR TITLE
Move thread pin action to menu

### DIFF
--- a/src/components/icons/IconTablerTrash.vue
+++ b/src/components/icons/IconTablerTrash.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M4 7h16M10 11v6M14 11v6M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2l1-12M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3"
+    />
+  </svg>
+</template>

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -35,8 +35,15 @@
             <template #left>
               <span class="thread-left-stack">
                 <span v-if="shouldShowThreadIndicator(thread)" class="thread-status-indicator" :data-state="getThreadState(thread)" />
-                <button class="thread-pin-button" type="button" title="pin" @click.stop="togglePin(thread.id)">
-                  <IconTablerPin class="thread-icon" />
+                <button
+                  class="thread-delete-button"
+                  type="button"
+                  :data-confirming="isInlineDeleteConfirming(thread.id)"
+                  :title="isInlineDeleteConfirming(thread.id) ? 'Confirm delete' : t('Delete thread')"
+                  @click.stop="onInlineDeleteClick(thread.id)"
+                >
+                  <span v-if="isInlineDeleteConfirming(thread.id)" class="thread-delete-confirm-label">Confirm</span>
+                  <IconTablerTrash v-else class="thread-icon" />
                 </button>
               </span>
             </template>
@@ -191,8 +198,15 @@
                 class="thread-status-indicator"
                 :data-state="getThreadState(thread)"
               />
-              <button class="thread-pin-button" type="button" title="pin" @click.stop="togglePin(thread.id)">
-                <IconTablerPin class="thread-icon" />
+              <button
+                class="thread-delete-button"
+                type="button"
+                :data-confirming="isInlineDeleteConfirming(thread.id)"
+                :title="isInlineDeleteConfirming(thread.id) ? 'Confirm delete' : t('Delete thread')"
+                @click.stop="onInlineDeleteClick(thread.id)"
+              >
+                <span v-if="isInlineDeleteConfirming(thread.id)" class="thread-delete-confirm-label">Confirm</span>
+                <IconTablerTrash v-else class="thread-icon" />
               </button>
             </span>
           </template>
@@ -356,8 +370,15 @@
                       class="thread-status-indicator"
                       :data-state="getThreadState(thread)"
                     />
-                    <button class="thread-pin-button" type="button" title="pin" @click.stop="togglePin(thread.id)">
-                      <IconTablerPin class="thread-icon" />
+                    <button
+                      class="thread-delete-button"
+                      type="button"
+                      :data-confirming="isInlineDeleteConfirming(thread.id)"
+                      :title="isInlineDeleteConfirming(thread.id) ? 'Confirm delete' : t('Delete thread')"
+                      @click.stop="onInlineDeleteClick(thread.id)"
+                    >
+                      <span v-if="isInlineDeleteConfirming(thread.id)" class="thread-delete-confirm-label">Confirm</span>
+                      <IconTablerTrash v-else class="thread-icon" />
                     </button>
                   </span>
                 </template>
@@ -485,8 +506,15 @@
                   class="thread-status-indicator"
                   :data-state="getThreadState(thread)"
                 />
-                <button class="thread-pin-button" type="button" title="pin" @click.stop="togglePin(thread.id)">
-                  <IconTablerPin class="thread-icon" />
+                <button
+                  class="thread-delete-button"
+                  type="button"
+                  :data-confirming="isInlineDeleteConfirming(thread.id)"
+                  :title="isInlineDeleteConfirming(thread.id) ? 'Confirm delete' : t('Delete thread')"
+                  @click.stop="onInlineDeleteClick(thread.id)"
+                >
+                  <span v-if="isInlineDeleteConfirming(thread.id)" class="thread-delete-confirm-label">Confirm</span>
+                  <IconTablerTrash v-else class="thread-icon" />
                 </button>
               </span>
             </template>
@@ -555,6 +583,9 @@
         </button>
         <button class="thread-menu-item" type="button" @click="onForkThread(openThreadMenuThread.id)">
           Create chat fork
+        </button>
+        <button class="thread-menu-item" type="button" @click="onTogglePinFromMenu(openThreadMenuThread.id)">
+          {{ isPinned(openThreadMenuThread.id) ? 'Unpin thread' : 'Pin thread' }}
         </button>
         <button class="thread-menu-item" type="button" @click="openRenameThreadDialog(openThreadMenuThread.id, openThreadMenuThread.title)">
           {{ t('Rename thread') }}
@@ -687,7 +718,7 @@ import IconTablerFolder from '../icons/IconTablerFolder.vue'
 import IconTablerFolderOpen from '../icons/IconTablerFolderOpen.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
 import IconTablerFilter from '../icons/IconTablerFilter.vue'
-import IconTablerPin from '../icons/IconTablerPin.vue'
+import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import { isProjectlessChatPath } from '../../pathUtils.js'
 import SidebarMenuRow from './SidebarMenuRow.vue'
@@ -765,6 +796,7 @@ const showChatsFirst = ref(loadBooleanStorage(CHATS_FIRST_STORAGE_KEY, false))
 const chatSortMode = ref<ChatSortMode>(loadChatSortMode())
 let hasLoadedPinnedThreadState = false
 const pinnedThreadIds = ref<string[]>([])
+const inlineDeleteConfirmThreadId = ref('')
 const openProjectMenuId = ref('')
 const openThreadMenuId = ref('')
 const projectMenuDirectionById = ref<Record<string, MenuDirection>>({})
@@ -1166,7 +1198,13 @@ function togglePin(threadId: string): void {
   pinnedThreadIds.value = [threadId, ...pinnedThreadIds.value]
 }
 
+function onTogglePinFromMenu(threadId: string): void {
+  togglePin(threadId)
+  closeThreadMenu()
+}
+
 function onSelect(threadId: string): void {
+  inlineDeleteConfirmThreadId.value = ''
   emit('select', threadId)
 }
 
@@ -1239,6 +1277,7 @@ function closeThreadMenu(): void {
 }
 
 function toggleThreadMenu(threadId: string): void {
+  inlineDeleteConfirmThreadId.value = ''
   if (openThreadMenuId.value === threadId) {
     closeThreadMenu()
     return
@@ -1254,6 +1293,7 @@ function toggleThreadMenu(threadId: string): void {
 
 function onThreadRowContextMenu(event: MouseEvent, threadId: string): void {
   event.preventDefault()
+  inlineDeleteConfirmThreadId.value = ''
   openThreadMenuId.value = threadId
 }
 
@@ -1283,6 +1323,7 @@ function submitRenameThread(): void {
 }
 
 function openDeleteThreadDialog(threadId: string, currentTitle: string): void {
+  inlineDeleteConfirmThreadId.value = ''
   deleteThreadDialogThreadId.value = threadId
   deleteThreadTitle.value = currentTitle
   deleteThreadDialogVisible.value = true
@@ -1298,6 +1339,26 @@ function closeDeleteThreadDialog(): void {
 async function submitDeleteThread(): Promise<void> {
   const threadId = deleteThreadDialogThreadId.value
   if (!threadId) return
+  await deleteThreadById(threadId)
+  closeDeleteThreadDialog()
+}
+
+function isInlineDeleteConfirming(threadId: string): boolean {
+  return inlineDeleteConfirmThreadId.value === threadId
+}
+
+async function onInlineDeleteClick(threadId: string): Promise<void> {
+  if (inlineDeleteConfirmThreadId.value !== threadId) {
+    inlineDeleteConfirmThreadId.value = threadId
+    closeThreadMenu()
+    return
+  }
+
+  await deleteThreadById(threadId)
+  inlineDeleteConfirmThreadId.value = ''
+}
+
+async function deleteThreadById(threadId: string): Promise<void> {
   if (threadHasAutomation(threadId)) {
     try {
       await deleteThreadAutomation(threadId)
@@ -1310,7 +1371,6 @@ async function submitDeleteThread(): Promise<void> {
   }
   pinnedThreadIds.value = pinnedThreadIds.value.filter((id) => id !== threadId)
   emit('archive', threadId)
-  closeDeleteThreadDialog()
 }
 
 function openAutomationDialog(threadId: string): void {
@@ -2297,8 +2357,16 @@ onBeforeUnmount(() => {
   @apply relative w-4 h-4 flex items-center justify-center;
 }
 
-.thread-pin-button {
-  @apply absolute inset-0 w-4 h-4 rounded text-zinc-500 opacity-0 pointer-events-none transition flex items-center justify-center;
+.thread-delete-button {
+  @apply absolute left-0 top-1/2 -translate-y-1/2 h-4 min-w-4 rounded text-zinc-500 opacity-0 pointer-events-none transition flex items-center justify-center;
+}
+
+.thread-delete-button[data-confirming='true'] {
+  @apply z-10 h-5 min-w-16 px-1.5 bg-rose-600 text-white opacity-100 pointer-events-auto shadow-sm;
+}
+
+.thread-delete-confirm-label {
+  @apply text-[11px] font-medium leading-none;
 }
 
 .thread-main-button {
@@ -2403,8 +2471,9 @@ onBeforeUnmount(() => {
   @apply bg-zinc-200;
 }
 
-.thread-row:hover .thread-pin-button,
-.thread-row:focus-within .thread-pin-button {
+.thread-row:hover .thread-delete-button,
+.thread-row:focus-within .thread-delete-button,
+.thread-delete-button[data-confirming='true'] {
   @apply opacity-100 pointer-events-auto;
 }
 

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -797,6 +797,7 @@ const chatSortMode = ref<ChatSortMode>(loadChatSortMode())
 let hasLoadedPinnedThreadState = false
 const pinnedThreadIds = ref<string[]>([])
 const inlineDeleteConfirmThreadId = ref('')
+const optimisticallyArchivedThreadIds = ref<string[]>([])
 const openProjectMenuId = ref('')
 const openThreadMenuId = ref('')
 const projectMenuDirectionById = ref<Record<string, MenuDirection>>({})
@@ -958,8 +959,10 @@ const matchedThreadIdSet = computed(() => {
   return new Set(props.searchMatchedThreadIds)
 })
 const pinnedThreadIdSet = computed(() => new Set(pinnedThreadIds.value))
+const optimisticallyArchivedThreadIdSet = computed(() => new Set(optimisticallyArchivedThreadIds.value))
 
 function threadMatchesSearch(thread: UiThread): boolean {
+  if (optimisticallyArchivedThreadIdSet.value.has(thread.id)) return false
   if (!isSearchActive.value) return true
   if (matchedThreadIdSet.value) {
     return matchedThreadIdSet.value.has(thread.id)
@@ -1014,6 +1017,7 @@ const threadById = computed(() => {
 
   for (const group of props.groups) {
     for (const thread of group.threads) {
+      if (optimisticallyArchivedThreadIdSet.value.has(thread.id)) continue
       map.set(thread.id, thread)
     }
   }
@@ -1069,7 +1073,7 @@ const threadProjectNameById = computed(() => {
 const unpinnedThreadsByProjectName = computed(() => {
   const map = new Map<string, UiThread[]>()
   for (const group of props.groups) {
-    const rows = group.threads.filter((thread) => !pinnedThreadIdSet.value.has(thread.id))
+    const rows = group.threads.filter((thread) => !pinnedThreadIdSet.value.has(thread.id) && !optimisticallyArchivedThreadIdSet.value.has(thread.id))
     map.set(group.projectName, rows)
   }
   return map
@@ -1339,7 +1343,7 @@ function closeDeleteThreadDialog(): void {
 async function submitDeleteThread(): Promise<void> {
   const threadId = deleteThreadDialogThreadId.value
   if (!threadId) return
-  await deleteThreadById(threadId)
+  deleteThreadById(threadId)
   closeDeleteThreadDialog()
 }
 
@@ -1347,30 +1351,32 @@ function isInlineDeleteConfirming(threadId: string): boolean {
   return inlineDeleteConfirmThreadId.value === threadId
 }
 
-async function onInlineDeleteClick(threadId: string): Promise<void> {
+function onInlineDeleteClick(threadId: string): void {
   if (inlineDeleteConfirmThreadId.value !== threadId) {
     inlineDeleteConfirmThreadId.value = threadId
     closeThreadMenu()
     return
   }
 
-  await deleteThreadById(threadId)
+  deleteThreadById(threadId)
   inlineDeleteConfirmThreadId.value = ''
 }
 
-async function deleteThreadById(threadId: string): Promise<void> {
+function deleteThreadById(threadId: string): void {
+  if (!optimisticallyArchivedThreadIdSet.value.has(threadId)) {
+    optimisticallyArchivedThreadIds.value = [threadId, ...optimisticallyArchivedThreadIds.value]
+  }
+  inlineDeleteConfirmThreadId.value = ''
+  closeThreadMenu()
+  pinnedThreadIds.value = pinnedThreadIds.value.filter((id) => id !== threadId)
+  emit('archive', threadId)
+
   if (threadHasAutomation(threadId)) {
-    try {
-      await deleteThreadAutomation(threadId)
-    } catch {
-      // Keep thread archive usable even if automation cleanup fails.
-    }
+    void deleteThreadAutomation(threadId).catch(() => undefined)
     automationByThreadId.value = Object.fromEntries(
       Object.entries(automationByThreadId.value).filter(([id]) => id !== threadId),
     )
   }
-  pinnedThreadIds.value = pinnedThreadIds.value.filter((id) => id !== threadId)
-  emit('archive', threadId)
 }
 
 function openAutomationDialog(threadId: string): void {

--- a/src/style.css
+++ b/src/style.css
@@ -472,8 +472,12 @@
   @apply bg-rose-500 text-white hover:bg-rose-400;
 }
 
-:root.dark .thread-pin-button {
+:root.dark .thread-delete-button {
   @apply text-zinc-400;
+}
+
+:root.dark .thread-delete-button[data-confirming='true'] {
+  @apply bg-rose-500 text-white hover:bg-rose-400;
 }
 
 :root.dark .message-bubble {

--- a/tests.md
+++ b/tests.md
@@ -3883,3 +3883,35 @@ Codex app-server `account/chatgptAuthTokens/refresh` requests are handled automa
 
 #### Rollback/Cleanup
 - None, unless a test-only `$CODEX_HOME` was used
+
+---
+
+### Sidebar thread inline delete confirmation and menu pin action
+
+#### Feature/Change Name
+Thread rows show an inline delete button that morphs to `Confirm`, while pin/unpin moves to the thread context menu.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Sidebar contains at least two disposable test threads
+3. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, hover a disposable thread row and verify the left-side action shows a delete icon instead of a pin icon
+2. Click the delete icon once and verify it changes to a `Confirm` button without selecting the row
+3. Click a different thread row and verify the pending `Confirm` state clears
+4. Hover the disposable thread row again, click delete, then click `Confirm`
+5. Verify the thread is removed from the sidebar and, if it was pinned, removed from the `Pinned` section too
+6. Open another thread row context menu and verify it contains `Pin thread` for an unpinned thread
+7. Click `Pin thread`, reopen the same thread menu, and verify it now shows `Unpin thread`
+8. Switch to dark theme and repeat steps 1 through 7 with another disposable thread
+
+#### Expected Results
+- The inline row action is delete, not pin
+- Delete requires two clicks: delete icon, then `Confirm`
+- Confirming archives/removes the correct thread and clears any pinned state for that thread
+- Pin/unpin is available from the thread context menu and updates the `Pinned` section immediately
+- Delete icon, `Confirm` button, and context menu items are readable in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Delete or unpin any disposable threads created only for this test

--- a/tests.md
+++ b/tests.md
@@ -3901,7 +3901,7 @@ Thread rows show an inline delete button that morphs to `Confirm`, while pin/unp
 2. Click the delete icon once and verify it changes to a `Confirm` button without selecting the row
 3. Click a different thread row and verify the pending `Confirm` state clears
 4. Hover the disposable thread row again, click delete, then click `Confirm`
-5. Verify the thread is removed from the sidebar and, if it was pinned, removed from the `Pinned` section too
+5. Verify the thread is removed from the sidebar immediately and, if it was pinned, removed from the `Pinned` section too
 6. Open another thread row context menu and verify it contains `Pin thread` for an unpinned thread
 7. Click `Pin thread`, reopen the same thread menu, and verify it now shows `Unpin thread`
 8. Switch to dark theme and repeat steps 1 through 7 with another disposable thread
@@ -3909,7 +3909,7 @@ Thread rows show an inline delete button that morphs to `Confirm`, while pin/unp
 #### Expected Results
 - The inline row action is delete, not pin
 - Delete requires two clicks: delete icon, then `Confirm`
-- Confirming archives/removes the correct thread and clears any pinned state for that thread
+- Confirming archives/removes the correct thread immediately from the sidebar and clears any pinned state for that thread
 - Pin/unpin is available from the thread context menu and updates the `Pinned` section immediately
 - Delete icon, `Confirm` button, and context menu items are readable in both light theme and dark theme
 


### PR DESCRIPTION
## Summary
- replace inline thread pin control with a delete button that morphs to Confirm
- hide deleted threads optimistically while archive cleanup runs in the background
- move pin/unpin into the thread context menu
- document light/dark manual verification steps in tests.md

## Verification
- pnpm run build:frontend