### PR TITLE
Match Codex app project sidebar parity

### DIFF
--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -290,7 +290,7 @@
               :data-dragging-handle="isDraggingProject(group.projectName)"
               @mousedown.left="onProjectHandleMouseDown($event, group.projectName)"
             >
-              <span class="project-title" :title="getProjectDisplayName(group.projectName)">
+              <span class="project-title" :title="getProjectTooltipTitle(group.projectName)">
                 {{ getProjectVisibleName(group) }}
               </span>
             </span>
@@ -1464,6 +1464,10 @@ function getProjectDisplayName(projectName: string): string {
 
 function isPathLikeProjectName(value: string): boolean {
   return value.includes('/') || value.includes('\\')
+}
+
+function getProjectTooltipTitle(projectName: string): string {
+  return isPathLikeProjectName(projectName) ? projectName : getProjectDisplayName(projectName)
 }
 
 function isDuplicatePathLeafName(value: string): boolean {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -162,7 +162,7 @@ describe('filterGroupsByWorkspaceRoots', () => {
     ])
   })
 
-  it('keeps unregistered managed worktrees under the main root when another managed worktree root is registered', () => {
+  it('keeps managed Codex worktrees under the main root even when a worktree root is registered', () => {
     const groups: UiProjectGroup[] = [
       {
         projectName: 'codex-web-local',
@@ -186,8 +186,28 @@ describe('filterGroupsByWorkspaceRoots', () => {
     }
 
     expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
-      ['/Users/igor/Git-projects/codex-web-local', ['main-chat', 'unregistered-worktree-chat']],
-      ['/Users/igor/.codex/worktrees/a77f/codex-web-local', ['registered-worktree-chat']],
+      ['/Users/igor/Git-projects/codex-web-local', ['main-chat', 'registered-worktree-chat', 'unregistered-worktree-chat']],
+    ])
+  })
+
+  it('keeps a managed Codex worktree root visible when no canonical root exists', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'codex-web-local',
+        threads: [
+          thread('worktree-chat', '/Users/igor/.codex/worktrees/a77f/codex-web-local', { hasWorktree: true }),
+        ],
+      },
+    ]
+    const rootsState: WorkspaceRootsState = {
+      order: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
+      labels: {},
+      active: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
+      projectOrder: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
+    }
+
+    expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
+      ['codex-web-local', ['worktree-chat']],
     ])
   })
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -162,6 +162,35 @@ describe('filterGroupsByWorkspaceRoots', () => {
     ])
   })
 
+  it('keeps unregistered managed worktrees under the main root when another managed worktree root is registered', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'codex-web-local',
+        threads: [
+          thread('main-chat', '/Users/igor/Git-projects/codex-web-local'),
+          thread('registered-worktree-chat', '/Users/igor/.codex/worktrees/a77f/codex-web-local', { hasWorktree: true }),
+          thread('unregistered-worktree-chat', '/Users/igor/.codex/worktrees/53e7/codex-web-local', { hasWorktree: true }),
+        ],
+      },
+    ]
+    const rootsState: WorkspaceRootsState = {
+      order: [
+        '/Users/igor/Git-projects/codex-web-local',
+        '/Users/igor/.codex/worktrees/a77f/codex-web-local',
+      ],
+      labels: {
+        '/Users/igor/.codex/worktrees/a77f/codex-web-local': 'codex-web-local2',
+      },
+      active: ['/Users/igor/Git-projects/codex-web-local'],
+      projectOrder: ['/Users/igor/Git-projects/codex-web-local'],
+    }
+
+    expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
+      ['/Users/igor/Git-projects/codex-web-local', ['main-chat', 'unregistered-worktree-chat']],
+      ['/Users/igor/.codex/worktrees/a77f/codex-web-local', ['registered-worktree-chat']],
+    ])
+  })
+
   it('does not group unrelated git worktrees under a same-leaf workspace root project', () => {
     const groups: UiProjectGroup[] = [
       {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -162,7 +162,7 @@ describe('filterGroupsByWorkspaceRoots', () => {
     ])
   })
 
-  it('keeps managed Codex worktrees under the main root even when a worktree root is registered', () => {
+  it('keeps unregistered managed worktrees under the main root when another managed worktree root is registered', () => {
     const groups: UiProjectGroup[] = [
       {
         projectName: 'codex-web-local',
@@ -186,28 +186,8 @@ describe('filterGroupsByWorkspaceRoots', () => {
     }
 
     expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
-      ['/Users/igor/Git-projects/codex-web-local', ['main-chat', 'registered-worktree-chat', 'unregistered-worktree-chat']],
-    ])
-  })
-
-  it('keeps a managed Codex worktree root visible when no canonical root exists', () => {
-    const groups: UiProjectGroup[] = [
-      {
-        projectName: 'codex-web-local',
-        threads: [
-          thread('worktree-chat', '/Users/igor/.codex/worktrees/a77f/codex-web-local', { hasWorktree: true }),
-        ],
-      },
-    ]
-    const rootsState: WorkspaceRootsState = {
-      order: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
-      labels: {},
-      active: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
-      projectOrder: ['/Users/igor/.codex/worktrees/a77f/codex-web-local'],
-    }
-
-    expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
-      ['codex-web-local', ['worktree-chat']],
+      ['/Users/igor/Git-projects/codex-web-local', ['main-chat', 'unregistered-worktree-chat']],
+      ['/Users/igor/.codex/worktrees/a77f/codex-web-local', ['registered-worktree-chat']],
     ])
   })
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -8,13 +8,13 @@ import {
 import type { UiProjectGroup } from '../types/codex'
 import type { WorkspaceRootsState } from '../api/codexGateway'
 
-function thread(id: string, cwd: string) {
+function thread(id: string, cwd: string, options: { hasWorktree?: boolean } = {}) {
   return {
     id,
     title: id,
     projectName: cwd ? cwd.split('/').at(-1) || cwd : 'Projectless',
     cwd,
-    hasWorktree: false,
+    hasWorktree: options.hasWorktree ?? false,
     createdAtIso: '2026-04-28T00:00:00.000Z',
     updatedAtIso: '2026-04-28T00:00:00.000Z',
     preview: '',
@@ -137,6 +137,28 @@ describe('filterGroupsByWorkspaceRoots', () => {
     expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.length])).toEqual([
       ['remote-project-id', 0],
       ['local-project', 0],
+    ])
+  })
+
+  it('keeps managed worktree threads under the matching workspace root project', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'codex-web-local',
+        threads: [
+          thread('main-chat', '/Users/igor/Git-projects/codex-web-local'),
+          thread('worktree-chat', '/Users/igor/.codex/worktrees/53e7/codex-web-local', { hasWorktree: true }),
+        ],
+      },
+    ]
+    const rootsState: WorkspaceRootsState = {
+      order: ['/Users/igor/Git-projects/codex-web-local'],
+      labels: {},
+      active: ['/Users/igor/Git-projects/codex-web-local'],
+      projectOrder: ['/Users/igor/Git-projects/codex-web-local'],
+    }
+
+    expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
+      ['codex-web-local', ['main-chat', 'worktree-chat']],
     ])
   })
 })

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -161,6 +161,28 @@ describe('filterGroupsByWorkspaceRoots', () => {
       ['codex-web-local', ['main-chat', 'worktree-chat']],
     ])
   })
+
+  it('does not group unrelated git worktrees under a same-leaf workspace root project', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'codex-web-local',
+        threads: [
+          thread('main-chat', '/Users/igor/Git-projects/codex-web-local'),
+          thread('other-git-worktree-chat', '/tmp/other/.git/worktrees/codex-web-local', { hasWorktree: true }),
+        ],
+      },
+    ]
+    const rootsState: WorkspaceRootsState = {
+      order: ['/Users/igor/Git-projects/codex-web-local'],
+      labels: {},
+      active: ['/Users/igor/Git-projects/codex-web-local'],
+      projectOrder: ['/Users/igor/Git-projects/codex-web-local'],
+    }
+
+    expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
+      ['/Users/igor/Git-projects/codex-web-local', ['main-chat']],
+    ])
+  })
 })
 
 describe('workspace roots project persistence helpers', () => {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -998,17 +998,35 @@ function getWorkspaceProjectOrderPaths(rootsState: WorkspaceRootsState | null): 
   return orderedRoots
 }
 
+function hasCanonicalWorkspaceRootForManagedWorktree(rootPath: string, rootsState: WorkspaceRootsState | null): boolean {
+  const normalizedRootPath = normalizePathForUi(rootPath).trim()
+  if (!isManagedCodexWorktreePath(normalizedRootPath)) return false
+  const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
+  return (rootsState?.order ?? []).some((candidate) => {
+    const normalizedCandidate = normalizePathForUi(candidate).trim()
+    return normalizedCandidate.length > 0
+      && !isManagedCodexWorktreePath(normalizedCandidate)
+      && toProjectNameFromWorkspaceRoot(normalizedCandidate) === leafName
+  })
+}
+
 function getWorkspaceProjectOrderNames(
   rootsState: WorkspaceRootsState | null,
   duplicateLeafNames: Set<string>,
 ): string[] {
   const remoteProjectsById = getRemoteProjectById(rootsState)
-  return getWorkspaceProjectOrderPaths(rootsState).map((rootPath) => {
-    if (remoteProjectsById.has(rootPath)) return rootPath
+  const names: string[] = []
+  for (const rootPath of getWorkspaceProjectOrderPaths(rootsState)) {
+    if (remoteProjectsById.has(rootPath)) {
+      names.push(rootPath)
+      continue
+    }
+    if (hasCanonicalWorkspaceRootForManagedWorktree(rootPath, rootsState)) continue
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
-    return duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName
-  })
+    names.push(duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName)
+  }
+  return names
 }
 
 function matchesWorkspaceRootProject(rootPath: string, projectName: string): boolean {
@@ -1167,11 +1185,9 @@ function disambiguateProjectGroupsByCwd(
   const uniqueCanonicalWorkspaceRootLeafNames = new Set<string>()
   const duplicateCanonicalWorkspaceRootLeafNames = new Set<string>()
   const canonicalWorkspaceRootByLeafName = new Map<string, string>()
-  const registeredWorkspaceRoots = new Set<string>()
   for (const rootPath of rootsState?.order ?? []) {
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
-    registeredWorkspaceRoots.add(normalizedRootPath)
     if (isManagedCodexWorktreePath(normalizedRootPath)) continue
     const leafName = toProjectName(normalizedRootPath)
     if (uniqueCanonicalWorkspaceRootLeafNames.has(leafName)) {
@@ -1190,9 +1206,7 @@ function disambiguateProjectGroupsByCwd(
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      const isRegisteredRoot = registeredWorkspaceRoots.has(normalizedCwd)
       const isCanonicalWorktreeThread = isManagedCodexWorktreePath(normalizedCwd)
-        && !isRegisteredRoot
         && uniqueCanonicalWorkspaceRootLeafNames.has(leafName)
       let projectName = group.projectName
       if (isCanonicalWorktreeThread && duplicateLeafNames.has(leafName)) {
@@ -1234,6 +1248,7 @@ function addWorkspaceRootPlaceholderGroups(
     }
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
+    if (hasCanonicalWorkspaceRootForManagedWorktree(normalizedRootPath, rootsState)) continue
     const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
     const projectName = duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName
     if (existingProjectNames.has(projectName)) continue

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1117,7 +1117,7 @@ function orderGroupsByWorkspaceProjectOrder(
 
 function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: WorkspaceRootsState | null): Set<string> {
   const rootByLeafName = new Map<string, Set<string>>()
-  const workspaceRootCountsByLeafName = new Map<string, number>()
+  const canonicalWorkspaceRootCountsByLeafName = new Map<string, number>()
   const addPath = (value: string): void => {
     const normalizedPath = normalizePathForUi(value).trim()
     if (!normalizedPath) return
@@ -1131,14 +1131,17 @@ function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: 
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
     const leafName = toProjectName(normalizedRootPath)
-    workspaceRootCountsByLeafName.set(leafName, (workspaceRootCountsByLeafName.get(leafName) ?? 0) + 1)
+    if (!isManagedCodexWorktreePath(normalizedRootPath)) {
+      canonicalWorkspaceRootCountsByLeafName.set(leafName, (canonicalWorkspaceRootCountsByLeafName.get(leafName) ?? 0) + 1)
+    }
     addPath(rootPath)
   }
   for (const group of groups) {
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      if (isManagedCodexWorktreePath(normalizedCwd) && workspaceRootCountsByLeafName.get(leafName) === 1) continue
+      const isRegisteredRoot = rootsState?.order.some((rootPath) => normalizePathForUi(rootPath).trim() === normalizedCwd) === true
+      if (isManagedCodexWorktreePath(normalizedCwd) && !isRegisteredRoot && canonicalWorkspaceRootCountsByLeafName.get(leafName) === 1) continue
       addPath(thread.cwd)
     }
   }
@@ -1161,17 +1164,23 @@ function disambiguateProjectGroupsByCwd(
   const duplicateLeafNames = collectDuplicateProjectLeafNames(groups, rootsState)
   if (duplicateLeafNames.size === 0) return groups
 
-  const uniqueWorkspaceRootLeafNames = new Set<string>()
-  const duplicateWorkspaceRootLeafNames = new Set<string>()
+  const uniqueCanonicalWorkspaceRootLeafNames = new Set<string>()
+  const duplicateCanonicalWorkspaceRootLeafNames = new Set<string>()
+  const canonicalWorkspaceRootByLeafName = new Map<string, string>()
+  const registeredWorkspaceRoots = new Set<string>()
   for (const rootPath of rootsState?.order ?? []) {
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
+    registeredWorkspaceRoots.add(normalizedRootPath)
+    if (isManagedCodexWorktreePath(normalizedRootPath)) continue
     const leafName = toProjectName(normalizedRootPath)
-    if (uniqueWorkspaceRootLeafNames.has(leafName)) {
-      uniqueWorkspaceRootLeafNames.delete(leafName)
-      duplicateWorkspaceRootLeafNames.add(leafName)
-    } else if (!duplicateWorkspaceRootLeafNames.has(leafName)) {
-      uniqueWorkspaceRootLeafNames.add(leafName)
+    if (uniqueCanonicalWorkspaceRootLeafNames.has(leafName)) {
+      uniqueCanonicalWorkspaceRootLeafNames.delete(leafName)
+      duplicateCanonicalWorkspaceRootLeafNames.add(leafName)
+      canonicalWorkspaceRootByLeafName.delete(leafName)
+    } else if (!duplicateCanonicalWorkspaceRootLeafNames.has(leafName)) {
+      uniqueCanonicalWorkspaceRootLeafNames.add(leafName)
+      canonicalWorkspaceRootByLeafName.set(leafName, normalizedRootPath)
     }
   }
 
@@ -1181,10 +1190,16 @@ function disambiguateProjectGroupsByCwd(
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      const isCanonicalWorktreeThread = isManagedCodexWorktreePath(normalizedCwd) && uniqueWorkspaceRootLeafNames.has(leafName)
-      const projectName = normalizedCwd && duplicateLeafNames.has(leafName) && !isCanonicalWorktreeThread
-        ? normalizedCwd
-        : group.projectName
+      const isRegisteredRoot = registeredWorkspaceRoots.has(normalizedCwd)
+      const isCanonicalWorktreeThread = isManagedCodexWorktreePath(normalizedCwd)
+        && !isRegisteredRoot
+        && uniqueCanonicalWorkspaceRootLeafNames.has(leafName)
+      let projectName = group.projectName
+      if (isCanonicalWorktreeThread && duplicateLeafNames.has(leafName)) {
+        projectName = canonicalWorkspaceRootByLeafName.get(leafName) ?? group.projectName
+      } else if (normalizedCwd && duplicateLeafNames.has(leafName)) {
+        projectName = normalizedCwd
+      }
       const nextThread = thread.projectName === projectName ? thread : { ...thread, projectName }
       const existingGroup = groupsByProjectName.get(projectName)
       if (existingGroup) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1138,7 +1138,7 @@ function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: 
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      if (thread.hasWorktree && workspaceRootCountsByLeafName.get(leafName) === 1) continue
+      if (isManagedCodexWorktreePath(normalizedCwd) && workspaceRootCountsByLeafName.get(leafName) === 1) continue
       addPath(thread.cwd)
     }
   }
@@ -1148,6 +1148,10 @@ function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: 
     if (paths.size > 1) duplicateLeafNames.add(leafName)
   }
   return duplicateLeafNames
+}
+
+function isManagedCodexWorktreePath(value: string): boolean {
+  return value.includes('/.codex/worktrees/')
 }
 
 function disambiguateProjectGroupsByCwd(
@@ -1177,7 +1181,7 @@ function disambiguateProjectGroupsByCwd(
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      const isCanonicalWorktreeThread = thread.hasWorktree && uniqueWorkspaceRootLeafNames.has(leafName)
+      const isCanonicalWorktreeThread = isManagedCodexWorktreePath(normalizedCwd) && uniqueWorkspaceRootLeafNames.has(leafName)
       const projectName = normalizedCwd && duplicateLeafNames.has(leafName) && !isCanonicalWorktreeThread
         ? normalizedCwd
         : group.projectName

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1117,6 +1117,7 @@ function orderGroupsByWorkspaceProjectOrder(
 
 function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: WorkspaceRootsState | null): Set<string> {
   const rootByLeafName = new Map<string, Set<string>>()
+  const workspaceRootCountsByLeafName = new Map<string, number>()
   const addPath = (value: string): void => {
     const normalizedPath = normalizePathForUi(value).trim()
     if (!normalizedPath) return
@@ -1126,9 +1127,20 @@ function collectDuplicateProjectLeafNames(groups: UiProjectGroup[], rootsState: 
     rootByLeafName.set(leafName, existing)
   }
 
-  for (const rootPath of rootsState?.order ?? []) addPath(rootPath)
+  for (const rootPath of rootsState?.order ?? []) {
+    const normalizedRootPath = normalizePathForUi(rootPath).trim()
+    if (!normalizedRootPath) continue
+    const leafName = toProjectName(normalizedRootPath)
+    workspaceRootCountsByLeafName.set(leafName, (workspaceRootCountsByLeafName.get(leafName) ?? 0) + 1)
+    addPath(rootPath)
+  }
   for (const group of groups) {
-    for (const thread of group.threads) addPath(thread.cwd)
+    for (const thread of group.threads) {
+      const normalizedCwd = normalizePathForUi(thread.cwd).trim()
+      const leafName = toProjectName(normalizedCwd)
+      if (thread.hasWorktree && workspaceRootCountsByLeafName.get(leafName) === 1) continue
+      addPath(thread.cwd)
+    }
   }
 
   const duplicateLeafNames = new Set<string>()
@@ -1145,13 +1157,30 @@ function disambiguateProjectGroupsByCwd(
   const duplicateLeafNames = collectDuplicateProjectLeafNames(groups, rootsState)
   if (duplicateLeafNames.size === 0) return groups
 
+  const uniqueWorkspaceRootLeafNames = new Set<string>()
+  const duplicateWorkspaceRootLeafNames = new Set<string>()
+  for (const rootPath of rootsState?.order ?? []) {
+    const normalizedRootPath = normalizePathForUi(rootPath).trim()
+    if (!normalizedRootPath) continue
+    const leafName = toProjectName(normalizedRootPath)
+    if (uniqueWorkspaceRootLeafNames.has(leafName)) {
+      uniqueWorkspaceRootLeafNames.delete(leafName)
+      duplicateWorkspaceRootLeafNames.add(leafName)
+    } else if (!duplicateWorkspaceRootLeafNames.has(leafName)) {
+      uniqueWorkspaceRootLeafNames.add(leafName)
+    }
+  }
+
   const disambiguatedGroups: UiProjectGroup[] = []
   const groupsByProjectName = new Map<string, UiProjectGroup>()
   for (const group of groups) {
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
-      const projectName = normalizedCwd && duplicateLeafNames.has(leafName) ? normalizedCwd : group.projectName
+      const isCanonicalWorktreeThread = thread.hasWorktree && uniqueWorkspaceRootLeafNames.has(leafName)
+      const projectName = normalizedCwd && duplicateLeafNames.has(leafName) && !isCanonicalWorktreeThread
+        ? normalizedCwd
+        : group.projectName
       const nextThread = thread.projectName === projectName ? thread : { ...thread, projectName }
       const existingGroup = groupsByProjectName.get(projectName)
       if (existingGroup) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -998,35 +998,17 @@ function getWorkspaceProjectOrderPaths(rootsState: WorkspaceRootsState | null): 
   return orderedRoots
 }
 
-function hasCanonicalWorkspaceRootForManagedWorktree(rootPath: string, rootsState: WorkspaceRootsState | null): boolean {
-  const normalizedRootPath = normalizePathForUi(rootPath).trim()
-  if (!isManagedCodexWorktreePath(normalizedRootPath)) return false
-  const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
-  return (rootsState?.order ?? []).some((candidate) => {
-    const normalizedCandidate = normalizePathForUi(candidate).trim()
-    return normalizedCandidate.length > 0
-      && !isManagedCodexWorktreePath(normalizedCandidate)
-      && toProjectNameFromWorkspaceRoot(normalizedCandidate) === leafName
-  })
-}
-
 function getWorkspaceProjectOrderNames(
   rootsState: WorkspaceRootsState | null,
   duplicateLeafNames: Set<string>,
 ): string[] {
   const remoteProjectsById = getRemoteProjectById(rootsState)
-  const names: string[] = []
-  for (const rootPath of getWorkspaceProjectOrderPaths(rootsState)) {
-    if (remoteProjectsById.has(rootPath)) {
-      names.push(rootPath)
-      continue
-    }
-    if (hasCanonicalWorkspaceRootForManagedWorktree(rootPath, rootsState)) continue
+  return getWorkspaceProjectOrderPaths(rootsState).map((rootPath) => {
+    if (remoteProjectsById.has(rootPath)) return rootPath
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
-    names.push(duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName)
-  }
-  return names
+    return duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName
+  })
 }
 
 function matchesWorkspaceRootProject(rootPath: string, projectName: string): boolean {
@@ -1185,9 +1167,11 @@ function disambiguateProjectGroupsByCwd(
   const uniqueCanonicalWorkspaceRootLeafNames = new Set<string>()
   const duplicateCanonicalWorkspaceRootLeafNames = new Set<string>()
   const canonicalWorkspaceRootByLeafName = new Map<string, string>()
+  const registeredWorkspaceRoots = new Set<string>()
   for (const rootPath of rootsState?.order ?? []) {
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
+    registeredWorkspaceRoots.add(normalizedRootPath)
     if (isManagedCodexWorktreePath(normalizedRootPath)) continue
     const leafName = toProjectName(normalizedRootPath)
     if (uniqueCanonicalWorkspaceRootLeafNames.has(leafName)) {
@@ -1206,7 +1190,9 @@ function disambiguateProjectGroupsByCwd(
     for (const thread of group.threads) {
       const normalizedCwd = normalizePathForUi(thread.cwd).trim()
       const leafName = toProjectName(normalizedCwd)
+      const isRegisteredRoot = registeredWorkspaceRoots.has(normalizedCwd)
       const isCanonicalWorktreeThread = isManagedCodexWorktreePath(normalizedCwd)
+        && !isRegisteredRoot
         && uniqueCanonicalWorkspaceRootLeafNames.has(leafName)
       let projectName = group.projectName
       if (isCanonicalWorktreeThread && duplicateLeafNames.has(leafName)) {
@@ -1248,7 +1234,6 @@ function addWorkspaceRootPlaceholderGroups(
     }
     const normalizedRootPath = normalizePathForUi(rootPath).trim()
     if (!normalizedRootPath) continue
-    if (hasCanonicalWorkspaceRootForManagedWorktree(normalizedRootPath, rootsState)) continue
     const leafName = toProjectNameFromWorkspaceRoot(normalizedRootPath)
     const projectName = duplicateLeafNames.has(leafName) ? normalizedRootPath : leafName
     if (existingProjectNames.has(projectName)) continue

--- a/tests.md
+++ b/tests.md
@@ -4149,27 +4149,30 @@ Composer runtime options and project menu worktree actions are hidden when the s
 ### Project worktree threads under canonical project
 
 #### Feature/Change Name
-Managed worktree threads remain visible under their matching canonical workspace-root project, and path-like project tooltips expose the full path.
+Managed worktree threads remain visible under their matching canonical workspace-root project, and registered managed worktree roots do not appear as separate empty projects when the canonical root exists.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
 2. Codex global workspace roots include `/Users/igor/Git-projects/codex-web-local`
 3. Thread history contains at least one thread whose cwd is under `/Users/igor/.codex/worktrees/*/codex-web-local`
-4. Light theme and dark theme both available from the appearance switcher
+4. Optional: Codex global workspace roots include a registered worktree root such as `/Users/igor/.codex/worktrees/a77f/codex-web-local`
+5. Light theme and dark theme both available from the appearance switcher
 
 #### Steps
 1. In light theme, open the sidebar Projects section.
 2. Scroll to the `codex-web-local` project.
 3. Confirm the project includes the main-root thread and managed worktree threads.
 4. Confirm worktree rows still show the worktree icon.
-5. Confirm unrelated `.git/worktrees` rows with the same leaf folder name are not grouped into this project.
-6. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
-7. Switch to dark theme and repeat steps 1-6.
+5. Confirm a registered managed worktree root with the same leaf folder name does not appear as a separate empty project such as `codex-web-local2 a77f`.
+6. Confirm unrelated `.git/worktrees` rows with the same leaf folder name are not grouped into this project.
+7. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
+8. Switch to dark theme and repeat steps 1-7.
 
 #### Expected Results
 - Managed worktree threads with the same leaf folder name are not split into hidden path-like project groups.
 - Generic `.git/worktrees` rows are not treated as managed Codex worktrees for project-root grouping.
 - The canonical `codex-web-local` project shows both main-root and worktree threads.
+- Registered managed Codex worktree roots are suppressed as standalone empty groups when the canonical workspace root is also registered.
 - Path-like project tooltips expose the full project path.
 - Project rows and worktree icons remain readable in light and dark themes.
 

--- a/tests.md
+++ b/tests.md
@@ -4149,30 +4149,27 @@ Composer runtime options and project menu worktree actions are hidden when the s
 ### Project worktree threads under canonical project
 
 #### Feature/Change Name
-Managed worktree threads remain visible under their matching canonical workspace-root project, and registered managed worktree roots do not appear as separate empty projects when the canonical root exists.
+Managed worktree threads remain visible under their matching canonical workspace-root project, and path-like project tooltips expose the full path.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
 2. Codex global workspace roots include `/Users/igor/Git-projects/codex-web-local`
 3. Thread history contains at least one thread whose cwd is under `/Users/igor/.codex/worktrees/*/codex-web-local`
-4. Optional: Codex global workspace roots include a registered worktree root such as `/Users/igor/.codex/worktrees/a77f/codex-web-local`
-5. Light theme and dark theme both available from the appearance switcher
+4. Light theme and dark theme both available from the appearance switcher
 
 #### Steps
 1. In light theme, open the sidebar Projects section.
 2. Scroll to the `codex-web-local` project.
 3. Confirm the project includes the main-root thread and managed worktree threads.
 4. Confirm worktree rows still show the worktree icon.
-5. Confirm a registered managed worktree root with the same leaf folder name does not appear as a separate empty project such as `codex-web-local2 a77f`.
-6. Confirm unrelated `.git/worktrees` rows with the same leaf folder name are not grouped into this project.
-7. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
-8. Switch to dark theme and repeat steps 1-7.
+5. Confirm unrelated `.git/worktrees` rows with the same leaf folder name are not grouped into this project.
+6. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
+7. Switch to dark theme and repeat steps 1-6.
 
 #### Expected Results
 - Managed worktree threads with the same leaf folder name are not split into hidden path-like project groups.
 - Generic `.git/worktrees` rows are not treated as managed Codex worktrees for project-root grouping.
 - The canonical `codex-web-local` project shows both main-root and worktree threads.
-- Registered managed Codex worktree roots are suppressed as standalone empty groups when the canonical workspace root is also registered.
 - Path-like project tooltips expose the full project path.
 - Project rows and worktree icons remain readable in light and dark themes.
 

--- a/tests.md
+++ b/tests.md
@@ -4162,11 +4162,13 @@ Managed worktree threads remain visible under their matching canonical workspace
 2. Scroll to the `codex-web-local` project.
 3. Confirm the project includes the main-root thread and managed worktree threads.
 4. Confirm worktree rows still show the worktree icon.
-5. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
-6. Switch to dark theme and repeat steps 1-5.
+5. Confirm unrelated `.git/worktrees` rows with the same leaf folder name are not grouped into this project.
+6. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
+7. Switch to dark theme and repeat steps 1-6.
 
 #### Expected Results
 - Managed worktree threads with the same leaf folder name are not split into hidden path-like project groups.
+- Generic `.git/worktrees` rows are not treated as managed Codex worktrees for project-root grouping.
 - The canonical `codex-web-local` project shows both main-root and worktree threads.
 - Path-like project tooltips expose the full project path.
 - Project rows and worktree icons remain readable in light and dark themes.

--- a/tests.md
+++ b/tests.md
@@ -4143,3 +4143,33 @@ Composer runtime options and project menu worktree actions are hidden when the s
 
 #### Rollback/Cleanup
 - Remove any disposable plain folder or test chats created for this validation.
+
+---
+
+### Project worktree threads under canonical project
+
+#### Feature/Change Name
+Managed worktree threads remain visible under their matching canonical workspace-root project, and path-like project tooltips expose the full path.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Codex global workspace roots include `/Users/igor/Git-projects/codex-web-local`
+3. Thread history contains at least one thread whose cwd is under `/Users/igor/.codex/worktrees/*/codex-web-local`
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open the sidebar Projects section.
+2. Scroll to the `codex-web-local` project.
+3. Confirm the project includes the main-root thread and managed worktree threads.
+4. Confirm worktree rows still show the worktree icon.
+5. Hover any shortened path-like duplicate project title and confirm the tooltip shows the full project path, not only the friendly label.
+6. Switch to dark theme and repeat steps 1-5.
+
+#### Expected Results
+- Managed worktree threads with the same leaf folder name are not split into hidden path-like project groups.
+- The canonical `codex-web-local` project shows both main-root and worktree threads.
+- Path-like project tooltips expose the full project path.
+- Project rows and worktree icons remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- None.


### PR DESCRIPTION
## Summary
- Match Codex.app project ordering from global state, including remote projects.
- Keep same-name folders distinct while showing friendly project labels and full paths on hover.
- Keep projectless generated chats out of Projects and avoid persisting hydrated project state back to localStorage.
- Prefer Browser Use in agent guidance, with fallback to older approaches.

## Tests
- pnpm run test:unit -- src/composables/useDesktopState.test.ts
- pnpm run build:frontend
- Sidebar smoke on http://localhost:5174/#/ confirmed ubuntu a1, Android Tester New project 4, Claude Happy New project 2, and no projectless chat leaks.