### PR TITLE
Fix skills sync no-op commits

### DIFF
--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -833,9 +833,10 @@ async function readRemoteSkillsManifest(token: string, repoOwner: string, repoNa
   return skills
 }
 
-async function writeRemoteSkillsManifest(token: string, repoOwner: string, repoName: string, skills: SyncedSkill[]): Promise<void> {
+async function writeRemoteSkillsManifest(token: string, repoOwner: string, repoName: string, skills: SyncedSkill[]): Promise<boolean> {
   const url = `https://api.github.com/repos/${repoOwner}/${repoName}/contents/${SKILLS_SYNC_MANIFEST_PATH}`
   let sha = ''
+  const nextContent = JSON.stringify(skills, null, 2)
   const existing = await fetch(url, {
     headers: {
       Accept: 'application/vnd.github+json',
@@ -845,15 +846,18 @@ async function writeRemoteSkillsManifest(token: string, repoOwner: string, repoN
     },
   })
   if (existing.ok) {
-    const payload = await existing.json() as { sha?: string }
+    const payload = await existing.json() as { sha?: string; content?: string }
     sha = payload.sha ?? ''
+    const currentContent = payload.content ? Buffer.from(payload.content.replace(/\n/g, ''), 'base64').toString('utf8') : ''
+    if (currentContent === nextContent) return false
   }
-  const content = Buffer.from(JSON.stringify(skills, null, 2), 'utf8').toString('base64')
+  const content = Buffer.from(nextContent, 'utf8').toString('base64')
   await getGithubJson(url, token, 'PUT', {
     message: 'Update synced skills manifest',
     content,
     ...(sha ? { sha } : {}),
   })
+  return true
 }
 
 function toGitHubTokenRemote(repoOwner: string, repoName: string, token: string): string {
@@ -1163,8 +1167,10 @@ async function syncInstalledSkillsFolderToRepo(
   await runCommand('git', ['config', 'user.name', 'Skills Sync'], { cwd: repoDir })
   await restoreProtectedFilesFromOrigin(repoDir, branch)
   await runCommand('git', ['add', '.'], { cwd: repoDir })
-  const status = (await runCommandWithOutput('git', ['status', '--porcelain'], { cwd: repoDir })).trim()
-  if (!status) return
+  try {
+    await runCommand('git', ['diff', '--cached', '--quiet', '--exit-code'], { cwd: repoDir })
+    return
+  } catch {}
   await runCommand('git', ['commit', '-m', 'Sync installed skills folder and manifest'], { cwd: repoDir })
   await pushWithNonFastForwardRetry(repoDir, branch)
 }

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -1050,6 +1050,17 @@ async function hasLocalUncommittedChanges(repoDir: string): Promise<boolean> {
   return status.length > 0
 }
 
+async function hasCommittableWorkingTreeChanges(repoDir: string): Promise<boolean> {
+  try {
+    await runCommand('git', ['diff', '--quiet', '--exit-code', '--ignore-submodules=dirty'], { cwd: repoDir })
+    await runCommand('git', ['diff', '--cached', '--quiet', '--exit-code', '--ignore-submodules=dirty'], { cwd: repoDir })
+  } catch {
+    return true
+  }
+  const untracked = (await runCommandWithOutput('git', ['ls-files', '--others', '--exclude-standard'], { cwd: repoDir })).trim()
+  return untracked.length > 0
+}
+
 async function walkFileMtimes(rootDir: string, currentDir: string, out: Map<string, number>): Promise<void> {
   let entries: Array<{ name: string | Buffer; isDirectory: () => boolean; isFile: () => boolean }>
   try {
@@ -1222,10 +1233,10 @@ async function autoPushSyncedSkills(appServer: AppServerLike): Promise<void> {
   await runCommand('git', ['fetch', 'origin', PRIVATE_SYNC_BRANCH], { cwd: repoDir })
   const head = (await runCommandWithOutput('git', ['rev-parse', 'HEAD'], { cwd: repoDir })).trim()
   const originHead = (await runCommandWithOutput('git', ['rev-parse', `origin/${PRIVATE_SYNC_BRANCH}`], { cwd: repoDir })).trim()
-  const status = (await runCommandWithOutput('git', ['status', '--porcelain'], { cwd: repoDir })).trim()
+  const hasCommittableChanges = await hasCommittableWorkingTreeChanges(repoDir)
   // After a successful pull, if local tree is already clean and equal to remote,
   // skip push entirely to avoid rewriting/deleting remote-only updates.
-  if (!status && head === originHead) return
+  if (!hasCommittableChanges && head === originHead) return
   const local = await collectLocalSyncedSkills(appServer)
   const installedMap = await scanInstalledSkillsFromDisk()
   await writeRemoteSkillsManifest(state.githubToken, state.repoOwner, state.repoName, local)

--- a/tests.md
+++ b/tests.md
@@ -224,6 +224,38 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Skills sync idempotent commits and nested shared skills handling
+
+#### Feature/Change Name
+Skills Sync skips unchanged manifest writes and does not fail parent commits when only nested `shared_skills` content is dirty.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 5173`)
+2. GitHub Skills Sync is connected to a private skills sync repo
+3. `/Users/igor/.codex/skills/shared_skills` exists as a nested Git repository
+4. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, open `#/skills`.
+2. Click `Startup Sync` when no installed skills manifest content has changed.
+3. Confirm the sync completes without adding a new `Update synced skills manifest` commit to the GitHub repo.
+4. Modify a file inside `/Users/igor/.codex/skills/shared_skills` without committing it inside that nested repository.
+5. Click `Push` or `Startup Sync` again.
+6. Confirm the sync does not show `Command failed (git commit -m Sync installed skills folder and manifest)` for the parent `/Users/igor/.codex/skills` repository.
+7. Confirm the startup auto-push path skips when the only local status is dirty nested `shared_skills` content and local `HEAD` equals `origin/main`.
+8. Switch to dark theme and repeat steps 1, 2, and 5.
+
+#### Expected Results
+- Unchanged `installed-skills.json` content is not written back to GitHub, so repeated empty-looking manifest commits are not created.
+- A dirty nested `shared_skills` repository does not make the parent skills sync fail with `no changes added to commit`.
+- Dirty nested `shared_skills` content alone does not keep triggering no-op startup push work.
+- Skills Sync status, errors, and action buttons remain readable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Revert or commit the intentional test edit inside `/Users/igor/.codex/skills/shared_skills`.
+
+---
+
 ### Header Git branch dropdown with commit reset
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- skip unchanged installed-skills manifest writes
- commit skills repo only when parent index has staged changes
- ignore dirty nested shared_skills for startup no-op push checks

## Tests
- pnpm run build:frontend
- git diff --check
- real codexskills create/delete smoke test with codex-sync-smoke-test