### PR TITLE
Keep composer controls active during responses

### DIFF
--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -218,7 +218,7 @@
               role="switch"
               :aria-checked="isPlanModeSelected"
               :aria-label="isPlanModeSelected ? t('Disable plan mode') : t('Enable plan mode')"
-              :disabled="disabled || !activeThreadId || isTurnInProgress"
+              :disabled="isComposerConfigDisabled"
               @click="toggleCollaborationMode"
             >
               <span class="thread-composer-attach-setting-copy">
@@ -241,7 +241,7 @@
             :selected-prefix-icon="showFastModeModelIcon ? IconTablerBolt : null"
             :placeholder="t('Model')"
             open-direction="up"
-            :disabled="disabled || !activeThreadId || models.length === 0 || isTurnInProgress"
+            :disabled="isComposerConfigDisabled || models.length === 0"
             enable-search
             :search-placeholder="t('Search models...')"
             @update:model-value="onModelSelect"
@@ -257,7 +257,7 @@
             :allow-remove="true"
             :remove-label="t('Remove prompt')"
             open-direction="up"
-            :disabled="disabled || !activeThreadId || isTurnInProgress"
+            :disabled="isComposerConfigDisabled"
             @toggle="onSkillDropdownToggle"
             @create="onCreatePrompt"
             @remove="onRemovePrompt"
@@ -269,7 +269,7 @@
             :options="reasoningOptions"
             :placeholder="t('Thinking')"
             open-direction="up"
-            :disabled="disabled || !activeThreadId || isTurnInProgress"
+            :disabled="isComposerConfigDisabled"
             @update:model-value="onReasoningEffortSelect"
           />
         </template>
@@ -628,6 +628,7 @@ const standaloneFileAttachments = computed(() => {
   return fileAttachments.value.filter((att) => !grouped.has(att.fsPath))
 })
 const isInteractionDisabled = computed(() => props.disabled || !props.activeThreadId)
+const isComposerConfigDisabled = computed(() => props.disabled || !props.activeThreadId)
 const isFastModeSupported = computed(() => props.selectedModel.trim() === 'gpt-5.4')
 const showFastModeModelIcon = computed(() =>
   props.selectedSpeedMode === 'fast' && isFastModeSupported.value,

--- a/tests.md
+++ b/tests.md
@@ -176,6 +176,39 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - None.
 
+---
+
+### Composer controls stay editable during responses
+
+#### Feature/Change Name
+Model, skill, thinking, and plan controls remain usable while a thread turn is in progress.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. A thread that can produce a long enough response to interact with the composer while the assistant is responding
+3. At least one installed skill or saved prompt
+4. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, send a message that starts an assistant response.
+2. While the response is still streaming, type a follow-up draft in the composer.
+3. Open the model dropdown and select a different model.
+4. Open the skills dropdown and select a skill or saved prompt.
+5. Open the thinking dropdown and select a different value.
+6. Open the attachment menu and toggle plan mode.
+7. Verify the stop button and send/queue behavior still match the in-progress turn state.
+8. Switch to dark theme and repeat steps 1 through 7.
+
+#### Expected Results
+- The message textarea remains editable while the assistant is responding.
+- Model, skills, thinking, and plan controls are not disabled during the in-progress response.
+- Selected controls update the composer state for the next submitted or queued message.
+- Stop remains available while no draft content is present, and the submit button switches to the configured steer/queue behavior when draft content exists.
+- Light-theme and dark-theme controls remain readable and do not overlap.
+
+#### Rollback/Cleanup
+- Remove any disposable queued messages or test skill selections from the thread.
+
 ### Feature: Remove GitHub trending projects from the new-thread screen
 
 #### Prerequisites


### PR DESCRIPTION
## Summary
- keep model, skills, thinking, and plan controls enabled while a turn is in progress
- preserve stop/send in-progress behavior
- document light/dark manual verification in tests.md

## Tests
- pnpm run build:frontend