### PR TITLE
Support remote-device media uploads

### DIFF
--- a/src/server/codexAppServerBridge.inlinePayload.test.ts
+++ b/src/server/codexAppServerBridge.inlinePayload.test.ts
@@ -1,5 +1,9 @@
 import { existsSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
 
 const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
@@ -7,6 +11,22 @@ const pngDataUrl = `data:image/png;base64,${pngBase64}`
 const gifBase64 = 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
 const jpegBase64 = '/9j/4AAQSkZJRgABAQAAAQABAAD/2w=='
 const webpBase64 = 'UklGRiIAAABXRUJQVlA4IC4AAAAwAQCdASoBAAEAAQAcJaQAA3AA/vuUAAA='
+const originalCodexHome = process.env.CODEX_HOME
+
+let tempCodexHome: string | null = null
+
+beforeEach(async () => {
+  tempCodexHome = await mkdtemp(join(tmpdir(), 'codexui-inline-media-'))
+  process.env.CODEX_HOME = tempCodexHome
+})
+
+afterEach(async () => {
+  process.env.CODEX_HOME = originalCodexHome
+  if (tempCodexHome) {
+    await rm(tempCodexHome, { recursive: true, force: true })
+    tempCodexHome = null
+  }
+})
 
 function localImagePathFromProxyUrl(value: string): string {
   const parsed = new URL(value, 'http://localhost')

--- a/src/server/codexAppServerBridge.inlinePayload.test.ts
+++ b/src/server/codexAppServerBridge.inlinePayload.test.ts
@@ -21,7 +21,11 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  process.env.CODEX_HOME = originalCodexHome
+  if (typeof originalCodexHome === 'string') {
+    process.env.CODEX_HOME = originalCodexHome
+  } else {
+    delete process.env.CODEX_HOME
+  }
   if (tempCodexHome) {
     await rm(tempCodexHome, { recursive: true, force: true })
     tempCodexHome = null

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -29,6 +29,11 @@ import {
 import { handleOpenRouterProxyRequest } from './openRouterProxy.js'
 import { handleZenProxyRequest } from './zenProxy.js'
 import { handleCustomEndpointProxyRequest } from './customEndpointProxy.js'
+import {
+  pruneManagedTempMedia,
+  storeManagedTempMediaDataUrl,
+  storeManagedTempMediaFile,
+} from './tempMediaStore.js'
 import { ThreadTerminalManager } from './terminalManager.js'
 import { getSpawnInvocation } from '../utils/commandInvocation.js'
 import {
@@ -398,17 +403,6 @@ function normalizeBase64ImageDataUrl(value: string, mimeType: string): string | 
   return `data:${finalMimeType};base64,${compact}`
 }
 
-function extensionFromMimeType(mimeType: string): string {
-  const normalized = mimeType.trim().toLowerCase()
-  if (normalized === 'image/png') return '.png'
-  if (normalized === 'image/jpeg') return '.jpg'
-  if (normalized === 'image/webp') return '.webp'
-  if (normalized === 'image/gif') return '.gif'
-  if (normalized === 'image/svg+xml') return '.svg'
-  if (normalized === 'application/pdf') return '.pdf'
-  return ''
-}
-
 function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
@@ -427,33 +421,7 @@ function toAttachmentLinkTarget(block: Record<string, unknown>, fallback: string
 }
 
 async function persistInlineDataUrlToLocalFile(dataUrl: string, baseName: string): Promise<string | null> {
-  const trimmed = dataUrl.trim()
-  const match = /^data:([^;,]*)(;base64)?,(.*)$/isu.exec(trimmed)
-  if (!match) return null
-  const mimeType = (match[1] ?? '').trim().toLowerCase()
-  const encodedPayload = match[3] ?? ''
-  let bytes: Buffer
-  try {
-    bytes = match[2]
-      ? Buffer.from(encodedPayload, 'base64')
-      : Buffer.from(decodeURIComponent(encodedPayload), 'utf8')
-  } catch {
-    return null
-  }
-  if (bytes.length === 0) return null
-
-  const hash = createHash('sha1').update(bytes).digest('hex')
-  const ext = extensionFromMimeType(mimeType)
-  const mediaDir = join(tmpdir(), 'codex-web-inline-media')
-  await mkdir(mediaDir, { recursive: true })
-  const fileName = `${baseName}-${hash}${ext}`
-  const filePath = join(mediaDir, fileName)
-  try {
-    await stat(filePath)
-  } catch {
-    await writeFile(filePath, bytes)
-  }
-  return filePath
+  return await storeManagedTempMediaDataUrl(dataUrl, baseName)
 }
 
 function toLocalImageProxyUrl(path: string): string {
@@ -3648,11 +3616,7 @@ function handleFileUpload(req: IncomingMessage, res: ServerResponse): void {
         break
       }
       if (!fileData) { setJson(res, 400, { error: 'No file in request' }); return }
-      const uploadDir = join(tmpdir(), 'codex-web-uploads')
-      await mkdir(uploadDir, { recursive: true })
-      const destDir = await mkdtemp(join(uploadDir, 'f-'))
-      const destPath = join(destDir, fileName)
-      await writeFile(destPath, fileData)
+      const destPath = await storeManagedTempMediaFile(fileName, fileData)
       setJson(res, 200, { path: destPath })
     } catch (err) {
       setJson(res, 500, { error: getErrorMessage(err, 'Upload failed') })

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -7,6 +7,7 @@ import express, { type Express } from 'express'
 import { createCodexBridgeMiddleware } from './codexAppServerBridge.js'
 import { createAuthSession } from './authMiddleware.js'
 import { createDirectoryListingHtml, createTextEditorHtml, decodeBrowsePath, getLocalDirectoryListing, isTextEditableFile, normalizeLocalPath } from './localBrowseUi.js'
+import { pruneManagedTempMedia } from './tempMediaStore.js'
 import { WebSocketServer, type WebSocket } from 'ws'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -75,6 +76,7 @@ function readWildcardPathParam(value: unknown): string {
 export function createServer(options: ServerOptions = {}): ServerInstance {
   const app = express()
   const bridge = createCodexBridgeMiddleware()
+  void pruneManagedTempMedia().catch(() => {})
   const authSession = options.password ? createAuthSession(options.password) : null
 
   // 1. Auth middleware (if password is set)

--- a/src/server/tempMediaStore.test.ts
+++ b/src/server/tempMediaStore.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, stat, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { mkdtemp } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -19,6 +19,20 @@ describe('managed temp media store', () => {
       const path = await storeManagedTempMediaFile('screenshot.png', Buffer.from('hello'), { root })
       expect(path.startsWith(root)).toBe(true)
       await expect(stat(path)).resolves.toMatchObject({ size: 5 })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps uploaded file writes isolated per upload', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
+    try {
+      const firstPath = await storeManagedTempMediaFile('screenshot.png', Buffer.from('hello'), { root })
+      const secondPath = await storeManagedTempMediaFile('screenshot.png', Buffer.from('hello'), { root })
+
+      expect(firstPath).not.toBe(secondPath)
+      expect(firstPath.startsWith(join(root, 'asset-'))).toBe(true)
+      expect(secondPath.startsWith(join(root, 'asset-'))).toBe(true)
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -49,11 +63,25 @@ describe('managed temp media store', () => {
     }
   })
 
-  it('stores inline image data under the managed root', async () => {
+  it('stores inline image data under a deterministic managed path', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
     try {
       const path = await storeManagedTempMediaDataUrl(pngDataUrl, 'inline-image', { root })
-      expect(path).toMatch(new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+      expect(path).toMatch(new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/inline/[0-9a-f]{2}/inline-image-[0-9a-f]{40}\\.png$`))
+      await expect(stat(path ?? '')).resolves.toBeTruthy()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reuses deterministic inline image paths for repeated content', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
+    try {
+      const firstPath = await storeManagedTempMediaDataUrl(pngDataUrl, 'inline-image', { root })
+      const secondPath = await storeManagedTempMediaDataUrl(pngDataUrl, 'inline-image', { root })
+
+      expect(firstPath).toBe(secondPath)
+      await expect(readdir(root)).resolves.toEqual(['inline'])
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/server/tempMediaStore.test.ts
+++ b/src/server/tempMediaStore.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, rm, stat, utimes, writeFile } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  pruneManagedTempMedia,
+  storeManagedTempMediaDataUrl,
+  storeManagedTempMediaFile,
+} from './tempMediaStore'
+
+const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+const pngDataUrl = `data:image/png;base64,${pngBase64}`
+
+describe('managed temp media store', () => {
+  it('stores uploaded files under the managed root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
+    try {
+      const path = await storeManagedTempMediaFile('screenshot.png', Buffer.from('hello'), { root })
+      expect(path.startsWith(root)).toBe(true)
+      await expect(stat(path)).resolves.toMatchObject({ size: 5 })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('prunes managed media older than 30 days', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
+    try {
+      const now = Date.now()
+      const staleDir = join(root, 'stale-entry')
+      const freshDir = join(root, 'fresh-entry')
+      await mkdir(staleDir, { recursive: true })
+      await mkdir(freshDir, { recursive: true })
+      await writeFile(join(staleDir, 'stale.txt'), 'old')
+      await writeFile(join(freshDir, 'fresh.txt'), 'new')
+
+      const staleTime = new Date(now - (31 * 24 * 60 * 60 * 1000))
+      const freshTime = new Date(now - (24 * 60 * 60 * 1000))
+      await utimes(staleDir, staleTime, staleTime)
+      await utimes(freshDir, freshTime, freshTime)
+
+      await pruneManagedTempMedia(root, now)
+
+      await expect(stat(staleDir)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(stat(freshDir)).resolves.toBeTruthy()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('stores inline image data under the managed root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codexui-temp-media-'))
+    try {
+      const path = await storeManagedTempMediaDataUrl(pngDataUrl, 'inline-image', { root })
+      expect(path).toMatch(new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/tempMediaStore.ts
+++ b/src/server/tempMediaStore.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 const TEMP_MEDIA_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
 const TEMP_MEDIA_ROOT_SEGMENT = join('tmp', 'codex-web-media')
@@ -17,6 +17,10 @@ export function getManagedTempMediaRoot(codexHome = getCodexHomeDir()): string {
 
 function isMissingFileSystemEntryError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+function isExistingFileSystemEntryError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'EEXIST'
 }
 
 function sanitizeTempMediaFileName(fileName: string): string {
@@ -102,6 +106,22 @@ export async function storeManagedTempMediaDataUrl(
   const hash = createHash('sha1').update(bytes).digest('hex')
   const extension = extensionFromMimeType(mimeType)
   const safeBaseName = sanitizeTempMediaFileName(baseName)
-  const fileName = `${safeBaseName}-${hash}${extension}`
-  return await storeManagedTempMediaFile(fileName, bytes, options)
+  const root = options.root ?? getManagedTempMediaRoot()
+  const filePath = join(root, 'inline', hash.slice(0, 2), `${safeBaseName}-${hash}${extension}`)
+
+  try {
+    await stat(filePath)
+    return filePath
+  } catch (error) {
+    if (!isMissingFileSystemEntryError(error)) throw error
+  }
+
+  await pruneManagedTempMedia(root)
+  await mkdir(dirname(filePath), { recursive: true })
+  try {
+    await writeFile(filePath, bytes, { flag: 'wx' })
+  } catch (error) {
+    if (!isExistingFileSystemEntryError(error)) throw error
+  }
+  return filePath
 }

--- a/src/server/tempMediaStore.ts
+++ b/src/server/tempMediaStore.ts
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const TEMP_MEDIA_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
+const TEMP_MEDIA_ROOT_SEGMENT = join('tmp', 'codex-web-media')
+
+function getCodexHomeDir(): string {
+  const codexHome = process.env.CODEX_HOME?.trim()
+  return codexHome && codexHome.length > 0 ? codexHome : join(homedir(), '.codex')
+}
+
+export function getManagedTempMediaRoot(codexHome = getCodexHomeDir()): string {
+  return join(codexHome, TEMP_MEDIA_ROOT_SEGMENT)
+}
+
+function isMissingFileSystemEntryError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+}
+
+function sanitizeTempMediaFileName(fileName: string): string {
+  const normalized = fileName.trim().replace(/[\\/]+/g, '_')
+  return normalized.length > 0 ? normalized : 'uploaded-file'
+}
+
+function extensionFromMimeType(mimeType: string): string {
+  const normalized = mimeType.trim().toLowerCase()
+  if (normalized === 'image/png') return '.png'
+  if (normalized === 'image/jpeg') return '.jpg'
+  if (normalized === 'image/webp') return '.webp'
+  if (normalized === 'image/gif') return '.gif'
+  if (normalized === 'image/svg+xml') return '.svg'
+  if (normalized === 'application/pdf') return '.pdf'
+  return ''
+}
+
+async function ensureTempMediaRoot(root: string): Promise<void> {
+  await mkdir(root, { recursive: true })
+}
+
+export async function pruneManagedTempMedia(
+  root = getManagedTempMediaRoot(),
+  nowMs = Date.now(),
+): Promise<void> {
+  const cutoffMs = nowMs - TEMP_MEDIA_RETENTION_MS
+  await ensureTempMediaRoot(root)
+
+  try {
+    const entries = await readdir(root, { withFileTypes: true })
+    for (const entry of entries) {
+      const entryPath = join(root, entry.name)
+      try {
+        const info = await stat(entryPath)
+        if (info.mtimeMs >= cutoffMs) continue
+        await rm(entryPath, { recursive: true, force: true })
+      } catch (error) {
+        if (isMissingFileSystemEntryError(error)) continue
+        throw error
+      }
+    }
+  } catch (error) {
+    if (isMissingFileSystemEntryError(error)) return
+    throw error
+  }
+}
+
+export async function storeManagedTempMediaFile(
+  fileName: string,
+  bytes: Buffer,
+  options: { root?: string } = {},
+): Promise<string> {
+  const root = options.root ?? getManagedTempMediaRoot()
+  await pruneManagedTempMedia(root)
+  const uploadDir = await mkdtemp(join(root, 'asset-'))
+  const filePath = join(uploadDir, sanitizeTempMediaFileName(fileName))
+  await writeFile(filePath, bytes)
+  return filePath
+}
+
+export async function storeManagedTempMediaDataUrl(
+  dataUrl: string,
+  baseName: string,
+  options: { root?: string } = {},
+): Promise<string | null> {
+  const trimmed = dataUrl.trim()
+  const match = /^data:([^;,]*)(;base64)?,(.*)$/isu.exec(trimmed)
+  if (!match) return null
+
+  const mimeType = (match[1] ?? '').trim().toLowerCase()
+  const encodedPayload = match[3] ?? ''
+  let bytes: Buffer
+  try {
+    bytes = match[2]
+      ? Buffer.from(encodedPayload, 'base64')
+      : Buffer.from(decodeURIComponent(encodedPayload), 'utf8')
+  } catch {
+    return null
+  }
+  if (bytes.length === 0) return null
+
+  const hash = createHash('sha1').update(bytes).digest('hex')
+  const extension = extensionFromMimeType(mimeType)
+  const safeBaseName = sanitizeTempMediaFileName(baseName)
+  const fileName = `${safeBaseName}-${hash}${extension}`
+  return await storeManagedTempMediaFile(fileName, bytes, options)
+}

--- a/tests.md
+++ b/tests.md
@@ -224,6 +224,38 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Remote-safe media uploads
+
+#### Feature/Change Name
+Uploaded screenshots, pasted images, and dragged files are stored in a Codex-managed temp media tree with 30-day retention.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Access to the app from a browser on another host, or a remote session over Tailscale
+3. One disposable thread for attachment testing
+4. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, upload or paste a small image into the composer.
+2. Confirm the image preview appears before sending.
+3. Send the message and confirm the attachment renders in the conversation.
+4. Check the server host and confirm the file is stored under `CODEX_HOME/tmp/codex-web-media`.
+5. Repeat steps 1 through 4 using drag and drop.
+6. Switch to dark theme and repeat steps 1 through 4.
+7. Create or keep a scratch media directory older than 30 days, then trigger another upload and confirm the stale directory is removed by the temp-media cleanup path.
+
+#### Expected Results
+- The browser can upload images from a different machine without depending on a browser-local filesystem path.
+- Uploaded media is retained in the Codex-managed temp tree instead of `tmpdir()` on the OS.
+- The preview and sent attachment remain usable after upload.
+- Temp media older than 30 days is pruned before new media is written.
+- Behavior is consistent in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Remove any disposable attachments and delete scratch files under `CODEX_HOME/tmp/codex-web-media` if they were created for testing.
+
+---
+
 ### npx run dev compatibility shim
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -242,11 +242,13 @@ Uploaded screenshots, pasted images, and dragged files are stored in a Codex-man
 4. Check the server host and confirm the file is stored under `CODEX_HOME/tmp/codex-web-media`.
 5. Repeat steps 1 through 4 using drag and drop.
 6. Switch to dark theme and repeat steps 1 through 4.
-7. Create or keep a scratch media directory older than 30 days, then trigger another upload and confirm the stale directory is removed by the temp-media cleanup path.
+7. Reopen or refresh a thread containing an inline generated image several times and confirm the same inline media file path is reused under `CODEX_HOME/tmp/codex-web-media/inline`.
+8. Create or keep a scratch media directory older than 30 days, then trigger another upload and confirm the stale directory is removed by the temp-media cleanup path.
 
 #### Expected Results
 - The browser can upload images from a different machine without depending on a browser-local filesystem path.
 - Uploaded media is retained in the Codex-managed temp tree instead of `tmpdir()` on the OS.
+- Re-reading the same inline media payload does not create duplicate `asset-*` directories.
 - The preview and sent attachment remain usable after upload.
 - Temp media older than 30 days is pruned before new media is written.
 - Behavior is consistent in light theme and dark theme.


### PR DESCRIPTION
## Summary

This is primarily for **remote-device uploads**: when codexUI is running on one machine, but the browser is opened from another machine, uploaded screenshots and dragged files need to become readable on the codexUI host before they are sent to Codex.

For example, a user might run codexUI on a Mac mini or Linux box at home, expose it over Tailscale, then open the UI from a laptop. If they take a screenshot on the laptop and drag it into the composer, the old flow could hand Codex a temp path that only made sense on the laptop. The server-side Codex process cannot read that path.

This PR copies uploaded screenshots, pasted images, and dragged files into a Codex-managed temporary media tree on the host machine. The managed tree lives under `$CODEX_HOME/tmp/codex-web-media` and is pruned with a 30-day retention window.

## Problem

The previous upload path worked well for local-only use because the browser and codexUI server were usually on the same machine. In that setup, browser temp paths and server-readable paths often collapse into the same filesystem reality.

That assumption breaks for remote usage. With Tailscale, SSH tunnels, LAN access, or any setup where the browser is not running on the codexUI host, the browser's local temp path is not a valid file path for the server. The natural remote-debugging workflow is:

1. See an issue on the client device.
2. Take a screenshot on that client device.
3. Drag or paste it into the remote codexUI session.
4. Ask Codex running on the host to inspect it.

Step 4 requires the upload bytes to be materialized on the host. Passing around a client-local path is not a valid cross-device contract.

## What changed

- Added a managed temp-media store under `$CODEX_HOME/tmp/codex-web-media`.
- Added helpers for storing uploaded file payloads and data URLs on the server host.
- Updated inline payload handling so uploaded media is materialized into host-readable files instead of depending on browser-local temp paths.
- Added startup/write-path pruning for media directories older than 30 days, so remote uploads do not accumulate indefinitely.
- Added tests covering managed temp-media writes, stale media cleanup, and inline payload rewriting.
- Documented manual verification for remote-safe uploads, including paste/upload/drag-and-drop and cleanup behavior.

## Why this shape

The server is the source of truth for files that Codex can read. Copying upload content into a host-owned temp tree keeps the contract simple: once the browser uploads the bytes, the server owns a stable local path for the lifetime of the request and short-term conversation history.

The 30-day cleanup keeps this practical for remote use without requiring users to manually prune screenshot artifacts.

## Verification

- `pnpm run test:unit`
- `pnpm run build`
- Merge simulation against current `origin/main` reports clean for this branch.