### PR TITLE
Fix: make node-pty optional to prevent install failure on Android/Termux

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,11 @@
     "express": "^5.1.0",
     "firebase": "^12.2.1",
     "highlight.js": "^11.11.1",
-    "node-pty": "^1.1.0",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/tests.md
+++ b/tests.md
@@ -4175,3 +4175,34 @@ Managed worktree threads remain visible under their matching canonical workspace
 
 #### Rollback/Cleanup
 - None.
+
+---
+
+### Optional node-pty install on Android/Termux
+
+#### Feature/Change Name
+`node-pty` is now installed as an optional dependency so global install does not fail on Android/Termux when native PTY rebuild is unavailable.
+
+#### Prerequisites/Setup
+1. Android Termux environment with Node.js and npm.
+2. No globally installed `codexapp` package.
+3. A second host (macOS/Linux/Windows) where `node-pty` can install successfully for terminal feature verification.
+4. Light theme and dark theme are available in the UI.
+
+#### Steps
+1. In Termux, run `npm i -g codexapp`.
+2. Confirm install completes even if npm logs a skipped/failed optional build for `node-pty`.
+3. Run `codexapp --no-login` and open a thread.
+4. Verify integrated terminal is shown as unavailable (no crash) when PTY support is missing.
+5. On a supported host, run `npm i -g codexapp` and launch `codexapp --no-login`.
+6. In light theme, open a thread and verify integrated terminal opens normally.
+7. Switch to dark theme and verify integrated terminal remains readable and functional.
+
+#### Expected Results
+- Termux global installation no longer hard-fails because `node-pty` rebuild fails.
+- App startup succeeds on Termux and gracefully reports terminal unavailability instead of crashing.
+- Supported hosts still load `node-pty` and integrated terminal behavior remains unchanged.
+- Terminal surfaces remain readable in both light and dark themes.
+
+#### Rollback/Cleanup
+- Remove global package via `npm rm -g codexapp` on test hosts if installed only for validation.


### PR DESCRIPTION
Fixes #116

## Summary

`node-pty` is listed as a required dependency, but its native build fails on Android/Termux because `binding.gyp` references an undefined `android_ndk_path` variable. This causes `npm i -g codexapp` to hard-fail on Termux before the package can even finish installing.

The fix moves `node-pty` from `dependencies` to `optionalDependencies`. When the native build fails on unsupported platforms (Termux/Android), npm skips it gracefully instead of aborting the entire install. The app already handles the missing PTY module at runtime by reporting "Integrated terminal is unavailable on this host".

## Changes

- `package.json`: move `node-pty` from `dependencies` to `optionalDependencies`

## Verification on Android 15 / Termux

**Environment:**
- Android 15, Termux
- Node v24.14.1, npm 11.13.0
- Branch: `fix/issue-116-termux-node-pty-optional`

**Steps & key output:**

```bash
# 1. Clone fix branch
git clone -b fix/issue-116-termux-node-pty-optional https://github.com/chenhui-su/codex-web-ui.git
cd codex-web-ui

# 2. Install deps — postinstall succeeds, node-pty failure no longer blocks
npm install
# > added 298 packages, and audited 299 packages in 1m
# > found 0 vulnerability

# 3. Build CLI
npm run build:cli
# > ESM dist-cli/index.js     433.38 KB
# > ESM ⚡️ Build success in 670ms

# 4. Global install — completes without error
npm uninstall -g codexapp
npm i -g .
# > added 1 package in 919ms

# 5. codexapp command is available
ls "$(npm prefix -g)/bin" | grep codex
# codexapp
# codexui

# 6. App launches successfully
codexapp --no-login
# Codex Web Local is running!
#   Version:  0.1.87
#   Bind:     http://0.0.0.0:5900
#   Codex sandbox: danger-full-access
#   Approval policy: never
#   Local:    http://localhost:5900
#   Network:  http://192.168.31.64:5900
#   Password: emn-1z5-okr
```

**Before the fix** (issue #116): `npm i -g codexapp` fails with `gyp: Undefined variable android_ndk_path in binding.gyp` and exits with code 1.

**After the fix**: install completes; app starts and gracefully reports terminal unavailability when PTY is missing.

## Impact on supported platforms

On platforms where `node-pty` builds successfully (Linux, macOS, Windows), `optionalDependencies` are installed identically to regular `dependencies`. No behavioral change on supported hosts — the integrated terminal continues to work as before.
