### PR TITLE
Fix thread archive deletion recovery

### DIFF
--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -4,6 +4,7 @@ import {
   collectWorkspaceRootPathsForProjectRemoval,
   filterGroupsByWorkspaceRoots,
   findAdjacentThreadId,
+  removeThreadFromGroups,
 } from './useDesktopState'
 import type { UiProjectGroup } from '../types/codex'
 import type { WorkspaceRootsState } from '../api/codexGateway'
@@ -211,6 +212,49 @@ describe('filterGroupsByWorkspaceRoots', () => {
     expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => [group.projectName, group.threads.map((row) => row.id)])).toEqual([
       ['/Users/igor/Git-projects/codex-web-local', ['main-chat']],
     ])
+  })
+})
+
+describe('removeThreadFromGroups', () => {
+  it('removes an archived thread and drops the now-empty project group', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'alpha',
+        threads: [thread('keep-alpha', '/tmp/alpha')],
+      },
+      {
+        projectName: 'archived-project',
+        threads: [thread('archive-me', '/tmp/archived-project')],
+      },
+      {
+        projectName: 'beta',
+        threads: [thread('keep-beta', '/tmp/beta')],
+      },
+      {
+        projectName: 'empty-workspace-root',
+        threads: [],
+      },
+    ]
+
+    expect(removeThreadFromGroups(groups, 'archive-me').map((group) => [
+      group.projectName,
+      group.threads.map((row) => row.id),
+    ])).toEqual([
+      ['alpha', ['keep-alpha']],
+      ['beta', ['keep-beta']],
+      ['empty-workspace-root', []],
+    ])
+  })
+
+  it('preserves referential identity when the thread is absent', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'alpha',
+        threads: [thread('keep-alpha', '/tmp/alpha')],
+      },
+    ]
+
+    expect(removeThreadFromGroups(groups, 'missing-thread')).toBe(groups)
   })
 })
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -886,6 +886,29 @@ function pruneThreadStateMap<T>(stateMap: Record<string, T>, threadIds: Set<stri
   return Object.fromEntries(nextEntries) as Record<string, T>
 }
 
+export function removeThreadFromGroups(groups: UiProjectGroup[], threadId: string): UiProjectGroup[] {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) return groups
+
+  let changed = false
+  const nextGroups: UiProjectGroup[] = []
+
+  for (const group of groups) {
+    const nextThreads = group.threads.filter((thread) => thread.id !== normalizedThreadId)
+    const removedFromGroup = nextThreads.length !== group.threads.length
+    if (removedFromGroup) {
+      changed = true
+    }
+    if (nextThreads.length > 0) {
+      nextGroups.push(removedFromGroup ? { ...group, threads: nextThreads } : group)
+    } else if (group.threads.length === 0) {
+      nextGroups.push(group)
+    }
+  }
+
+  return changed ? nextGroups : groups
+}
+
 function mergeThreadGroups(
   previous: UiProjectGroup[],
   incoming: UiProjectGroup[],
@@ -3948,6 +3971,13 @@ export function useDesktopState() {
     }
   }
 
+  function removeArchivedThreadFromLoadedLists(threadId: string): void {
+    loadedThreadListGroups = removeThreadFromGroups(loadedThreadListGroups, threadId)
+    sourceGroups.value = removeThreadFromGroups(sourceGroups.value, threadId)
+    inProgressById.value = omitKey(inProgressById.value, threadId)
+    applyThreadFlags()
+  }
+
   function mergeThreadGroupPages(previous: UiProjectGroup[], incoming: UiProjectGroup[]): UiProjectGroup[] {
     if (previous.length === 0) return incoming
     if (incoming.length === 0) return previous
@@ -4295,6 +4325,7 @@ export function useDesktopState() {
 
     try {
       await archiveThread(threadId)
+      removeArchivedThreadFromLoadedLists(threadId)
       await loadThreads()
 
       if (wasSelectedThread && nextSelectedThreadId && selectedThreadId.value === nextSelectedThreadId) {

--- a/src/server/codexAppServerBridge.archive.test.ts
+++ b/src/server/codexAppServerBridge.archive.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { callRpcWithArchiveRecovery } from './codexAppServerBridge'
+
+describe('callRpcWithArchiveRecovery', () => {
+  it('sets a fallback name and retries archive when Codex has not materialized a rollout', async () => {
+    const calls: Array<{ method: string; params: unknown }> = []
+    let archiveCalls = 0
+    const appServer = {
+      async rpc(method: string, params: unknown): Promise<unknown> {
+        calls.push({ method, params })
+        if (method === 'thread/archive') {
+          archiveCalls += 1
+          if (archiveCalls === 1) {
+            throw new Error('no rollout found for thread test-thread')
+          }
+          return { ok: true }
+        }
+        if (method === 'thread/read') {
+          return {
+            thread: {
+              id: 'test-thread',
+              preview: 'Preview title',
+              path: '/home/user/.codex/sessions/rollout-test-thread.jsonl',
+            },
+          }
+        }
+        return { ok: true }
+      },
+    }
+
+    await expect(callRpcWithArchiveRecovery(appServer, 'thread/archive', { threadId: 'test-thread' })).resolves.toEqual({ ok: true })
+    expect(calls).toEqual([
+      { method: 'thread/archive', params: { threadId: 'test-thread' } },
+      { method: 'thread/read', params: { threadId: 'test-thread', includeTurns: false } },
+      { method: 'thread/name/set', params: { threadId: 'test-thread', name: 'Preview title' } },
+      { method: 'thread/archive', params: { threadId: 'test-thread' } },
+    ])
+  })
+
+  it('treats no-rollout archive of an already archived thread as successful', async () => {
+    const calls: Array<{ method: string; params: unknown }> = []
+    const appServer = {
+      async rpc(method: string, params: unknown): Promise<unknown> {
+        calls.push({ method, params })
+        if (method === 'thread/archive') {
+          throw new Error('no rollout found for thread archived-thread')
+        }
+        if (method === 'thread/read') {
+          return {
+            thread: {
+              id: 'archived-thread',
+              path: '/home/user/.codex/archived_sessions/rollout-archived-thread.jsonl',
+            },
+          }
+        }
+        throw new Error(`unexpected method ${method}`)
+      },
+    }
+
+    await expect(callRpcWithArchiveRecovery(appServer, 'thread/archive', { threadId: 'archived-thread' })).resolves.toBeNull()
+    expect(calls).toEqual([
+      { method: 'thread/archive', params: { threadId: 'archived-thread' } },
+      { method: 'thread/read', params: { threadId: 'archived-thread', includeTurns: false } },
+    ])
+  })
+
+  it('does not recover unrelated RPC failures', async () => {
+    const appServer = {
+      async rpc(): Promise<unknown> {
+        throw new Error('network failed')
+      },
+    }
+
+    await expect(callRpcWithArchiveRecovery(appServer, 'thread/archive', { threadId: 'test-thread' })).rejects.toThrow('network failed')
+    await expect(callRpcWithArchiveRecovery(appServer, 'thread/read', { threadId: 'test-thread' })).rejects.toThrow('network failed')
+  })
+})

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -60,6 +60,10 @@ type RpcProxyRequest = {
   params?: unknown
 }
 
+type RpcExecutor = {
+  rpc: (method: string, params: unknown) => Promise<unknown>
+}
+
 type ServerRequestReply = {
   result?: unknown
   error?: {
@@ -1009,6 +1013,64 @@ function extractThreadMessageText(threadReadPayload: unknown): string {
 
 function readNonEmptyString(value: unknown): string {
   return typeof value === 'string' && value.trim().length > 0 ? value : ''
+}
+
+function readThreadArchiveFallbackName(threadReadResult: unknown): string {
+  const record = asRecord(threadReadResult)
+  const thread = asRecord(record?.thread)
+  return (
+    readNonEmptyString(thread?.name)
+    || readNonEmptyString(thread?.title)
+    || readNonEmptyString(thread?.preview)
+    || 'Untitled thread'
+  )
+}
+
+function isArchivedThreadReadResult(threadReadResult: unknown): boolean {
+  const record = asRecord(threadReadResult)
+  const thread = asRecord(record?.thread)
+  const sessionPath = readNonEmptyString(thread?.path)
+  return sessionPath.split(/[\\/]+/u).includes('archived_sessions')
+}
+
+export async function callRpcWithArchiveRecovery(
+  appServer: RpcExecutor,
+  method: string,
+  params: unknown,
+): Promise<unknown> {
+  try {
+    return await appServer.rpc(method, params ?? null)
+  } catch (error) {
+    if (method !== 'thread/archive') {
+      throw error
+    }
+
+    const paramsRecord = asRecord(params)
+    const threadId = readNonEmptyString(paramsRecord?.threadId)
+    const errorMessage = getErrorMessage(error, '')
+    if (!threadId || !errorMessage.includes('no rollout found')) {
+      throw error
+    }
+
+    let threadReadResult: unknown = null
+    try {
+      threadReadResult = await appServer.rpc('thread/read', {
+        threadId,
+        includeTurns: false,
+      })
+      if (isArchivedThreadReadResult(threadReadResult)) {
+        return null
+      }
+    } catch {
+      // If metadata cannot be read, still try materializing a title before retrying archive.
+    }
+
+    await appServer.rpc('thread/name/set', {
+      threadId,
+      name: readThreadArchiveFallbackName(threadReadResult),
+    })
+    return appServer.rpc(method, params ?? null)
+  }
 }
 
 type TerminalQuickCommand = {
@@ -5276,7 +5338,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
 
-        const rpcResult = await appServer.rpc(body.method, body.params ?? null)
+        const rpcResult = await callRpcWithArchiveRecovery(appServer, body.method, body.params ?? null)
         const trimmedResult = trimThreadTurnsInRpcResult(body.method, rpcResult)
         const result = await sanitizeThreadTurnsInlinePayloads(body.method, trimmedResult)
 

--- a/tests.md
+++ b/tests.md
@@ -224,6 +224,39 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Thread archive recovery and sidebar pruning
+
+#### Feature/Change Name
+Deleting a thread recovers from Codex `no rollout found` archive failures and removes successfully archived threads from the sidebar immediately.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Codex CLI available on `PATH`
+3. At least one normal thread and one newly-created thread that has not yet produced a rollout
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, create a new empty thread from the sidebar.
+2. Open that thread's menu and choose `Delete thread`.
+3. Confirm the thread disappears from the sidebar without a `no rollout found` error.
+4. Rename another visible thread, then delete it.
+5. Confirm the renamed thread disappears immediately and does not reappear after sidebar refresh/background pagination.
+6. Call `thread/list` with `archived:false` through `/codex-api/rpc` and confirm the deleted thread ids are absent.
+7. Call `thread/list` with `archived:true` and confirm the deleted thread ids are present.
+8. Switch to dark theme and repeat steps 1-5.
+
+#### Expected Results
+- Empty or not-yet-materialized threads are archived after CodexUI sets a fallback name and retries.
+- Already archived threads are treated as archived instead of surfacing a stale `no rollout found` error.
+- The sidebar prunes archived ids from its accumulated paginated list before refreshing.
+- Older unarchived threads may appear as the list refills, but archived threads do not remain visible.
+- Behavior is consistent in light and dark themes.
+
+#### Rollback/Cleanup
+- None.
+
+---
+
 ### Skills sync idempotent commits and nested shared skills handling
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- recover `thread/archive` when Codex returns `no rollout found` by setting a fallback thread name and retrying
- treat already-archived `no rollout found` responses as successful archive operations
- prune archived thread ids from the sidebar's accumulated paginated thread list before refreshing

## Tests
- `pnpm exec vitest run src/server/codexAppServerBridge.archive.test.ts src/composables/useDesktopState.test.ts`
- `pnpm run test:unit`
- `pnpm run build`
