### PR TITLE
Reset branch from header commit picker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -530,7 +530,7 @@
               :review-open="isReviewPaneOpen"
               @toggle-review="isReviewPaneOpen = !isReviewPaneOpen"
               @checkout-branch="onCheckoutContentHeaderBranch"
-              @checkout-commit="onCheckoutContentHeaderCommit"
+              @reset-branch-to-commit="onResetContentHeaderBranchToCommit"
               @load-commits="loadThreadBranchCommits"
             />
           </template>
@@ -969,7 +969,6 @@ import { useMobile } from './composables/useMobile'
 import { useUiLanguage } from './composables/useUiLanguage'
 import {
   checkoutGitBranch,
-  checkoutGitCommit,
   configureTelegramBot,
   createPermanentWorktree,
   createWorktree,
@@ -994,6 +993,7 @@ import {
   persistFirstLaunchPluginsCardPreference,
   removeAccount,
   refreshAccountsFromAuth,
+  resetGitBranchToCommit,
   startCodexLogin,
   searchThreads,
   switchAccount,
@@ -2907,21 +2907,22 @@ function onCheckoutContentHeaderBranch(value: string): void {
     })
 }
 
-function onCheckoutContentHeaderCommit(sha: string): void {
+function onResetContentHeaderBranchToCommit(payload: { branch: string; sha: string }): void {
   if (isSwitchingThreadBranch.value) return
-  const targetSha = sha.trim()
+  const targetBranch = payload.branch.trim()
+  const targetSha = payload.sha.trim()
   const cwd = composerCwd.value.trim()
-  if (!targetSha || !cwd) return
+  if (!targetBranch || !targetSha || !cwd) return
   isSwitchingThreadBranch.value = true
   threadBranchError.value = ''
-  void checkoutGitCommit(cwd, targetSha)
+  void resetGitBranchToCommit(cwd, targetBranch, targetSha)
     .then((state) => {
       applyThreadGitState(state)
       isReviewPaneOpen.value = false
       return loadThreadBranches(cwd)
     })
     .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : 'Failed to check out commit'
+      const message = error instanceof Error ? error.message : 'Failed to reset branch to commit'
       void loadThreadBranches(cwd).finally(() => {
         threadBranchError.value = message
       })

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -2503,18 +2503,19 @@ export async function getGitBranchCommits(cwd: string, branch: string): Promise<
   })
 }
 
-export async function checkoutGitCommit(cwd: string, sha: string): Promise<GitBranchState> {
-  const response = await fetch('/codex-api/git/checkout-commit', {
+export async function resetGitBranchToCommit(cwd: string, branch: string, sha: string): Promise<GitBranchState> {
+  const response = await fetch('/codex-api/git/reset-to-commit', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       cwd: cwd.trim(),
+      branch: branch.trim(),
       sha: sha.trim(),
     }),
   })
   const payload = (await response.json()) as { data?: unknown; error?: string }
   if (!response.ok) {
-    throw new Error(payload.error || 'Failed to check out commit')
+    throw new Error(payload.error || 'Failed to reset branch to commit')
   }
   const record = payload.data && typeof payload.data === 'object' && !Array.isArray(payload.data)
     ? (payload.data as Record<string, unknown>)

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -325,7 +325,6 @@ export type GitCommitOption = {
   shortSha: string
   subject: string
   date: string
-  isReachableFromBranch: boolean
 }
 
 export type GitRepositoryStatus = {
@@ -2500,7 +2499,7 @@ export async function getGitBranchCommits(cwd: string, branch: string): Promise<
     const subject = typeof record.subject === 'string' ? record.subject.trim() : ''
     const date = typeof record.date === 'string' ? record.date.trim() : ''
     if (!sha || !shortSha) return []
-    return [{ sha, shortSha, subject: subject || shortSha, date, isReachableFromBranch: record.isReachableFromBranch !== false }]
+    return [{ sha, shortSha, subject: subject || shortSha, date }]
   })
 }
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -325,6 +325,7 @@ export type GitCommitOption = {
   shortSha: string
   subject: string
   date: string
+  isReachableFromBranch: boolean
 }
 
 export type GitRepositoryStatus = {
@@ -2499,7 +2500,7 @@ export async function getGitBranchCommits(cwd: string, branch: string): Promise<
     const subject = typeof record.subject === 'string' ? record.subject.trim() : ''
     const date = typeof record.date === 'string' ? record.date.trim() : ''
     if (!sha || !shortSha) return []
-    return [{ sha, shortSha, subject: subject || shortSha, date }]
+    return [{ sha, shortSha, subject: subject || shortSha, date, isReachableFromBranch: record.isReachableFromBranch !== false }]
   })
 }
 

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -154,7 +154,7 @@ const detachedCommitMeta = computed(() => {
 const triggerLabel = computed(() => `Git branch: ${displayLabel.value}`)
 const disabled = computed(() => props.loading && props.branches.length === 0)
 const busy = computed(() => props.busy || props.loading)
-const statusMessage = computed(() => props.error || (props.dirty ? 'Uncommitted changes must be committed, stashed, or discarded before switching.' : ''))
+const statusMessage = computed(() => props.error || (props.dirty ? 'Tracked changes must be committed, stashed, or discarded before switching or resetting. Untracked files are allowed unless Git would overwrite them.' : ''))
 const statusKind = computed(() => props.error ? 'error' : 'info')
 const filteredBranches = computed(() => {
   const query = searchQuery.value.trim().toLowerCase()

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -83,6 +83,7 @@
                   <code>{{ commit.shortSha }}</code>
                   <span class="header-git-commit-meta">
                     <span v-if="isCurrentCommit(commit)" class="header-git-branch-meta">current</span>
+                    <span v-else-if="!commit.isReachableFromBranch" class="header-git-branch-meta" title="Saved from reset history, not on this branch">saved</span>
                     <span>{{ commit.date }}</span>
                   </span>
                 </span>

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -75,9 +75,9 @@
                 class="header-git-commit"
                 :class="{ 'is-current': isCurrentCommit(commit) }"
                 type="button"
-                :disabled="busy"
-                :title="`Reset ${branch.value} to ${commit.shortSha}`"
-                @click="emit('resetBranchToCommit', { branch: branch.value, sha: commit.sha })"
+                :disabled="busy || branch.isRemote"
+                :title="commitActionTitle(branch, commit)"
+                @click="onSelectCommit(branch, commit)"
               >
                 <span class="header-git-commit-top">
                   <code>{{ commit.shortSha }}</code>
@@ -177,6 +177,16 @@ function isCurrentCommit(commit: GitCommitOption): boolean {
   const headSha = props.headSha?.trim() ?? ''
   if (!headSha) return false
   return commit.sha === headSha || commit.shortSha === headSha || commit.sha.startsWith(headSha)
+}
+
+function commitActionTitle(branch: WorktreeBranchOption, commit: GitCommitOption): string {
+  if (branch.isRemote) return 'Remote branches cannot be reset from this menu'
+  return `Reset ${branch.value} to ${commit.shortSha}`
+}
+
+function onSelectCommit(branch: WorktreeBranchOption, commit: GitCommitOption): void {
+  if (branch.isRemote) return
+  emit('resetBranchToCommit', { branch: branch.value, sha: commit.sha })
 }
 
 function onEscapeSearch(): void {

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -76,7 +76,8 @@
                 :class="{ 'is-current': isCurrentCommit(commit) }"
                 type="button"
                 :disabled="busy"
-                @click="emit('checkoutCommit', commit.sha)"
+                :title="`Reset ${branch.value} to ${commit.shortSha}`"
+                @click="emit('resetBranchToCommit', { branch: branch.value, sha: commit.sha })"
               >
                 <span class="header-git-commit-top">
                   <code>{{ commit.shortSha }}</code>
@@ -130,7 +131,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   toggleReview: []
   checkoutBranch: [branch: string]
-  checkoutCommit: [sha: string]
+  resetBranchToCommit: [payload: { branch: string; sha: string }]
   loadCommits: [branch: string]
 }>()
 
@@ -150,7 +151,7 @@ const detachedCommitMeta = computed(() => {
   if (!props.detached) return ''
   return [props.headSha, props.headDate].filter(Boolean).join(' · ')
 })
-const triggerLabel = computed(() => `Git checkout: ${displayLabel.value}`)
+const triggerLabel = computed(() => `Git branch: ${displayLabel.value}`)
 const disabled = computed(() => props.loading && props.branches.length === 0)
 const busy = computed(() => props.busy || props.loading)
 const statusMessage = computed(() => props.error || (props.dirty ? 'Uncommitted changes must be committed, stashed, or discarded before switching.' : ''))

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -83,7 +83,6 @@
                   <code>{{ commit.shortSha }}</code>
                   <span class="header-git-commit-meta">
                     <span v-if="isCurrentCommit(commit)" class="header-git-branch-meta">current</span>
-                    <span v-else-if="!commit.isReachableFromBranch" class="header-git-branch-meta" title="Saved from reset history, not on this branch">saved</span>
                     <span>{{ commit.date }}</span>
                   </span>
                 </span>

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2533,10 +2533,14 @@ async function readGitHeaderState(cwd: string): Promise<{
   }
 }
 
-async function assertCleanGitWorktree(repoRoot: string): Promise<void> {
+async function assertNoTrackedGitChanges(repoRoot: string): Promise<void> {
   const statusRaw = await runCommandCapture('git', ['status', '--porcelain'], { cwd: repoRoot })
-  if (statusRaw.trim()) {
-    throw new Error('Cannot switch branches or reset with uncommitted changes. Commit, stash, or discard local changes first.')
+  const trackedChanges = statusRaw
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line && !line.startsWith('?? '))
+  if (trackedChanges.length > 0) {
+    throw new Error('Cannot switch branches or reset with tracked uncommitted changes. Commit, stash, or discard tracked changes first. Untracked files are allowed unless Git would overwrite them.')
   }
 }
 
@@ -6014,7 +6018,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         }
         try {
           const gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd })
-          await assertCleanGitWorktree(gitRoot)
+          await assertNoTrackedGitChanges(gitRoot)
           try {
             await runCommand('git', ['checkout', targetBranch], { cwd: gitRoot })
           } catch (checkoutError) {
@@ -6101,7 +6105,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const cwd = isAbsolute(rawCwd) ? rawCwd : resolve(rawCwd)
         try {
           const gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd })
-          await assertCleanGitWorktree(gitRoot)
+          await assertNoTrackedGitChanges(gitRoot)
           await assertLocalGitBranch(gitRoot, branch)
           const currentBranch = (await runCommandCapture('git', ['branch', '--show-current'], { cwd: gitRoot })).trim()
           if (currentBranch && currentBranch !== branch) {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2498,6 +2498,14 @@ function normalizeBranchRefName(value: string): string {
   return trimmed
 }
 
+function toHeaderGitResetHistoryRef(branchName: string, commitSha: string): string {
+  return `refs/codex/header-git-reset-history/${branchName}/${commitSha}`
+}
+
+async function assertLocalGitBranch(repoRoot: string, branchName: string): Promise<void> {
+  await runCommandCapture('git', ['show-ref', '--verify', `refs/heads/${branchName}`], { cwd: repoRoot })
+}
+
 async function readGitHeaderState(cwd: string): Promise<{
   currentBranch: string | null
   headSha: string | null
@@ -2528,7 +2536,7 @@ async function readGitHeaderState(cwd: string): Promise<{
 async function assertCleanGitWorktree(repoRoot: string): Promise<void> {
   const statusRaw = await runCommandCapture('git', ['status', '--porcelain'], { cwd: repoRoot })
   if (statusRaw.trim()) {
-    throw new Error('Cannot switch checkout with uncommitted changes. Commit, stash, or discard local changes first.')
+    throw new Error('Cannot switch branches or reset with uncommitted changes. Commit, stash, or discard local changes first.')
   }
 }
 
@@ -6039,9 +6047,19 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         try {
           const gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd })
           await runCommandCapture('git', ['rev-parse', '--verify', `${branch}^{commit}`], { cwd: gitRoot })
+          const resetHistoryRefPrefix = `refs/codex/header-git-reset-history/${branch}/`
+          const resetHistoryRefsRaw = await runCommandCapture(
+            'git',
+            ['for-each-ref', '--format=%(refname)', resetHistoryRefPrefix],
+            { cwd: gitRoot },
+          ).catch(() => '')
+          const resetHistoryRefs = resetHistoryRefsRaw
+            .split('\n')
+            .map((entry) => entry.trim())
+            .filter(Boolean)
           const output = await runCommandCapture(
             'git',
-            ['log', '-n', '12', '--date=short', '--format=%H%x09%h%x09%cd%x09%s', branch],
+            ['log', '-n', '12', '--date=short', '--format=%H%x09%h%x09%cd%x09%s', branch, ...resetHistoryRefs],
             { cwd: gitRoot },
           )
           const commits = output.split('\n').flatMap((line) => {
@@ -6058,7 +6076,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
-      if (req.method === 'POST' && url.pathname === '/codex-api/git/checkout-commit') {
+      if (req.method === 'POST' && url.pathname === '/codex-api/git/reset-to-commit') {
         const payload = await readJsonBody(req)
         const record = asRecord(payload)
         if (!record) {
@@ -6066,9 +6084,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
         const rawCwd = readNonEmptyString(record.cwd)
+        const branch = readNonEmptyString(record.branch)
         const sha = readNonEmptyString(record.sha)
         if (!rawCwd) {
           setJson(res, 400, { error: 'Missing cwd' })
+          return
+        }
+        if (!branch) {
+          setJson(res, 400, { error: 'Missing branch' })
           return
         }
         if (!sha) {
@@ -6079,11 +6102,20 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         try {
           const gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd })
           await assertCleanGitWorktree(gitRoot)
+          await assertLocalGitBranch(gitRoot, branch)
+          const currentBranch = (await runCommandCapture('git', ['branch', '--show-current'], { cwd: gitRoot })).trim()
+          if (currentBranch && currentBranch !== branch) {
+            await runCommand('git', ['checkout', branch], { cwd: gitRoot })
+          } else if (!currentBranch) {
+            await runCommand('git', ['checkout', branch], { cwd: gitRoot })
+          }
+          const previousTip = await runCommandCapture('git', ['rev-parse', 'HEAD'], { cwd: gitRoot })
           const targetSha = await runCommandCapture('git', ['rev-parse', '--verify', `${sha}^{commit}`], { cwd: gitRoot })
-          await runCommand('git', ['checkout', '--detach', targetSha.trim()], { cwd: gitRoot })
+          await runCommand('git', ['update-ref', toHeaderGitResetHistoryRef(branch, previousTip.trim()), previousTip.trim()], { cwd: gitRoot })
+          await runCommand('git', ['reset', '--hard', targetSha.trim()], { cwd: gitRoot })
           setJson(res, 200, { data: await readGitHeaderState(gitRoot) })
         } catch (error) {
-          setJson(res, 500, { error: getErrorMessage(error, 'Failed to check out commit') })
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to reset branch to commit') })
         }
         return
       }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -2502,8 +2502,40 @@ function toHeaderGitResetHistoryRef(branchName: string, commitSha: string): stri
   return `refs/codex/header-git-reset-history/${branchName}/${commitSha}`
 }
 
+const HEADER_GIT_RESET_HISTORY_REF_LIMIT = 25
+
 async function assertLocalGitBranch(repoRoot: string, branchName: string): Promise<void> {
   await runCommandCapture('git', ['show-ref', '--verify', `refs/heads/${branchName}`], { cwd: repoRoot })
+}
+
+async function checkoutGitBranchWithWorktreeRecovery(repoRoot: string, branchName: string): Promise<void> {
+  try {
+    await runCommand('git', ['checkout', branchName], { cwd: repoRoot })
+  } catch (checkoutError) {
+    const blockingWorktreePath = extractBranchLockedWorktreePath(checkoutError, branchName)
+    if (!blockingWorktreePath) {
+      throw checkoutError
+    }
+    await runCommand('git', ['checkout', '--detach'], { cwd: blockingWorktreePath })
+    await runCommand('git', ['checkout', branchName], { cwd: repoRoot })
+  }
+}
+
+async function pruneHeaderGitResetHistoryRefs(repoRoot: string, branchName: string): Promise<void> {
+  const resetHistoryRefPrefix = `refs/codex/header-git-reset-history/${branchName}/`
+  const refsRaw = await runCommandCapture(
+    'git',
+    ['for-each-ref', '--sort=-creatordate', '--format=%(refname)', resetHistoryRefPrefix],
+    { cwd: repoRoot },
+  ).catch(() => '')
+  const refs = refsRaw
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const staleRefs = refs.slice(HEADER_GIT_RESET_HISTORY_REF_LIMIT)
+  for (const refName of staleRefs) {
+    await runCommand('git', ['update-ref', '-d', refName], { cwd: repoRoot })
+  }
 }
 
 async function readGitHeaderState(cwd: string): Promise<{
@@ -6019,16 +6051,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         try {
           const gitRoot = await runCommandCapture('git', ['rev-parse', '--show-toplevel'], { cwd })
           await assertNoTrackedGitChanges(gitRoot)
-          try {
-            await runCommand('git', ['checkout', targetBranch], { cwd: gitRoot })
-          } catch (checkoutError) {
-            const blockingWorktreePath = extractBranchLockedWorktreePath(checkoutError, targetBranch)
-            if (!blockingWorktreePath) {
-              throw checkoutError
-            }
-            await runCommand('git', ['checkout', '--detach'], { cwd: blockingWorktreePath })
-            await runCommand('git', ['checkout', targetBranch], { cwd: gitRoot })
-          }
+          await checkoutGitBranchWithWorktreeRecovery(gitRoot, targetBranch)
           setJson(res, 200, { data: await readGitHeaderState(gitRoot) })
         } catch (error) {
           setJson(res, 500, { error: getErrorMessage(error, 'Failed to switch branch') })
@@ -6054,13 +6077,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           const resetHistoryRefPrefix = `refs/codex/header-git-reset-history/${branch}/`
           const resetHistoryRefsRaw = await runCommandCapture(
             'git',
-            ['for-each-ref', '--format=%(refname)', resetHistoryRefPrefix],
+            ['for-each-ref', '--sort=-creatordate', '--format=%(refname)', resetHistoryRefPrefix],
             { cwd: gitRoot },
           ).catch(() => '')
           const resetHistoryRefs = resetHistoryRefsRaw
             .split('\n')
             .map((entry) => entry.trim())
             .filter(Boolean)
+            .slice(0, HEADER_GIT_RESET_HISTORY_REF_LIMIT)
           const output = await runCommandCapture(
             'git',
             ['log', '-n', '12', '--date=short', '--format=%H%x09%h%x09%cd%x09%s', branch, ...resetHistoryRefs],
@@ -6109,13 +6133,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           await assertLocalGitBranch(gitRoot, branch)
           const currentBranch = (await runCommandCapture('git', ['branch', '--show-current'], { cwd: gitRoot })).trim()
           if (currentBranch && currentBranch !== branch) {
-            await runCommand('git', ['checkout', branch], { cwd: gitRoot })
+            await checkoutGitBranchWithWorktreeRecovery(gitRoot, branch)
           } else if (!currentBranch) {
-            await runCommand('git', ['checkout', branch], { cwd: gitRoot })
+            await checkoutGitBranchWithWorktreeRecovery(gitRoot, branch)
           }
           const previousTip = await runCommandCapture('git', ['rev-parse', 'HEAD'], { cwd: gitRoot })
           const targetSha = await runCommandCapture('git', ['rev-parse', '--verify', `${sha}^{commit}`], { cwd: gitRoot })
           await runCommand('git', ['update-ref', toHeaderGitResetHistoryRef(branch, previousTip.trim()), previousTip.trim()], { cwd: gitRoot })
+          await pruneHeaderGitResetHistoryRefs(gitRoot, branch)
           await runCommand('git', ['reset', '--hard', targetSha.trim()], { cwd: gitRoot })
           setJson(res, 200, { data: await readGitHeaderState(gitRoot) })
         } catch (error) {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -6090,13 +6090,26 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             ['log', '-n', '12', '--date=short', '--format=%H%x09%h%x09%cd%x09%s', branch, ...resetHistoryRefs],
             { cwd: gitRoot },
           )
-          const commits = output.split('\n').flatMap((line) => {
+          const commits = []
+          for (const line of output.split('\n')) {
             const [sha = '', shortSha = '', date = '', ...subjectParts] = line.split('\t')
             const subject = subjectParts.join('\t').trim()
-            return sha.trim() && shortSha.trim()
-              ? [{ sha: sha.trim(), shortSha: shortSha.trim(), date: date.trim(), subject: subject || shortSha.trim() }]
-              : []
-          })
+            const normalizedSha = sha.trim()
+            const normalizedShortSha = shortSha.trim()
+            if (!normalizedSha || !normalizedShortSha) continue
+            const isReachableFromBranch = await runCommandCapture(
+              'git',
+              ['merge-base', '--is-ancestor', normalizedSha, branch],
+              { cwd: gitRoot },
+            ).then(() => true).catch(() => false)
+            commits.push({
+              sha: normalizedSha,
+              shortSha: normalizedShortSha,
+              date: date.trim(),
+              subject: subject || normalizedShortSha,
+              isReachableFromBranch,
+            })
+          }
           setJson(res, 200, { data: commits })
         } catch (error) {
           setJson(res, 500, { error: getErrorMessage(error, 'Failed to load branch commits') })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -6090,26 +6090,13 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             ['log', '-n', '12', '--date=short', '--format=%H%x09%h%x09%cd%x09%s', branch, ...resetHistoryRefs],
             { cwd: gitRoot },
           )
-          const commits = []
-          for (const line of output.split('\n')) {
+          const commits = output.split('\n').flatMap((line) => {
             const [sha = '', shortSha = '', date = '', ...subjectParts] = line.split('\t')
             const subject = subjectParts.join('\t').trim()
-            const normalizedSha = sha.trim()
-            const normalizedShortSha = shortSha.trim()
-            if (!normalizedSha || !normalizedShortSha) continue
-            const isReachableFromBranch = await runCommandCapture(
-              'git',
-              ['merge-base', '--is-ancestor', normalizedSha, branch],
-              { cwd: gitRoot },
-            ).then(() => true).catch(() => false)
-            commits.push({
-              sha: normalizedSha,
-              shortSha: normalizedShortSha,
-              date: date.trim(),
-              subject: subject || normalizedShortSha,
-              isReachableFromBranch,
-            })
-          }
+            return sha.trim() && shortSha.trim()
+              ? [{ sha: sha.trim(), shortSha: shortSha.trim(), date: date.trim(), subject: subject || shortSha.trim() }]
+              : []
+          })
           setJson(res, 200, { data: commits })
         } catch (error) {
           setJson(res, 500, { error: getErrorMessage(error, 'Failed to load branch commits') })

--- a/tests.md
+++ b/tests.md
@@ -187,7 +187,7 @@ Thread header Git dropdown replaces the simple review action with branch search,
 1. Dev server running (`pnpm run dev`)
 2. Open a thread whose `cwd` is inside a Git repository with at least two branches and several commits
 3. Use a disposable local branch with at least two commits ahead of its reset target.
-4. Ensure the repository is clean for successful branch switch/reset paths: `git -C <thread-cwd> status --porcelain`
+4. Ensure the repository has no tracked uncommitted changes for successful branch switch/reset paths: `git -C <thread-cwd> status --porcelain`
 5. Light theme and dark theme are available from the appearance switcher
 
 #### Steps
@@ -200,12 +200,13 @@ Thread header Git dropdown replaces the simple review action with branch search,
 7. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
 8. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
 9. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
-10. Create an uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
-11. Switch to dark theme and repeat steps 1, 2, 4, 6, 9, and 10.
+10. Create a tracked uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
+11. Create only an untracked file, try to reset to a commit, and confirm the reset proceeds unless Git reports the untracked file would be overwritten.
+12. Switch to dark theme and repeat steps 1, 2, 4, 6, 9, 10, and 11.
 
 #### Expected Results
 - The header dropdown exposes Review, current checkout state, searchable branches, and inline commits.
-- Branch switching and branch reset-to-commit only proceed when the Git worktree is clean.
+- Branch switching and branch reset-to-commit are blocked by tracked uncommitted changes, but untracked-only changes are allowed unless Git would overwrite them.
 - Commit selection resets the local branch to that commit instead of detaching HEAD.
 - The branch commit list still shows commits that were ahead of the reset target by reading saved internal reset-history refs.
 - The selected branch HEAD commit is marked `current` in expanded commit lists.

--- a/tests.md
+++ b/tests.md
@@ -178,40 +178,43 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
-### Header Git branch dropdown with commit checkout
+### Header Git branch dropdown with commit reset
 
 #### Feature/Change Name
-Thread header Git dropdown replaces the simple review action with branch search, Review access, safe branch switching, detached HEAD recovery, and recent commit checkout.
+Thread header Git dropdown replaces the simple review action with branch search, Review access, safe branch switching, branch reset-to-commit, and reset-history commit preservation.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
 2. Open a thread whose `cwd` is inside a Git repository with at least two branches and several commits
-3. Ensure the repository is clean for successful checkout paths: `git -C <thread-cwd> status --porcelain`
-4. Light theme and dark theme are available from the appearance switcher
+3. Use a disposable local branch with at least two commits ahead of its reset target.
+4. Ensure the repository is clean for successful branch switch/reset paths: `git -C <thread-cwd> status --porcelain`
+5. Light theme and dark theme are available from the appearance switcher
 
 #### Steps
 1. In light theme, open the Git dropdown in the thread header.
-2. Confirm the trigger shows the current branch, or the detached commit subject when HEAD is detached.
+2. Confirm the trigger shows the current branch, or the detached commit subject if the repository is already detached.
 3. Click `Review` and confirm the review pane opens; click it again and confirm the pane toggles.
 4. Type part of a branch name in search and confirm the branch list filters.
 5. Select a different branch with a clean worktree and confirm the header updates to that branch.
 6. Expand a branch row and confirm recent commits load with short SHA, subject, and date.
-7. Select a commit and confirm the header changes to detached HEAD state with the commit subject as the main value and SHA/date metadata below it.
-8. Expand the branch containing the detached commit and confirm that commit row is marked `current`.
-9. From detached HEAD, select a branch and confirm the header recovers to normal branch state.
-10. Create an uncommitted change, try to switch branch or commit, and confirm the dropdown shows a dirty-worktree error instead of switching.
-11. Switch to dark theme and repeat steps 1, 2, 4, 6, 8, and 10.
+7. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
+8. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
+9. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
+10. Create an uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
+11. Switch to dark theme and repeat steps 1, 2, 4, 6, 9, and 10.
 
 #### Expected Results
 - The header dropdown exposes Review, current checkout state, searchable branches, and inline commits.
-- Branch switching and commit checkout only proceed when the Git worktree is clean.
-- Detached commit checkout is explicit in the header, shows the commit message, marks the active commit as current in expanded commit lists, and can recover by selecting any branch.
+- Branch switching and branch reset-to-commit only proceed when the Git worktree is clean.
+- Commit selection resets the local branch to that commit instead of detaching HEAD.
+- The branch commit list still shows commits that were ahead of the reset target by reading saved internal reset-history refs.
+- The selected branch HEAD commit is marked `current` in expanded commit lists.
 - Loading and error messages remain visible in the dropdown without using browser alerts.
 - Dropdown surfaces, text, badges, and errors are readable in both light theme and dark theme.
 
 #### Rollback/Cleanup
 - Restore any dirty-worktree file changed for validation.
-- If left detached, run `git -C <thread-cwd> checkout <expected-branch>`.
+- Restore or delete the disposable branch used for reset validation.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -200,7 +200,7 @@ Thread header Git dropdown replaces the simple review action with branch search,
 7. Expand a remote branch row and confirm its commit rows are disabled with a tooltip explaining remote branches cannot be reset.
 8. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
 9. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
-10. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current` and commits no longer reachable from the branch marked `saved`.
+10. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
 11. Repeat reset on the same branch several times and confirm the dropdown still opens quickly and shows recent reset-history commits.
 12. Create a tracked uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
 13. Create only an untracked file, try to reset to a commit, and confirm the reset proceeds unless Git reports the untracked file would be overwritten.
@@ -212,7 +212,6 @@ Thread header Git dropdown replaces the simple review action with branch search,
 - Commit selection resets the local branch to that commit instead of detaching HEAD.
 - Remote branch commit rows are inspectable but cannot trigger local branch reset.
 - The branch commit list still shows commits that were ahead of the reset target by reading saved internal reset-history refs.
-- Commits visible only through reset-history refs are labeled `saved`.
 - Reset-history refs are bounded so repeated resets do not grow commit-list inputs without limit.
 - The selected branch HEAD commit is marked `current` in expanded commit lists.
 - Loading and error messages remain visible in the dropdown without using browser alerts.

--- a/tests.md
+++ b/tests.md
@@ -200,7 +200,7 @@ Thread header Git dropdown replaces the simple review action with branch search,
 7. Expand a remote branch row and confirm its commit rows are disabled with a tooltip explaining remote branches cannot be reset.
 8. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
 9. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
-10. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
+10. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current` and commits no longer reachable from the branch marked `saved`.
 11. Repeat reset on the same branch several times and confirm the dropdown still opens quickly and shows recent reset-history commits.
 12. Create a tracked uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
 13. Create only an untracked file, try to reset to a commit, and confirm the reset proceeds unless Git reports the untracked file would be overwritten.
@@ -212,6 +212,7 @@ Thread header Git dropdown replaces the simple review action with branch search,
 - Commit selection resets the local branch to that commit instead of detaching HEAD.
 - Remote branch commit rows are inspectable but cannot trigger local branch reset.
 - The branch commit list still shows commits that were ahead of the reset target by reading saved internal reset-history refs.
+- Commits visible only through reset-history refs are labeled `saved`.
 - Reset-history refs are bounded so repeated resets do not grow commit-list inputs without limit.
 - The selected branch HEAD commit is marked `current` in expanded commit lists.
 - Loading and error messages remain visible in the dropdown without using browser alerts.

--- a/tests.md
+++ b/tests.md
@@ -197,18 +197,22 @@ Thread header Git dropdown replaces the simple review action with branch search,
 4. Type part of a branch name in search and confirm the branch list filters.
 5. Select a different branch with a clean worktree and confirm the header updates to that branch.
 6. Expand a branch row and confirm recent commits load with short SHA, subject, and date.
-7. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
-8. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
-9. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
-10. Create a tracked uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
-11. Create only an untracked file, try to reset to a commit, and confirm the reset proceeds unless Git reports the untracked file would be overwritten.
-12. Switch to dark theme and repeat steps 1, 2, 4, 6, 9, 10, and 11.
+7. Expand a remote branch row and confirm its commit rows are disabled with a tooltip explaining remote branches cannot be reset.
+8. Select an older commit on the disposable local branch and confirm the header stays on that branch instead of entering detached HEAD.
+9. Confirm `git -C <thread-cwd> rev-parse --abbrev-ref HEAD` still prints the branch name and `git -C <thread-cwd> rev-parse --short HEAD` matches the selected commit.
+10. Reopen/expand the same branch and confirm commits that were ahead of the reset target still appear, with the selected branch HEAD marked `current`.
+11. Repeat reset on the same branch several times and confirm the dropdown still opens quickly and shows recent reset-history commits.
+12. Create a tracked uncommitted change, try to switch branch or reset to a commit, and confirm the dropdown shows a dirty-worktree error instead of switching or resetting.
+13. Create only an untracked file, try to reset to a commit, and confirm the reset proceeds unless Git reports the untracked file would be overwritten.
+14. Switch to dark theme and repeat steps 1, 2, 4, 6, 7, 10, 12, and 13.
 
 #### Expected Results
 - The header dropdown exposes Review, current checkout state, searchable branches, and inline commits.
 - Branch switching and branch reset-to-commit are blocked by tracked uncommitted changes, but untracked-only changes are allowed unless Git would overwrite them.
 - Commit selection resets the local branch to that commit instead of detaching HEAD.
+- Remote branch commit rows are inspectable but cannot trigger local branch reset.
 - The branch commit list still shows commits that were ahead of the reset target by reading saved internal reset-history refs.
+- Reset-history refs are bounded so repeated resets do not grow commit-list inputs without limit.
 - The selected branch HEAD commit is marked `current` in expanded commit lists.
 - Loading and error messages remain visible in the dropdown without using browser alerts.
 - Dropdown surfaces, text, badges, and errors are readable in both light theme and dark theme.


### PR DESCRIPTION
## Summary
- change header commit selection from detached checkout to guarded branch reset
- save pre-reset branch tips under internal reset-history refs
- include reset-history refs when loading branch commits so previous commits remain visible after one or more resets
- allow reset/switch when the only dirty worktree entries are untracked files, while still blocking tracked/staged changes
- disable reset actions for remote branch commit rows
- reuse worktree-lock checkout recovery before reset and cap reset-history refs per branch
- update manual test docs for reset, untracked-file, remote-row, and repeated-reset behavior

## Tests
- pnpm run build:frontend
- pnpm run build:cli
- git diff --check
- temp repo smoke: reset branch to older commit and confirmed old tip still appears via saved ref
- temp repo smoke: reset succeeds with an untracked file present and tracked modifications are still detected
- temp repo smoke: reset-history ref pruning keeps 25 refs