### PR TITLE
[codex] Recover persisted idle queues

### DIFF
--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -4191,6 +4191,7 @@ class AppServerProcess {
 
 class BackendQueueProcessor {
   private readonly processingThreadIds = new Set<string>()
+  private readonly queueDrainTimersByThreadId = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly unsubscribe: () => void
 
   constructor(private readonly appServer: AppServerProcess) {
@@ -4200,29 +4201,86 @@ class BackendQueueProcessor {
       if (!threadId) return
       void this.processThreadQueue(threadId)
     })
+    void this.scheduleAllQueuedThreads(1000)
   }
 
   dispose(): void {
     this.unsubscribe()
+    for (const timer of this.queueDrainTimersByThreadId.values()) {
+      clearTimeout(timer)
+    }
+    this.queueDrainTimersByThreadId.clear()
     this.processingThreadIds.clear()
   }
 
-  private async processThreadQueue(threadId: string): Promise<void> {
+  async scheduleAllQueuedThreads(delayMs = 0): Promise<void> {
+    try {
+      const state = await readThreadQueueState()
+      for (const threadId of Object.keys(state)) {
+        this.scheduleThreadQueueDrain(threadId, delayMs)
+      }
+    } catch {
+      // Queue recovery is best-effort; normal turn-completed events can still drain later.
+    }
+  }
+
+  scheduleThreadQueueDrain(threadId: string, delayMs = 5000): void {
+    if (!threadId || this.queueDrainTimersByThreadId.has(threadId)) return
+    const timer = setTimeout(() => {
+      this.queueDrainTimersByThreadId.delete(threadId)
+      void this.processThreadQueue(threadId)
+    }, Math.max(0, delayMs))
+    timer.unref?.()
+    this.queueDrainTimersByThreadId.set(threadId, timer)
+  }
+
+  async processThreadQueue(threadId: string): Promise<void> {
     if (this.processingThreadIds.has(threadId)) return
     this.processingThreadIds.add(threadId)
     try {
+      const canStart = await this.canStartQueuedTurn(threadId)
+      if (!canStart) {
+        if (await this.hasQueuedTurns(threadId)) {
+          this.scheduleThreadQueueDrain(threadId)
+        }
+        return
+      }
       const next = await this.popNextQueuedTurn(threadId)
       if (!next) return
       try {
         await this.startQueuedTurn(next)
+        if (await this.hasQueuedTurns(threadId)) {
+          this.scheduleThreadQueueDrain(threadId)
+        }
       } catch {
         await this.restoreQueuedTurn(next)
+        this.scheduleThreadQueueDrain(threadId)
       }
     } catch {
       // Queue processing is best-effort. Keep the bridge alive if app-server is unavailable.
+      this.scheduleThreadQueueDrain(threadId)
     } finally {
       this.processingThreadIds.delete(threadId)
     }
+  }
+
+  private async hasQueuedTurns(threadId: string): Promise<boolean> {
+    const state = await readThreadQueueState()
+    const queue = state[threadId]
+    return Array.isArray(queue) && queue.length > 0
+  }
+
+  private async canStartQueuedTurn(threadId: string): Promise<boolean> {
+    const response = asRecord(await this.appServer.rpc('thread/read', { threadId, includeTurns: true }))
+    const thread = asRecord(response?.thread)
+    if (!thread) return false
+
+    const status = asRecord(thread.status)
+    const statusType = readNonEmptyString(status?.type)
+    if (statusType === 'inProgress' || statusType === 'running' || statusType === 'active') return false
+
+    const turns = Array.isArray(thread.turns) ? thread.turns : []
+    return !turns.some((turn) => readNonEmptyString(asRecord(turn)?.status) === 'inProgress')
   }
 
   private async popNextQueuedTurn(threadId: string): Promise<BackendQueuedTurn | null> {
@@ -5821,6 +5879,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
         await writeThreadQueueState(normalizeThreadQueueState(record))
+        void backendQueueProcessor.scheduleAllQueuedThreads()
         setJson(res, 200, { ok: true })
         return
       }

--- a/tests.md
+++ b/tests.md
@@ -3888,6 +3888,41 @@ The queue panel refreshes when the backend starts and drains persisted queued me
 
 ---
 
+### Persisted idle queue recovery
+
+#### Feature/Change Name
+Backend queued messages are retried and drained for idle threads even if the original `turn/completed` notification was missed or the server starts with persisted queue state already present.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. A thread exists with queued messages persisted in `/codex-api/thread-queue-state`
+3. The thread's latest turn is completed/idle
+4. Light theme and dark theme are both available
+
+#### Steps
+1. In light theme, open the thread with persisted queued rows
+2. Confirm the queued rows are visible above the composer
+3. Wait for backend queue recovery to start the first queued message
+4. Confirm the first queued row is removed and a new turn starts
+5. Wait for the queued turn to complete
+6. Confirm the next queued row starts automatically
+7. Repeat until `/codex-api/thread-queue-state` no longer includes the thread
+8. Refresh the thread and confirm all queued messages completed in order
+9. Switch to dark theme and confirm the completed conversation and empty queue state remain readable
+
+#### Expected Results
+- Idle persisted queues recover without requiring a new manual message
+- Queued messages do not start while the thread has an in-progress turn
+- Multiple queued messages drain one at a time and complete in order
+- The queue panel disappears after the final queued message is started
+- The recovered turns and empty queue state are visible in both light theme and dark theme
+
+#### Rollback/Cleanup
+- Delete any remaining queued test rows or let recovery drain them
+- Remove temporary test projects/threads if they are no longer needed
+
+---
+
 ### ChatGPT auth tokens refresh for external auth
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary

Fixes backend queued messages getting stuck when queue draining misses the original `turn/completed` edge or when the server starts with persisted queued state already present.

## Root Cause

The backend queue processor only drained after a `turn/completed` notification. If that notification was missed, or the server was restarted after queued messages had already been persisted, idle threads were never rechecked and queued rows stayed in `/codex-api/thread-queue-state` indefinitely.

During verification, a second edge case showed up: checking only the latest turn could allow queued turns to start while an earlier turn was still `inProgress`. The fix now blocks queue starts when the thread status is active/running/in-progress or when any turn is still in progress.

## Changes

- Schedule persisted queue recovery on bridge startup.
- Schedule queue recovery after thread queue state writes.
- Retry queued drains while queued messages remain.
- Check thread idleness before popping a queued message.
- Document persisted idle queue recovery in `tests.md`.

## Validation

- `pnpm run build:frontend`
- `pnpm run test:unit`
- Restarted the tmux-managed `5173` dev server and confirmed the previously stuck thread `019de0f1-b20d-70e2-a3e7-d6ddbb870188` drained to completion.
- Playwright verification against `http://100.127.77.25:4173` submitted one active turn plus three queued messages; all four turns completed and queue state returned to empty.

Screenshots from verification are under `output/playwright/` locally:

- `queue-multi-during-light-2026-05-01T00-25-19-477Z.png`
- `queue-multi-complete-light-2026-05-01T00-25-19-477Z.png`
- `queue-multi-complete-dark-2026-05-01T00-25-19-477Z.png`
