### PR TITLE
Refresh queue UI after backend drain

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3323,6 +3323,7 @@ export function useDesktopState() {
       setTurnSummaryForThread(startedTurn.threadId, null)
       setTurnErrorForThread(startedTurn.threadId, null)
       setThreadInProgress(startedTurn.threadId, true)
+      scheduleQueueStateRefresh(startedTurn.threadId)
       if (eventUnreadByThreadId.value[startedTurn.threadId]) {
         eventUnreadByThreadId.value = omitKey(eventUnreadByThreadId.value, startedTurn.threadId)
       }
@@ -3365,7 +3366,7 @@ export function useDesktopState() {
       markThreadUnreadByEvent(completedTurn.threadId)
       if (!shouldRetryWithFallback) {
         clearPendingTurnRequest(completedTurn.threadId)
-        void processQueuedMessages(completedTurn.threadId)
+        scheduleQueueStateRefresh(completedTurn.threadId)
       }
     }
 
@@ -3527,7 +3528,7 @@ export function useDesktopState() {
         markThreadUnreadByEvent(completedThreadId)
         if (!shouldRetryWithFallback) {
           clearPendingTurnRequest(completedThreadId)
-          void processQueuedMessages(completedThreadId)
+          scheduleQueueStateRefresh(completedThreadId)
         }
       }
     }
@@ -4532,6 +4533,14 @@ export function useDesktopState() {
     } finally {
       queueProcessingByThreadId.value = omitKey(queueProcessingByThreadId.value, threadId)
     }
+  }
+
+  function scheduleQueueStateRefresh(threadId: string): void {
+    void processQueuedMessages(threadId)
+    if (typeof window === 'undefined') return
+    window.setTimeout(() => {
+      void processQueuedMessages(threadId)
+    }, 650)
   }
 
   async function interruptSelectedThreadTurn(): Promise<void> {

--- a/tests.md
+++ b/tests.md
@@ -3858,6 +3858,36 @@ Queued messages are saved through the backend, survive page refresh, and can be 
 
 ---
 
+### Backend-drained queue UI refresh
+
+#### Feature/Change Name
+The queue panel refreshes when the backend starts and drains persisted queued messages.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Open a `TestChat` thread
+3. Queue at least three short messages while a turn is running
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, confirm queued rows are visible above the composer
+2. Let the backend drain each queued message
+3. Confirm the queue panel removes each row as its queued turn starts
+4. Confirm the queue panel disappears when the final queued message is submitted
+5. Refresh the thread after all queued turns complete
+6. Switch to dark theme and repeat the visibility check after queue drain
+
+#### Expected Results
+- Queued messages execute in order after the active turn completes
+- The queue panel reflects backend queue state after `turn/started` and `turn/completed`
+- No already-executed queued rows remain visible after the queue is empty
+- Queue row text, actions, and composer spacing remain readable in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Delete any remaining queued test messages or let the queue drain
+
+---
+
 ### ChatGPT auth tokens refresh for external auth
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- refresh frontend queue state when backend-started queued turns emit turn/started
- schedule a delayed queue refresh after completion to cover backend pop/start timing
- document manual queue UI refresh verification

## Verification
- Fresh TestChat queue test: ACTIVE, Q1, Q2, Q3 completed; visible queue rows 3 -> 0; persisted queue 0
- Refresh-during-queue TestChat test: queue continued after page refresh; visible rows ended at 0; persisted queue 0
- Direct backend check: thread had 4 turns, last status completed, queue length 0
- pnpm run build:frontend
- pnpm run test:unit