### PR TITLE
Support configurable Vite allowed hosts

### DIFF
--- a/tests.md
+++ b/tests.md
@@ -19,6 +19,29 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - <cleanup action, if any>
 
+### Feature: Vite local allowed hosts override
+
+#### Prerequisites
+- App is running from this repository.
+- `CODEXUI_VITE_ALLOWED_HOSTS` is set in ignored `.env.local` or the shell environment.
+
+#### Steps
+1. Confirm `.env.local` is ignored by git.
+2. Set `CODEXUI_VITE_ALLOWED_HOSTS` to a comma/space-separated host list, including quoted entries if needed.
+3. Start the dev server.
+4. Request the dev server with one configured host in the `Host` header.
+
+#### Expected Results
+- Tracked `vite.config.ts` keeps only the generic `CODEXUI_VITE_ALLOWED_HOSTS` hook, not host-specific DNS values.
+- Duplicate hosts are deduplicated.
+- Quoted host tokens are parsed without splitting inside the quoted token.
+- A fully quoted dotenv list such as `"phone.ts.net,tablet.ts.net"` is parsed as separate hosts.
+- An explicitly empty shell or `.env.local` value clears additional hosts instead of falling back to `.env`.
+- Requests using configured local hosts are accepted by the dev server.
+
+#### Rollback/Cleanup
+- Remove `CODEXUI_VITE_ALLOWED_HOSTS` from `.env.local` or the shell environment.
+
 ### Feature: Thread heartbeat automations
 
 #### Prerequisites

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,8 +79,20 @@ const worktreeName = getWorktreeName();
 const appVersion = typeof pkg.version === "string" ? pkg.version : "unknown";
 const WS_UPGRADE_ATTACHED_KEY = "__codexBridgeWsAttached__";
 
-function readEnvValueFromFile(filePath: string, key: string): string {
-  if (!existsSync(filePath)) return "";
+function stripSurroundingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === "\"" || first === "'") && first === last) {
+      return trimmed.slice(1, -1).trim();
+    }
+  }
+  return trimmed;
+}
+
+function readEnvValueFromFile(filePath: string, key: string): string | null {
+  if (!existsSync(filePath)) return null;
   const raw = readFileSync(filePath, "utf8");
   for (const line of raw.split(/\r?\n/u)) {
     const trimmed = line.trim();
@@ -89,18 +101,37 @@ function readEnvValueFromFile(filePath: string, key: string): string {
     if (separator <= 0) continue;
     const currentKey = trimmed.slice(0, separator).trim();
     if (currentKey !== key) continue;
-    return trimmed.slice(separator + 1).trim();
+    return stripSurroundingQuotes(trimmed.slice(separator + 1));
   }
-  return "";
+  return null;
 }
 
 function resolveViteRollbackDebugFallback(): string {
   const fromEnvLocal = readEnvValueFromFile(".env.local", "VITE_ROLLBACK_DEBUG");
   if (fromEnvLocal) return fromEnvLocal;
-  return readEnvValueFromFile(".env", "VITE_ROLLBACK_DEBUG");
+  return readEnvValueFromFile(".env", "VITE_ROLLBACK_DEBUG") ?? "";
+}
+
+function resolveAdditionalAllowedHosts(): string[] {
+  const envKey = "CODEXUI_VITE_ALLOWED_HOSTS";
+  const raw = Object.prototype.hasOwnProperty.call(process.env, envKey)
+    ? stripSurroundingQuotes(process.env[envKey] ?? "")
+    : (readEnvValueFromFile(".env.local", envKey) ?? readEnvValueFromFile(".env", envKey));
+  const normalizedRaw = stripSurroundingQuotes(raw ?? "");
+  if (!normalizedRaw) return [];
+
+  const hosts: string[] = [];
+  const hostPattern = /"([^"]*)"|'([^']*)'|([^,\s]+)/gu;
+  for (const match of normalizedRaw.matchAll(hostPattern)) {
+    const host = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (host) hosts.push(host);
+  }
+
+  return [...new Set(hosts)];
 }
 
 const viteRollbackDebugFallback = resolveViteRollbackDebugFallback();
+const additionalAllowedHosts = resolveAdditionalAllowedHosts();
 
 export default defineConfig({
   define: {
@@ -111,7 +142,7 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
-    allowedHosts: [".trycloudflare.com"],
+    allowedHosts: [".trycloudflare.com", ...additionalAllowedHosts],
     watch: {
       ignored: [
         '**/.omx/**',


### PR DESCRIPTION
## Summary

- add `CODEXUI_VITE_ALLOWED_HOSTS` support for extending Vite dev-server allowed hosts
- read the value from the shell environment, `.env.local`, or `.env`
- parse comma/space-separated host lists, including quoted tokens, and dedupe entries

This is primarily intended for local development setups where the Vite dev server is accessed from another device, such as an iPhone/iPad or Android device over Tailscale. Keeping the host list configurable avoids committing machine-specific Tailscale DNS names or temporary tunnel hosts.

## Testing

- `pnpm run build:frontend`
- `git diff --check main..HEAD`
