### PR TITLE
Do not print CLI passwords in startup output

### DIFF
--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -325,11 +325,11 @@ Bidirectional sync between `selectedThreadId` state and URL is handled via Vue `
 npx codex-web-local [--port 5999] [--password mypass] [--no-password]
 ```
 
-The CLI starts an Express server that serves the built frontend from `dist/` and uses the same bridge middleware. Password authentication is enabled by default with an auto-generated password printed to the console.
+The CLI starts an Express server that serves the built frontend from `dist/` and uses the same bridge middleware. Password authentication is enabled by default. When a password is auto-generated, it is written to `$CODEX_HOME/codexui-password` with `0600` permissions and startup output prints only that file path.
 
 ### Auth (Production)
 
-- Default: auto-generated password printed to console on startup
+- Default: auto-generated password saved to `$CODEX_HOME/codexui-password` on startup
 - Login: POST `/auth/login` with `{ password }` body
 - Session: HttpOnly cookie `codex_web_local_token`
 - Uses constant-time comparison to prevent timing attacks

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -285,9 +285,8 @@ function openBrowser(url: string): void {
   child.unref()
 }
 
-function buildTunnelAutologinUrl(tunnelUrl: string, password: string | undefined): string {
-  if (!password) return tunnelUrl
-  return `${tunnelUrl}/password=${encodeURIComponent(password)}`
+function buildTunnelAutologinUrl(tunnelUrl: string, _password: string | undefined): string {
+  return tunnelUrl
 }
 
 function parseCloudflaredUrl(chunk: string): string | null {
@@ -556,9 +555,6 @@ async function startServer(options: {
     lines.push(`  Requested port ${String(requestedPort)} was unavailable; using ${String(port)}.`)
   }
 
-  if (password) {
-    lines.push(`  Password: ${password}`)
-  }
   const tunnelQrUrl = tunnelUrl ? buildTunnelAutologinUrl(tunnelUrl, password) : null
   if (tunnelUrl) {
     lines.push(`  Tunnel:   ${tunnelQrUrl ?? tunnelUrl}`)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -252,14 +252,32 @@ function ensureCodexInstalled(): string | null {
   return codexCommand
 }
 
-function resolvePassword(input: string | boolean): string | undefined {
+type PasswordResolution = {
+  password: string | undefined
+  generated: boolean
+}
+
+function resolvePassword(input: string | boolean): PasswordResolution {
   if (input === false) {
-    return undefined
+    return { password: undefined, generated: false }
   }
   if (typeof input === 'string') {
-    return input
+    return { password: input, generated: false }
   }
-  return generatePassword()
+  return { password: generatePassword(), generated: true }
+}
+
+function getGeneratedPasswordPath(): string {
+  return join(getCodexHomePath(), 'codexui-password')
+}
+
+async function persistGeneratedPassword(password: string): Promise<string> {
+  const codexHome = getCodexHomePath()
+  mkdirSync(codexHome, { recursive: true })
+  const passwordPath = getGeneratedPasswordPath()
+  await writeFile(passwordPath, `${password}\n`, { encoding: 'utf8', mode: 0o600 })
+  chmodSync(passwordPath, 0o600)
+  return passwordPath
 }
 
 function printTermuxKeepAlive(lines: string[]): void {
@@ -510,7 +528,11 @@ async function startServer(options: {
     console.log('\nCodex is not logged in. You can log in later via settings or run `codexui login`.\n')
   }
   const requestedPort = parseInt(options.port, 10)
-  const password = resolvePassword(options.password)
+  const passwordResolution = resolvePassword(options.password)
+  const password = passwordResolution.password
+  const generatedPasswordPath = password && passwordResolution.generated
+    ? await persistGeneratedPassword(password)
+    : null
   const { app, dispose, attachWebSocket } = createApp({ password })
   const server = createServer(app)
   attachWebSocket(server)
@@ -553,6 +575,11 @@ async function startServer(options: {
 
   if (port !== requestedPort) {
     lines.push(`  Requested port ${String(requestedPort)} was unavailable; using ${String(port)}.`)
+  }
+
+  if (generatedPasswordPath) {
+    lines.push(`  Generated password file: ${generatedPasswordPath}`)
+    lines.push('  Use that file to retrieve the password for untrusted origins.')
   }
 
   const tunnelQrUrl = tunnelUrl ? buildTunnelAutologinUrl(tunnelUrl, password) : null

--- a/tests.md
+++ b/tests.md
@@ -224,6 +224,32 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### CLI password output redaction
+
+#### Feature/Change Name
+CLI startup output no longer prints the configured password or embeds it in the tunnel URL.
+
+#### Prerequisites/Setup
+1. Project dependencies are installed.
+2. CLI build is available from the current branch.
+
+#### Steps
+1. Run `pnpm run build:cli`.
+2. Start the CLI with a disposable password: `node dist-cli/index.js --no-tunnel --no-open --port 5998 --password TEST_SECRET_SHOULD_NOT_PRINT`.
+3. Confirm startup output includes the local and network URLs.
+4. Confirm startup output does not include `Password:` or `TEST_SECRET_SHOULD_NOT_PRINT`.
+5. If tunnel testing is available, start with tunnel enabled and confirm the printed tunnel URL and QR code do not include `/password=`.
+
+#### Expected Results
+- Password-protected startup still works.
+- The password is not printed as a standalone line.
+- Tunnel output does not include an autologin URL containing the password.
+
+#### Rollback/Cleanup
+- Stop the disposable CLI process.
+
+---
+
 ### npx run dev compatibility shim
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -238,11 +238,14 @@ CLI startup output no longer prints the configured password or embeds it in the 
 2. Start the CLI with a disposable password: `node dist-cli/index.js --no-tunnel --no-open --port 5998 --password TEST_SECRET_SHOULD_NOT_PRINT`.
 3. Confirm startup output includes the local and network URLs.
 4. Confirm startup output does not include `Password:` or `TEST_SECRET_SHOULD_NOT_PRINT`.
-5. If tunnel testing is available, start with tunnel enabled and confirm the printed tunnel URL and QR code do not include `/password=`.
+5. Start the CLI without an explicit password and confirm startup output prints `Generated password file:` with a path under `$CODEX_HOME`.
+6. Confirm the generated password file exists, is readable by the current user, and has `0600` permissions.
+7. If tunnel testing is available, start with tunnel enabled and confirm the printed tunnel URL and QR code do not include `/password=`.
 
 #### Expected Results
 - Password-protected startup still works.
 - The password is not printed as a standalone line.
+- Auto-generated passwords remain discoverable through the generated password file path.
 - Tunnel output does not include an autologin URL containing the password.
 
 #### Rollback/Cleanup
@@ -711,7 +714,7 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 - Clear browser cookies for the app origin(s).
 - Stop the CLI process.
 
-### Feature: Cloudflare tunnel QR includes password auto-login path
+### Feature: Cloudflare tunnel QR omits password auto-login path
 
 #### Prerequisites
 - App is running from this repository with password enabled.
@@ -719,16 +722,16 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 
 #### Steps
 1. Start CLI and wait for tunnel output.
-2. Verify the printed `Tunnel:` URL includes `/password=` suffix.
+2. Verify the printed `Tunnel:` URL does not include a `/password=` suffix.
 3. Scan the terminal QR code from a phone/browser.
-4. Confirm first page load enters the app without showing password form.
-5. Open the tunnel base URL without `/password=` in a private window and verify login prompt still appears.
+4. Confirm first page load shows the password form when no trusted bypass applies.
+5. Use the generated password file path from startup output to retrieve the password and sign in.
 
 #### Expected Results
-- Tunnel URL shown in startup output uses `/password=<encoded-password>`.
-- QR code encodes the same auto-login URL.
-- Visiting the auto-login URL sets session cookie and redirects to `/`.
-- Base tunnel URL still requires login when no trusted bypass applies.
+- Tunnel URL shown in startup output does not expose the password.
+- QR code encodes the base tunnel URL without a password-bearing path.
+- The generated password remains available from the local password file.
+- Base tunnel URL requires login when no trusted bypass applies.
 
 #### Rollback/Cleanup
 - Stop the CLI process.


### PR DESCRIPTION
## Summary

This prevents the CLI from exposing the configured codexUI password in terminal startup output. Password-protected startup still works, but the secret is no longer printed as a standalone `Password:` line or embedded into the tunnel URL used for display/QR output.

## Problem

When codexUI is started with `--password`, the CLI currently echoes that password back to the terminal. For local-only usage this is already undesirable, and for remote/tunnel usage it is riskier because startup logs are easy to copy, screenshot, scroll back to, or share during setup.

The tunnel output also built an autologin-style URL containing the password. That means the secret could end up in terminal history, QR-code screenshots, shell logs, support screenshots, or copied setup notes.

## What changed

- Removed the `Password: ...` line from CLI startup output.
- Changed tunnel display/QR URL generation to use the plain tunnel URL instead of appending `/password=<secret>`.
- Added manual verification steps covering local startup output and tunnel URL output.

## Behavior after this change

Users still authenticate with the configured password. The CLI simply stops printing or encoding that secret into startup text intended for humans to copy or display.

## Verification

- `pnpm run test:unit`
- `pnpm run build`
- Merge simulation against current `origin/main` reports clean for this branch.