### PR TITLE
Create branches for permanent worktrees

### DIFF
--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2507,6 +2507,44 @@ function extractBranchLockedWorktreePath(error: unknown, branchName: string): st
   return match?.[1]?.trim() ?? ''
 }
 
+function toPermanentWorktreeBranchNameDraft(worktreeName: string): string {
+  const sanitized = worktreeName
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    .replace(/\.+/gu, '.')
+    .replace(/-+/gu, '-')
+    .replace(/^[.-]+|[.-]+$/gu, '')
+  return sanitized || 'worktree'
+}
+
+async function isValidGitBranchName(gitRoot: string, branchName: string): Promise<boolean> {
+  try {
+    await runCommand('git', ['check-ref-format', '--branch', branchName], { cwd: gitRoot })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function doesLocalGitBranchExist(gitRoot: string, branchName: string): Promise<boolean> {
+  try {
+    await runCommand('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], { cwd: gitRoot })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function allocatePermanentWorktreeBranchName(gitRoot: string, worktreeName: string): Promise<string> {
+  const base = toPermanentWorktreeBranchNameDraft(worktreeName)
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const candidate = attempt === 0 ? base : `${base}-${attempt + 1}`
+    if (!await isValidGitBranchName(gitRoot, candidate)) continue
+    if (!await doesLocalGitBranchExist(gitRoot, candidate)) return candidate
+  }
+  throw new Error('Failed to allocate a unique branch name for worktree')
+}
+
 async function runCommandWithOutput(command: string, args: string[], options: { cwd?: string } = {}): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const proc = spawn(command, args, {
@@ -5700,18 +5738,19 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             // Expected for a new worktree path.
           }
 
+          const branchName = await allocatePermanentWorktreeBranchName(gitRoot, rawWorktreeName)
           try {
-            await runCommand('git', ['worktree', 'add', worktreeCwd, 'HEAD'], { cwd: gitRoot })
+            await runCommand('git', ['worktree', 'add', '-b', branchName, worktreeCwd, 'HEAD'], { cwd: gitRoot })
           } catch (error) {
             if (!isMissingHeadError(error)) throw error
             await ensureRepoHasInitialCommit(gitRoot)
-            await runCommand('git', ['worktree', 'add', worktreeCwd, 'HEAD'], { cwd: gitRoot })
+            await runCommand('git', ['worktree', 'add', '-b', branchName, worktreeCwd, 'HEAD'], { cwd: gitRoot })
           }
 
           setJson(res, 200, {
             data: {
               cwd: worktreeCwd,
-              branch: null,
+              branch: branchName,
               gitRoot,
             },
           })

--- a/tests.md
+++ b/tests.md
@@ -4104,19 +4104,21 @@ Project rows open the same action menu from right-click and the dots button, and
 7. Reopen the project menu, click `New worktree`, and confirm the prompt is prefilled with `<project name>-`.
 8. Enter a unique folder name such as `<project name>-manual-test`.
 9. Confirm a Git worktree is created at `../<worktree name>` relative to the source repo root.
-10. Confirm the new worktree is added as a project and the app opens the new-chat composer with that cwd selected.
-11. Rename the project to include a slash, reopen `New worktree`, and confirm the suggested folder name replaces the slash with `-`.
-12. Switch to dark theme and repeat steps 1-4, verifying menu contrast and danger styling remain readable.
+10. Run `git -C ../<worktree name> branch --show-current` and confirm it prints a branch based on the worktree folder name.
+11. Confirm the new worktree is added as a project and the app opens the new-chat composer with that cwd selected.
+12. Rename the project to include a slash, reopen `New worktree`, and confirm the suggested folder name replaces the slash with `-`.
+13. Switch to dark theme and repeat steps 1-4, verifying menu contrast and danger styling remain readable.
 
 #### Expected Results
 - Right-click and dots button expose the same project action menu.
 - `Browse files`, `Rename project`, and `Remove` remain available from that menu.
-- `New worktree` creates a permanent sibling worktree folder, registers it as a project, and opens a new chat for it.
+- `New worktree` creates a permanent sibling worktree folder on its own branch, registers it as a project, and opens a new chat for it.
 - Invalid path separator characters are not used in the default worktree folder suggestion.
 - Menu text, hover states, and the remove action remain readable in light and dark themes.
 
 #### Rollback/Cleanup
 - Remove the test worktree with `git -C <source-repo-root> worktree remove ../<worktree name>`.
+- Delete the test branch with `git -C <source-repo-root> branch -D <branch name>`.
 - Remove the temporary project from the sidebar if it remains listed.
 
 ---


### PR DESCRIPTION
## Summary
- Create a named Git branch when creating a permanent project worktree
- Derive the branch name from the requested worktree folder name
- Auto-suffix branch names when the derived branch already exists
- Return the created branch in the worktree creation API response
- Update manual test docs to verify the new branch

## Verification
- pnpm run build
- Endpoint smoke on http://127.0.0.1:5180
- Invalid name returns 400
- Worktree creation returns 200
- Returned branch matches git branch --show-current
- Project registration REGISTERED=true
- Worktree status count 0
- Cleanup CLEANUP_OK=true