### PR TITLE
Add project recency ordering and mobile project move mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,8 @@
 
           <SidebarThreadTree :groups="projectGroups" :project-display-name-by-id="projectDisplayNameById"
             :project-git-repo-by-name="projectGitRepoByName"
+            :project-sort-mode="projectSortMode"
+            :pinned-project-order="pinnedProjectOrder"
             v-if="!isSidebarCollapsed"
             :selected-thread-id="selectedThreadId" :is-loading="isLoadingThreads"
             :search-query="sidebarSearchQuery"
@@ -75,6 +77,8 @@
             @rename-thread="onRenameThread"
             @fork-thread="onForkThread"
             @remove-project="onRemoveProject" @reorder-project="onReorderProject"
+            @set-project-sort-mode="onSetProjectSortMode"
+            @toggle-project-pinned="onToggleProjectPinned"
             @export-thread="onExportThread"
             @start-new-chat="onStartNewThreadFromToolbar"
             @toggle-filter="toggleSidebarSearch" />
@@ -1183,6 +1187,8 @@ const WHISPER_LANGUAGES: Record<string, string> = {
 const {
   projectGroups,
   projectDisplayNameById,
+  projectSortMode,
+  pinnedProjectOrder,
   selectedThread,
   selectedThreadTokenUsage,
   selectedThreadTerminalOpen,
@@ -1232,7 +1238,9 @@ const {
   renameProject,
   removeProject,
   reorderProject,
-  pinProjectToTop,
+  setProjectSortMode,
+  focusProjectToTop,
+  toggleProjectPinned,
   startPolling,
   stopPolling,
   primeSelectedThread,
@@ -2372,7 +2380,7 @@ async function onCreateProjectWorktree(projectName: string): Promise<void> {
 
     newThreadCwd.value = normalizedPath
     newThreadRuntime.value = 'local'
-    pinProjectToTop(getPathLeafName(normalizedPath))
+    focusProjectToTop(getProjectOrderNameForPath(normalizedPath))
     await loadWorkspaceRootOptionsState()
     await refreshDefaultProjectName()
     if (isMobile.value) setSidebarCollapsed(true)
@@ -2426,6 +2434,14 @@ async function onRemoveProject(projectName: string): Promise<void> {
 
 function onReorderProject(payload: { projectName: string; toIndex: number }): void {
   reorderProject(payload.projectName, payload.toIndex)
+}
+
+function onSetProjectSortMode(mode: 'recent' | 'manual'): void {
+  setProjectSortMode(mode)
+}
+
+function onToggleProjectPinned(projectName: string): void {
+  toggleProjectPinned(projectName)
 }
 
 function onRespondServerRequest(payload: UiServerRequestReply): void {
@@ -3029,7 +3045,7 @@ async function onCreateProject(): Promise<void> {
     if (!normalizedPath) return
 
     newThreadCwd.value = normalizedPath
-    pinProjectToTop(getProjectOrderNameForPath(normalizedPath))
+    focusProjectToTop(getProjectOrderNameForPath(normalizedPath))
     await loadWorkspaceRootOptionsState()
     await refreshDefaultProjectName()
   } catch (error) {
@@ -3114,7 +3130,7 @@ async function onConfirmExistingFolder(path = resolvedExistingFolderPath.value):
     }
 
     newThreadCwd.value = normalizedPath
-    pinProjectToTop(getPathLeafName(normalizedPath))
+    focusProjectToTop(getProjectOrderNameForPath(normalizedPath))
     await loadWorkspaceRootOptionsState()
     await refreshDefaultProjectName()
     onCloseExistingFolderPanel()
@@ -3206,7 +3222,7 @@ async function applyLaunchProjectPathFromUrl(): Promise<boolean> {
     })
     if (!normalizedPath) return false
     newThreadCwd.value = normalizedPath
-    pinProjectToTop(getPathLeafName(normalizedPath))
+    focusProjectToTop(getProjectOrderNameForPath(normalizedPath))
     await router.replace({ name: 'home' })
     await loadWorkspaceRootOptionsState()
     const nextUrl = new URL(window.location.href)

--- a/src/components/icons/IconTablerArrowsSort.vue
+++ b/src/components/icons/IconTablerArrowsSort.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M3 9l4-4l4 4h-3v10h-2v-10zm10 6h3v-10h2v10h3l-4 4z"
+    />
+  </svg>
+</template>

--- a/src/components/icons/IconTablerGripVertical.vue
+++ b/src/components/icons/IconTablerGripVertical.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M9 5a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m0 7a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m0 7a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m9-14a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m0 7a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0m0 7a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0"
+    />
+  </svg>
+</template>

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -105,6 +105,26 @@
         <template #right>
           <div ref="organizeMenuWrapRef" class="organize-menu-wrap">
             <button
+              v-if="isProjectMoveMode"
+              class="project-move-done-button"
+              type="button"
+              @click.stop="stopProjectMoveMode"
+            >
+              {{ t('Done') }}
+            </button>
+            <button
+              v-else
+              class="project-reorder-button"
+              type="button"
+              :disabled="isSearchActive"
+              :aria-disabled="isSearchActive"
+              :aria-label="t('Reorder projects')"
+              :title="t('Reorder projects')"
+              @click.stop="startProjectMoveMode()"
+            >
+              <IconTablerArrowsSort class="thread-icon" />
+            </button>
+            <button
               class="organize-menu-trigger"
               type="button"
               :aria-expanded="isOrganizeMenuOpen"
@@ -117,6 +137,25 @@
 
             <div v-if="isOrganizeMenuOpen" class="organize-menu-panel" @click.stop>
               <p class="organize-menu-title">{{ t('Organize') }}</p>
+              <button
+                class="organize-menu-item"
+                :data-active="projectSortMode === 'recent'"
+                type="button"
+                @click="setProjectSortMode('recent')"
+              >
+                <span>{{ t('Recent projects') }}</span>
+                <span v-if="projectSortMode === 'recent'">✓</span>
+              </button>
+              <button
+                class="organize-menu-item"
+                :data-active="projectSortMode === 'manual'"
+                type="button"
+                @click="setProjectSortMode('manual')"
+              >
+                <span>{{ t('Manual project order') }}</span>
+                <span v-if="projectSortMode === 'manual'">✓</span>
+              </button>
+              <div class="organize-menu-separator" />
               <button
                 class="organize-menu-item"
                 :data-active="threadViewMode === 'project'"
@@ -290,6 +329,11 @@
               :data-dragging-handle="isDraggingProject(group.projectName)"
               @mousedown.left="onProjectHandleMouseDown($event, group.projectName)"
             >
+              <IconTablerPin
+                v-if="isProjectPinned(group.projectName)"
+                class="project-pin-indicator"
+                aria-hidden="true"
+              />
               <span class="project-title" :title="getProjectTooltipTitle(group.projectName)">
                 {{ getProjectVisibleName(group) }}
               </span>
@@ -327,6 +371,9 @@
                       <button class="project-menu-item" type="button" @click="openRenameProjectMenu(group)">
                         Rename project
                       </button>
+                      <button class="project-menu-item" type="button" @click="onToggleProjectPinned(group.projectName)">
+                        {{ isProjectPinPreferenceSet(group.projectName) ? t('Unpin project') : t('Pin project') }}
+                      </button>
                       <button
                         class="project-menu-item project-menu-item-danger"
                         type="button"
@@ -347,6 +394,17 @@
                   </div>
                 </div>
 
+                <button
+                  v-if="isProjectMoveMode"
+                  class="project-move-handle"
+                  type="button"
+                  :aria-label="t('Move project')"
+                  :title="t('Move project')"
+                  @click.stop
+                  @pointerdown.stop.prevent="onProjectMoveHandlePointerDown($event, group.projectName)"
+                >
+                  <IconTablerGripVertical class="thread-icon" />
+                </button>
                 <button
                   class="thread-start-button"
                   type="button"
@@ -724,6 +782,7 @@ import {
   upsertThreadAutomation,
 } from '../../api/codexGateway'
 import type { UiProjectGroup, UiThread, UiThreadAutomation, UiThreadAutomationStatus } from '../../types/codex'
+import IconTablerArrowsSort from '../icons/IconTablerArrowsSort.vue'
 import IconTablerChevronDown from '../icons/IconTablerChevronDown.vue'
 import IconTablerChevronRight from '../icons/IconTablerChevronRight.vue'
 import IconTablerDots from '../icons/IconTablerDots.vue'
@@ -732,15 +791,24 @@ import IconTablerFolder from '../icons/IconTablerFolder.vue'
 import IconTablerFolderOpen from '../icons/IconTablerFolderOpen.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
 import IconTablerFilter from '../icons/IconTablerFilter.vue'
+import IconTablerGripVertical from '../icons/IconTablerGripVertical.vue'
+import IconTablerPin from '../icons/IconTablerPin.vue'
 import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import { getPathLeafName, getPathParent, isProjectlessChatPath } from '../../pathUtils.js'
+import {
+  collapseProjectsForMoveMode,
+  createProjectMoveModeState,
+  stopProjectMoveMode as createStoppedProjectMoveMode,
+} from './projectMoveMode'
 import SidebarMenuRow from './SidebarMenuRow.vue'
 
 const props = defineProps<{
   groups: UiProjectGroup[]
   projectDisplayNameById: Record<string, string>
   projectGitRepoByName: Record<string, boolean>
+  projectSortMode: 'recent' | 'manual'
+  pinnedProjectOrder: string[]
   selectedThreadId: string
   isLoading: boolean
   searchQuery: string
@@ -761,6 +829,8 @@ const emit = defineEmits<{
   'rename-thread': [payload: { threadId: string; title: string }]
   'remove-project': [projectName: string]
   'reorder-project': [payload: { projectName: string; toIndex: number }]
+  'set-project-sort-mode': [mode: 'recent' | 'manual']
+  'toggle-project-pinned': [projectName: string]
   'export-thread': [threadId: string]
   'fork-thread': [threadId: string]
   'start-new-chat': []
@@ -800,6 +870,8 @@ type MenuDirection = 'up' | 'down'
 type ChatSortMode = 'created' | 'updated'
 
 const DRAG_START_THRESHOLD_PX = 4
+const SUPPRESSED_PROJECT_TOGGLE_CLEAR_DELAY_MS = 100
+const FALLBACK_PROJECT_MENU_HEIGHT_PX = 176
 const PROJECT_GROUP_EXPANDED_GAP_PX = 6
 const SECTION_EXPANSION_STORAGE_KEY = 'codex-web-local.sidebar-section-expansion.v1'
 const CHATS_FIRST_STORAGE_KEY = 'codex-web-local.sidebar-chats-first.v1'
@@ -849,8 +921,12 @@ const automationDraft = ref<{
 const groupsContainerRef = ref<HTMLElement | null>(null)
 const pendingProjectDrag = ref<PendingProjectDrag | null>(null)
 const activeProjectDrag = ref<ActiveProjectDrag | null>(null)
+const projectMoveMode = ref(createStoppedProjectMoveMode())
+const preMoveCollapsedProjects = ref<Record<string, boolean> | null>(null)
 let pendingDragPointerSample: DragPointerSample | null = null
 let dragPointerRafId: number | null = null
+let activeProjectPointerId: number | null = null
+let suppressProjectToggleClearTimer: number | null = null
 const suppressNextProjectToggleId = ref('')
 const measuredHeightByProject = ref<Record<string, number>>({})
 const projectGroupElementByName = new Map<string, HTMLElement>()
@@ -997,6 +1073,8 @@ const filteredGroups = computed<UiProjectGroup[]>(() => {
 })
 
 const isChronologicalView = computed(() => threadViewMode.value === 'chronological')
+const isProjectMoveMode = computed(() => projectMoveMode.value.isActive)
+const pinnedProjectNameSet = computed(() => new Set(props.pinnedProjectOrder))
 
 const globalThreads = computed<UiThread[]>(() => {
   const rows: UiThread[] = []
@@ -1537,6 +1615,10 @@ function setChatSortMode(mode: ChatSortMode): void {
   chatSortMode.value = mode
 }
 
+function setProjectSortMode(mode: 'recent' | 'manual'): void {
+  emit('set-project-sort-mode', mode)
+}
+
 function toggleProjectMenu(projectName: string): void {
   if (openProjectMenuId.value === projectName) {
     closeProjectMenu()
@@ -1601,6 +1683,39 @@ function onRemoveProject(projectName: string): void {
   closeProjectMenu()
 }
 
+function onToggleProjectPinned(projectName: string): void {
+  emit('toggle-project-pinned', projectName)
+  closeProjectMenu()
+}
+
+function isProjectPinned(projectName: string): boolean {
+  return props.projectSortMode === 'recent' && isProjectPinPreferenceSet(projectName)
+}
+
+function isProjectPinPreferenceSet(projectName: string): boolean {
+  return pinnedProjectNameSet.value.has(projectName)
+}
+
+function startProjectMoveMode(projectName = ''): void {
+  if (isSearchActive.value) return
+  const projectNames = props.groups.map((group) => group.projectName)
+  projectMoveMode.value = createProjectMoveModeState(projectNames, projectName || (projectNames[0] ?? ''))
+  if (projectMoveMode.value.isActive) {
+    preMoveCollapsedProjects.value = { ...collapsedProjects.value }
+    collapsedProjects.value = collapseProjectsForMoveMode(projectNames, collapsedProjects.value)
+    closeProjectMenu()
+  }
+}
+
+function stopProjectMoveMode(): void {
+  projectMoveMode.value = createStoppedProjectMoveMode()
+  if (preMoveCollapsedProjects.value) {
+    collapsedProjects.value = preMoveCollapsedProjects.value
+    preMoveCollapsedProjects.value = null
+  }
+  resetProjectDragState()
+}
+
 function onProjectHeaderKeyDown(event: KeyboardEvent, projectName: string): void {
   if (!event.altKey) return
   if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
@@ -1636,6 +1751,10 @@ function toggleProjectExpansion(projectName: string): void {
 
 function toggleProjectCollapse(projectName: string): void {
   if (suppressNextProjectToggleId.value === projectName) {
+    if (suppressProjectToggleClearTimer !== null) {
+      window.clearTimeout(suppressProjectToggleClearTimer)
+      suppressProjectToggleClearTimer = null
+    }
     suppressNextProjectToggleId.value = ''
     return
   }
@@ -1734,9 +1853,13 @@ function updateProjectMenuDirection(projectName: string): void {
   const menuWrapElement = projectMenuWrapElementByName.get(projectName)
   if (!menuWrapElement) return
 
+  const panelElement = menuWrapElement.querySelector<HTMLElement>('.project-menu-panel')
+  const panelRect = panelElement?.getBoundingClientRect()
+  const panelHeight = panelRect?.height || panelElement?.offsetHeight || FALLBACK_PROJECT_MENU_HEIGHT_PX
+
   projectMenuDirectionById.value = {
     ...projectMenuDirectionById.value,
-    [projectName]: resolveMenuDirection(menuWrapElement, 176),
+    [projectName]: resolveMenuDirection(menuWrapElement, panelHeight),
   }
 }
 
@@ -1918,30 +2041,46 @@ function setProjectGroupRef(projectName: string, element: Element | ComponentPub
   projectGroupElementByName.delete(projectName)
 }
 
-function onProjectHandleMouseDown(event: MouseEvent, projectName: string): void {
-  if (event.button !== 0) return
-  if (pendingProjectDrag.value || activeProjectDrag.value) return
+function beginProjectDrag(projectName: string, clientX: number, clientY: number): boolean {
+  if (isSearchActive.value) return false
+  if (pendingProjectDrag.value || activeProjectDrag.value) return false
 
   const fromIndex = props.groups.findIndex((group) => group.projectName === projectName)
   const projectGroupElement = projectGroupElementByName.get(projectName)
-  if (fromIndex < 0 || !projectGroupElement) return
+  if (fromIndex < 0 || !projectGroupElement) return false
 
   const groupRect = projectGroupElement.getBoundingClientRect()
   const groupGap = isCollapsed(projectName) ? 0 : PROJECT_GROUP_EXPANDED_GAP_PX
   pendingProjectDrag.value = {
     projectName,
     fromIndex,
-    startClientX: event.clientX,
-    startClientY: event.clientY,
-    pointerOffsetY: event.clientY - groupRect.top,
+    startClientX: clientX,
+    startClientY: clientY,
+    pointerOffsetY: clientY - groupRect.top,
     groupLeft: groupRect.left,
     groupWidth: groupRect.width,
     groupHeight: groupRect.height,
     groupOuterHeight: groupRect.height + groupGap,
   }
 
+  return true
+}
+
+function onProjectHandleMouseDown(event: MouseEvent, projectName: string): void {
+  if (event.button !== 0) return
+  if (!beginProjectDrag(projectName, event.clientX, event.clientY)) return
+
   event.preventDefault()
   bindProjectDragListeners()
+}
+
+function onProjectMoveHandlePointerDown(event: PointerEvent, projectName: string): void {
+  if (event.button !== 0) return
+  if (!isProjectMoveMode.value) return
+  if (!beginProjectDrag(projectName, event.clientX, event.clientY)) return
+
+  activeProjectPointerId = event.pointerId
+  bindProjectPointerDragListeners()
 }
 
 function bindProjectDragListeners(): void {
@@ -1956,6 +2095,20 @@ function unbindProjectDragListeners(): void {
   window.removeEventListener('keydown', onProjectDragKeyDown)
 }
 
+function bindProjectPointerDragListeners(): void {
+  window.addEventListener('pointermove', onProjectDragPointerMove)
+  window.addEventListener('pointerup', onProjectDragPointerUp)
+  window.addEventListener('pointercancel', onProjectDragPointerCancel)
+  window.addEventListener('keydown', onProjectDragKeyDown)
+}
+
+function unbindProjectPointerDragListeners(): void {
+  window.removeEventListener('pointermove', onProjectDragPointerMove)
+  window.removeEventListener('pointerup', onProjectDragPointerUp)
+  window.removeEventListener('pointercancel', onProjectDragPointerCancel)
+  window.removeEventListener('keydown', onProjectDragKeyDown)
+}
+
 function onProjectDragMouseMove(event: MouseEvent): void {
   pendingDragPointerSample = {
     clientX: event.clientX,
@@ -1965,10 +2118,30 @@ function onProjectDragMouseMove(event: MouseEvent): void {
 }
 
 function onProjectDragMouseUp(event: MouseEvent): void {
-  processProjectDragPointerSample({
+  finishProjectDrag({ clientX: event.clientX, clientY: event.clientY })
+}
+
+function onProjectDragPointerMove(event: PointerEvent): void {
+  if (activeProjectPointerId !== null && event.pointerId !== activeProjectPointerId) return
+  pendingDragPointerSample = {
     clientX: event.clientX,
     clientY: event.clientY,
-  })
+  }
+  scheduleProjectDragPointerFrame()
+}
+
+function onProjectDragPointerUp(event: PointerEvent): void {
+  if (activeProjectPointerId !== null && event.pointerId !== activeProjectPointerId) return
+  finishProjectDrag({ clientX: event.clientX, clientY: event.clientY })
+}
+
+function onProjectDragPointerCancel(event: PointerEvent): void {
+  if (activeProjectPointerId !== null && event.pointerId !== activeProjectPointerId) return
+  resetProjectDragState()
+}
+
+function finishProjectDrag(sample: DragPointerSample): void {
+  processProjectDragPointerSample(sample)
 
   const drag = activeProjectDrag.value
   if (drag && projectedDropProjectIndex.value !== null) {
@@ -2003,8 +2176,24 @@ function resetProjectDragState(): void {
   pendingDragPointerSample = null
   pendingProjectDrag.value = null
   activeProjectDrag.value = null
-  suppressNextProjectToggleId.value = ''
+  activeProjectPointerId = null
+  scheduleSuppressedProjectToggleClear()
   unbindProjectDragListeners()
+  unbindProjectPointerDragListeners()
+}
+
+function scheduleSuppressedProjectToggleClear(): void {
+  const suppressedProjectName = suppressNextProjectToggleId.value
+  if (!suppressedProjectName) return
+  if (suppressProjectToggleClearTimer !== null) {
+    window.clearTimeout(suppressProjectToggleClearTimer)
+  }
+  suppressProjectToggleClearTimer = window.setTimeout(() => {
+    if (suppressNextProjectToggleId.value === suppressedProjectName) {
+      suppressNextProjectToggleId.value = ''
+    }
+    suppressProjectToggleClearTimer = null
+  }, SUPPRESSED_PROJECT_TOGGLE_CLEAR_DELAY_MS)
 }
 
 function scheduleProjectDragPointerFrame(): void {
@@ -2187,6 +2376,14 @@ watch(
       resetProjectDragState()
     }
 
+    if (projectMoveMode.value.isActive) {
+      if (!props.groups.some((group) => group.projectName === projectMoveMode.value.projectName)) {
+        stopProjectMoveMode()
+      } else {
+        collapsedProjects.value = collapseProjectsForMoveMode(projectNames, collapsedProjects.value)
+      }
+    }
+
     const projectNameSet = new Set(projectNames)
     const nextMeasuredHeights = Object.fromEntries(
       Object.entries(measuredHeightByProject.value).filter(([projectName]) => projectNameSet.has(projectName)),
@@ -2197,6 +2394,12 @@ watch(
     }
   },
 )
+
+watch(isSearchActive, (nextIsSearchActive) => {
+  if (nextIsSearchActive && projectMoveMode.value.isActive) {
+    stopProjectMoveMode()
+  }
+})
 
 const hasOpenDismissableMenu = computed(
   () => isOrganizeMenuOpen.value || openProjectMenuId.value !== '' || openThreadMenuId.value !== '',
@@ -2224,6 +2427,11 @@ watch(openThreadMenuId, (threadId) => {
 })
 
 onBeforeUnmount(() => {
+  if (suppressProjectToggleClearTimer !== null) {
+    window.clearTimeout(suppressProjectToggleClearTimer)
+    suppressProjectToggleClearTimer = null
+  }
+  suppressNextProjectToggleId.value = ''
   for (const element of projectGroupElementByName.values()) {
     projectGroupResizeObserver?.unobserve(element)
   }
@@ -2287,7 +2495,7 @@ onBeforeUnmount(() => {
 }
 
 .organize-menu-wrap {
-  @apply relative;
+  @apply relative inline-flex items-center gap-1;
 }
 
 .organize-menu-trigger {
@@ -2343,11 +2551,24 @@ onBeforeUnmount(() => {
 }
 
 .project-main-button {
-  @apply min-w-0 w-full text-left rounded px-0 py-0 flex items-center min-h-5 cursor-grab;
+  @apply min-w-0 w-full text-left rounded px-0 py-0 flex items-center gap-1 min-h-5 cursor-grab;
 }
 
 .project-main-button[data-dragging-handle='true'] {
   @apply cursor-grabbing;
+}
+
+.project-move-done-button {
+  @apply h-6 rounded-md border border-zinc-200 bg-white px-2 text-xs font-medium text-zinc-700 transition hover:bg-zinc-50;
+}
+
+.project-reorder-button {
+  @apply h-6 w-6 rounded-md border border-zinc-200 bg-white text-zinc-600 flex items-center justify-center transition hover:bg-zinc-50;
+}
+
+.project-move-handle {
+  @apply h-6 w-6 rounded-md border border-zinc-200 bg-white text-zinc-600 flex items-center justify-center transition hover:bg-zinc-50;
+  touch-action: none;
 }
 
 .project-icon-stack {
@@ -2364,6 +2585,10 @@ onBeforeUnmount(() => {
 
 .project-title {
   @apply text-sm font-normal text-zinc-700 truncate select-none;
+}
+
+.project-pin-indicator {
+  @apply h-3.5 w-3.5 shrink-0 text-zinc-500;
 }
 
 .project-menu-wrap {

--- a/src/components/sidebar/projectMoveMode.test.ts
+++ b/src/components/sidebar/projectMoveMode.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { collapseProjectsForMoveMode, createProjectMoveModeState, stopProjectMoveMode } from './projectMoveMode'
+
+describe('project move mode', () => {
+  it('starts move mode when project name has surrounding whitespace', () => {
+    expect(createProjectMoveModeState(['alpha', 'beta'], '  beta  ')).toEqual({
+      isActive: true,
+      projectName: 'beta',
+    })
+  })
+
+  it('does not start move mode when trimmed project name is missing', () => {
+    expect(createProjectMoveModeState(['alpha'], '  beta  ')).toEqual({
+      isActive: false,
+      projectName: '',
+    })
+  })
+
+  it('starts move mode for an existing project', () => {
+    expect(createProjectMoveModeState(['alpha', 'beta'], 'beta')).toEqual({
+      isActive: true,
+      projectName: 'beta',
+    })
+  })
+
+  it('does not start move mode for a missing project', () => {
+    expect(createProjectMoveModeState(['alpha'], 'beta')).toEqual({
+      isActive: false,
+      projectName: '',
+    })
+  })
+
+  it('clears active project state when stopping move mode', () => {
+    expect(stopProjectMoveMode()).toEqual({
+      isActive: false,
+      projectName: '',
+    })
+  })
+
+  it('collapses every current project when move mode starts', () => {
+    expect(collapseProjectsForMoveMode(['alpha', 'beta'], { alpha: false, stale: false })).toEqual({
+      alpha: true,
+      beta: true,
+      stale: false,
+    })
+  })
+})

--- a/src/components/sidebar/projectMoveMode.ts
+++ b/src/components/sidebar/projectMoveMode.ts
@@ -1,0 +1,36 @@
+export type ProjectMoveModeState = {
+  isActive: boolean
+  projectName: string
+}
+
+export function stopProjectMoveMode(): ProjectMoveModeState {
+  return {
+    isActive: false,
+    projectName: '',
+  }
+}
+
+export function createProjectMoveModeState(projectNames: string[], projectName: string): ProjectMoveModeState {
+  const normalizedProjectName = projectName.trim()
+  if (!normalizedProjectName || !projectNames.includes(normalizedProjectName)) {
+    return stopProjectMoveMode()
+  }
+
+  return {
+    isActive: true,
+    projectName: normalizedProjectName,
+  }
+}
+
+export function collapseProjectsForMoveMode(
+  projectNames: string[],
+  currentCollapsedProjects: Record<string, boolean>,
+): Record<string, boolean> {
+  return projectNames.reduce<Record<string, boolean>>(
+    (nextCollapsedProjects, projectName) => {
+      nextCollapsedProjects[projectName] = true
+      return nextCollapsedProjects
+    },
+    { ...currentCollapsedProjects },
+  )
+}

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -1,13 +1,53 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildWorkspaceRootsProjectOrderState,
   collectWorkspaceRootPathsForProjectRemoval,
   filterGroupsByWorkspaceRoots,
   findAdjacentThreadId,
   isThreadUnreadByLastRead,
+  normalizePinnedProjectOrder,
+  orderGroupsByPinnedProjectOrder,
+  reorderPinnedProjectOrder,
+  useDesktopState,
 } from './useDesktopState'
 import type { UiProjectGroup } from '../types/codex'
 import type { WorkspaceRootsState } from '../api/codexGateway'
+
+const gatewayMocks = vi.hoisted(() => ({
+  archiveThread: vi.fn(),
+  forkThread: vi.fn(),
+  getAccountRateLimits: vi.fn(),
+  getAvailableCollaborationModes: vi.fn(),
+  getAvailableModelIds: vi.fn(),
+  getCurrentModelConfig: vi.fn(),
+  getPendingServerRequests: vi.fn(),
+  getSkillsList: vi.fn(),
+  getThreadDetail: vi.fn(),
+  getThreadGroupsPage: vi.fn(),
+  getThreadQueueState: vi.fn(),
+  getThreadTitleCache: vi.fn(),
+  getWorkspaceRootsState: vi.fn(),
+  generateThreadTitle: vi.fn(),
+  interruptThreadTurn: vi.fn(),
+  persistThreadTitle: vi.fn(),
+  renameThread: vi.fn(),
+  replyToServerRequest: vi.fn(),
+  resumeThread: vi.fn(),
+  revertThreadFileChanges: vi.fn(),
+  rollbackThread: vi.fn(),
+  setCodexSpeedMode: vi.fn(),
+  setThreadQueueState: vi.fn(),
+  setWorkspaceRootsState: vi.fn(),
+  startThread: vi.fn(),
+  startThreadTurn: vi.fn(),
+  subscribeCodexNotifications: vi.fn(),
+}))
+
+vi.mock('../api/codexGateway', () => ({
+  ...gatewayMocks,
+  getBackgroundThreadListLimit: vi.fn(() => 100),
+  pickCodexRateLimitSnapshot: vi.fn(() => null),
+}))
 
 function thread(id: string, cwd: string, options: { hasWorktree?: boolean } = {}) {
   return {
@@ -23,6 +63,34 @@ function thread(id: string, cwd: string, options: { hasWorktree?: boolean } = {}
     inProgress: false,
   }
 }
+
+function installTestWindow(initialStorage: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initialStorage))
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value)
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key)
+      }),
+    },
+    setTimeout: vi.fn(),
+    clearTimeout: vi.fn(),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  gatewayMocks.getThreadQueueState.mockResolvedValue({})
+  gatewayMocks.getThreadTitleCache.mockResolvedValue({ titles: {} })
+  gatewayMocks.getWorkspaceRootsState.mockRejectedValue(new Error('no workspace roots state'))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('filterGroupsByWorkspaceRoots', () => {
   it('keeps projectless chats visible when workspace roots are configured', () => {
@@ -97,6 +165,30 @@ describe('filterGroupsByWorkspaceRoots', () => {
     expect(filterGroupsByWorkspaceRoots(groups, rootsState).map((group) => group.projectName)).toEqual([
       'beta',
       'alpha',
+    ])
+  })
+
+  it('preserves incoming recency order when project sort mode is recent', () => {
+    const groups: UiProjectGroup[] = [
+      {
+        projectName: 'alpha',
+        threads: [thread('alpha-chat', '/tmp/alpha')],
+      },
+      {
+        projectName: 'beta',
+        threads: [thread('beta-chat', '/tmp/beta')],
+      },
+    ]
+    const rootsState: WorkspaceRootsState = {
+      order: ['/tmp/alpha', '/tmp/beta'],
+      labels: {},
+      active: ['/tmp/alpha'],
+      projectOrder: ['/tmp/beta', '/tmp/alpha'],
+    }
+
+    expect(filterGroupsByWorkspaceRoots(groups, rootsState, 'recent').map((group) => group.projectName)).toEqual([
+      'alpha',
+      'beta',
     ])
   })
 
@@ -279,6 +371,102 @@ describe('thread unread state helpers', () => {
       '2026-05-01T12:45:00.000Z',
       cutoffIso,
     )).toBe(true)
+  })
+})
+
+describe('pinned project ordering', () => {
+  const groups: UiProjectGroup[] = [
+    { projectName: 'alpha', threads: [thread('alpha-chat', '/tmp/alpha')] },
+    { projectName: 'beta', threads: [thread('beta-chat', '/tmp/beta')] },
+    { projectName: 'gamma', threads: [thread('gamma-chat', '/tmp/gamma')] },
+  ]
+
+  it('places pinned projects before remaining recent-order projects', () => {
+    expect(orderGroupsByPinnedProjectOrder(groups, ['gamma']).map((group) => group.projectName)).toEqual([
+      'gamma',
+      'alpha',
+      'beta',
+    ])
+  })
+
+  it('removes stale and duplicate pin entries while ordering visible projects', () => {
+    expect(orderGroupsByPinnedProjectOrder(groups, ['gamma', 'missing', 'gamma', 'alpha']).map((group) => group.projectName)).toEqual([
+      'gamma',
+      'alpha',
+      'beta',
+    ])
+  })
+
+  it('preserves path-qualified project ids when normalizing persisted pins', () => {
+    expect(normalizePinnedProjectOrder(['/tmp/first/api', 'api', '/tmp/first/api'])).toEqual([
+      '/tmp/first/api',
+      'api',
+    ])
+  })
+
+  it('pins an unpinned project into the pinned prefix when reordered in recent mode', () => {
+    expect(reorderPinnedProjectOrder(['alpha', 'beta', 'gamma'], ['gamma'], 'beta', 0)).toEqual([
+      'beta',
+      'gamma',
+    ])
+  })
+
+  it('keeps recent-mode reordered projects in the pinned prefix even when dropped below unpinned projects', () => {
+    expect(reorderPinnedProjectOrder(['alpha', 'beta', 'gamma'], ['gamma'], 'alpha', 2)).toEqual([
+      'gamma',
+      'alpha',
+    ])
+  })
+
+  it('reorders existing pins within the pinned prefix', () => {
+    expect(reorderPinnedProjectOrder(['alpha', 'beta', 'gamma'], ['gamma', 'alpha'], 'gamma', 1)).toEqual([
+      'alpha',
+      'gamma',
+    ])
+  })
+
+  it('preserves hidden entries after reordering visible projects', () => {
+    expect(reorderPinnedProjectOrder(['alpha', 'beta', 'gamma'], ['hidden', 'gamma', 'alpha', 'remote'], 'beta', 1)).toEqual([
+      'gamma',
+      'beta',
+      'alpha',
+      'hidden',
+      'remote',
+    ])
+  })
+
+  it('interprets target indexes against the visible project order', () => {
+    expect(reorderPinnedProjectOrder(['alpha', 'beta'], ['hidden', 'alpha', 'beta', 'gamma'], 'beta', 0)).toEqual([
+      'beta',
+      'alpha',
+      'hidden',
+      'gamma',
+    ])
+  })
+
+  it('keeps saved manual project order unchanged when reordering in recent mode', async () => {
+    const savedManualOrder = ['alpha', 'beta', 'gamma']
+    installTestWindow({
+      'codex-web-local.project-sort-mode.v1': 'recent',
+      'codex-web-local.project-order.v1': JSON.stringify(savedManualOrder),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups,
+      nextCursor: null,
+    })
+
+    const state = useDesktopState()
+    await state.refreshAll({ includeSelectedThreadMessages: false })
+    state.reorderProject('beta', 0)
+
+    expect(window.localStorage.getItem('codex-web-local.project-order.v1')).toBe(JSON.stringify(savedManualOrder))
+    expect(window.localStorage.getItem('codex-web-local.pinned-project-order.v1')).toBe(JSON.stringify(['beta']))
+    expect(state.projectGroups.value.map((group) => group.projectName)).toEqual([
+      'beta',
+      'alpha',
+      'gamma',
+    ])
+    expect(gatewayMocks.setWorkspaceRootsState).not.toHaveBeenCalled()
   })
 })
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -77,6 +77,8 @@ const SELECTED_THREAD_STORAGE_KEY = 'codex-web-local.selected-thread-id.v1'
 const SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY = 'codex-web-local.selected-model-by-context.v1'
 const LEGACY_SELECTED_MODEL_STORAGE_KEY = 'codex-web-local.selected-model-id.v1'
 const PROJECT_ORDER_STORAGE_KEY = 'codex-web-local.project-order.v1'
+const PINNED_PROJECT_ORDER_STORAGE_KEY = 'codex-web-local.pinned-project-order.v1'
+const PROJECT_SORT_MODE_STORAGE_KEY = 'codex-web-local.project-sort-mode.v1'
 const PROJECT_DISPLAY_NAME_STORAGE_KEY = 'codex-web-local.project-display-name.v1'
 const COLLABORATION_MODE_STORAGE_KEY = 'codex-web-local.collaboration-mode-by-context.v1'
 const LEGACY_COLLABORATION_MODE_STORAGE_KEY = 'codex-web-local.collaboration-mode.v1'
@@ -90,6 +92,7 @@ const RECENT_THREAD_MESSAGE_LOAD_REUSE_MS = 2000
 const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
 const GLOBAL_SERVER_REQUEST_SCOPE = '__global__'
 const MODEL_FALLBACK_ID = 'gpt-5.4-mini'
+export type ProjectSortMode = 'recent' | 'manual'
 
 function loadReadStateMap(): Record<string, string> {
   if (typeof window === 'undefined') return {}
@@ -488,9 +491,52 @@ function loadProjectOrder(): string[] {
   }
 }
 
+export function normalizePinnedProjectOrder(parsed: unknown): string[] {
+  if (!Array.isArray(parsed)) return []
+  const order: string[] = []
+  const seen = new Set<string>()
+  for (const item of parsed) {
+    if (typeof item !== 'string' || item.length === 0) continue
+    const normalizedItem = item.trim()
+    if (normalizedItem.length > 0 && !seen.has(normalizedItem)) {
+      order.push(normalizedItem)
+      seen.add(normalizedItem)
+    }
+  }
+  return order
+}
+
+function loadPinnedProjectOrder(): string[] {
+  if (typeof window === 'undefined') return []
+
+  try {
+    const raw = window.localStorage.getItem(PINNED_PROJECT_ORDER_STORAGE_KEY)
+    if (!raw) return []
+
+    return normalizePinnedProjectOrder(JSON.parse(raw) as unknown)
+  } catch {
+    return []
+  }
+}
+
 function saveProjectOrder(order: string[]): void {
   if (typeof window === 'undefined') return
   window.localStorage.setItem(PROJECT_ORDER_STORAGE_KEY, JSON.stringify(order))
+}
+
+function savePinnedProjectOrder(order: string[]): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(PINNED_PROJECT_ORDER_STORAGE_KEY, JSON.stringify(order))
+}
+
+function loadProjectSortMode(): ProjectSortMode {
+  if (typeof window === 'undefined') return 'recent'
+  return window.localStorage.getItem(PROJECT_SORT_MODE_STORAGE_KEY) === 'manual' ? 'manual' : 'recent'
+}
+
+function saveProjectSortMode(mode: ProjectSortMode): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(PROJECT_SORT_MODE_STORAGE_KEY, mode)
 }
 
 function loadProjectDisplayNames(): Record<string, string> {
@@ -552,6 +598,53 @@ function orderGroupsByProjectOrder(incoming: UiProjectGroup[], projectOrder: str
   }
 
   return ordered
+}
+
+export function orderGroupsByPinnedProjectOrder(incoming: UiProjectGroup[], pinnedProjectOrder: string[]): UiProjectGroup[] {
+  const incomingByName = new Map(incoming.map((group) => [group.projectName, group]))
+  const seen = new Set<string>()
+  const ordered: UiProjectGroup[] = []
+
+  for (const projectName of pinnedProjectOrder) {
+    if (seen.has(projectName)) continue
+    const group = incomingByName.get(projectName)
+    if (!group) continue
+    ordered.push(group)
+    seen.add(projectName)
+  }
+
+  for (const group of incoming) {
+    if (!seen.has(group.projectName)) {
+      ordered.push(group)
+    }
+  }
+
+  return ordered
+}
+
+export function reorderPinnedProjectOrder(
+  visibleProjectOrder: string[],
+  pinnedProjectOrder: string[],
+  projectName: string,
+  toIndex: number,
+): string[] {
+  const visibleProjectSet = new Set(visibleProjectOrder)
+  if (!visibleProjectSet.has(projectName)) return pinnedProjectOrder
+
+  const visiblePinnedOrder: string[] = []
+  const hiddenPinnedOrder: string[] = []
+  for (const pinnedProjectName of pinnedProjectOrder) {
+    if (visibleProjectSet.has(pinnedProjectName)) {
+      visiblePinnedOrder.push(pinnedProjectName)
+    } else {
+      hiddenPinnedOrder.push(pinnedProjectName)
+    }
+  }
+
+  const nextVisiblePinnedOrder = visiblePinnedOrder.filter((pinnedProjectName) => pinnedProjectName !== projectName)
+  const clampedToIndex = Math.max(0, Math.min(toIndex, nextVisiblePinnedOrder.length))
+  nextVisiblePinnedOrder.splice(clampedToIndex, 0, projectName)
+  return [...nextVisiblePinnedOrder, ...hiddenPinnedOrder]
 }
 
 function areStringArraysEqual(first?: string[], second?: string[]): boolean {
@@ -1300,6 +1393,7 @@ function isProjectlessGroup(group: UiProjectGroup): boolean {
 export function filterGroupsByWorkspaceRoots(
   groups: UiProjectGroup[],
   rootsState: WorkspaceRootsState | null,
+  projectSortMode: ProjectSortMode = 'manual',
 ): UiProjectGroup[] {
   const duplicateLeafNames = collectDuplicateProjectLeafNames(groups, rootsState)
   const disambiguatedGroups = disambiguateProjectGroupsByCwd(groups, rootsState)
@@ -1310,12 +1404,14 @@ export function filterGroupsByWorkspaceRoots(
     allowedProjectNames.add(projectName)
   }
   const filteredGroups = groupsWithWorkspaceRoots.filter((group) => allowedProjectNames.has(group.projectName) || isProjectlessGroup(group))
+  if (projectSortMode === 'recent') return filteredGroups
   return orderGroupsByWorkspaceProjectOrder(filteredGroups, rootsState, duplicateLeafNames)
 }
 
 export function useDesktopState() {
   const projectGroups = ref<UiProjectGroup[]>([])
   const sourceGroups = ref<UiProjectGroup[]>([])
+  const focusedProjectOrder = ref<string[]>([])
   const selectedThreadId = ref(loadSelectedThreadId())
   const persistedMessagesByThreadId = ref<Record<string, UiMessage[]>>({})
   const livePlanMessagesByThreadId = ref<Record<string, UiMessage[]>>({})
@@ -1365,6 +1461,8 @@ export function useDesktopState() {
   const readStateByThreadId = ref<Record<string, string>>(loadReadStateMap())
   const unreadCutoffIso = ref(loadUnreadCutoffIso())
   const projectOrder = ref<string[]>(loadProjectOrder())
+  const pinnedProjectOrder = ref<string[]>(loadPinnedProjectOrder())
+  const projectSortMode = ref<ProjectSortMode>(loadProjectSortMode())
   const projectDisplayNameById = ref<Record<string, string>>(loadProjectDisplayNames())
   const loadedVersionByThreadId = ref<Record<string, string>>({})
   const loadedMessagesByThreadId = ref<Record<string, boolean>>({})
@@ -2019,10 +2117,12 @@ export function useDesktopState() {
       sourceGroups.value = [{ projectName, threads: [nextThread] }, ...sourceGroups.value]
     }
 
-    const nextProjectOrder = mergeProjectOrder(projectOrder.value, sourceGroups.value)
-    if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
-      projectOrder.value = nextProjectOrder
-      saveProjectOrder(projectOrder.value)
+    if (projectSortMode.value === 'manual') {
+      const nextProjectOrder = mergeProjectOrder(projectOrder.value, sourceGroups.value)
+      if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
+        projectOrder.value = nextProjectOrder
+        saveProjectOrder(projectOrder.value)
+      }
     }
     applyThreadFlags()
   }
@@ -3897,45 +3997,35 @@ export function useDesktopState() {
     }
   }
 
-  function filterGroupsByWorkspaceRoots(
-    groups: UiProjectGroup[],
-    rootsState: WorkspaceRootsState | null,
-  ): UiProjectGroup[] {
-    const duplicateLeafNames = collectDuplicateProjectLeafNames(groups, rootsState)
-    const disambiguatedGroups = disambiguateProjectGroupsByCwd(groups, rootsState)
-    const groupsWithWorkspaceRoots = addWorkspaceRootPlaceholderGroups(disambiguatedGroups, rootsState, duplicateLeafNames)
-    if (!rootsState || (rootsState.order.length === 0 && (rootsState.remoteProjects ?? []).length === 0)) return groupsWithWorkspaceRoots
-    const allowedProjectNames = new Set<string>()
-    for (const projectName of getWorkspaceProjectOrderNames(rootsState, duplicateLeafNames)) {
-      allowedProjectNames.add(projectName)
-    }
-    const filteredGroups = groupsWithWorkspaceRoots.filter((group) => {
-      if (allowedProjectNames.has(group.projectName)) return true
-      return group.threads.some((thread) => isProjectlessChatPath(thread.cwd))
-    })
-    return orderGroupsByWorkspaceProjectOrder(filteredGroups, rootsState, duplicateLeafNames)
-  }
-
   function applyThreadGroups(groups: UiProjectGroup[], rootsState: WorkspaceRootsState | null): void {
-    const visibleGroups = filterGroupsByWorkspaceRoots(groups, rootsState)
+    const visibleGroups = filterGroupsByWorkspaceRoots(groups, rootsState, projectSortMode.value)
     const hasWorkspaceRootsState = Boolean(
       rootsState && (rootsState.order.length > 0 || rootsState.projectOrder.length > 0 || (rootsState.remoteProjects ?? []).length > 0),
     )
 
-    const nextProjectOrder = rootsState?.projectOrder.length
-      ? mergeProjectOrder(
-        getWorkspaceProjectOrderNames(rootsState, collectDuplicateProjectLeafNames(groups, rootsState)),
-        visibleGroups,
-      )
-      : mergeProjectOrder(projectOrder.value, visibleGroups)
-    if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
-      projectOrder.value = nextProjectOrder
-      if (!hasWorkspaceRootsState) {
-        saveProjectOrder(projectOrder.value)
+    if (projectSortMode.value === 'manual') {
+      const nextProjectOrder = rootsState?.projectOrder.length
+        ? mergeProjectOrder(
+          getWorkspaceProjectOrderNames(rootsState, collectDuplicateProjectLeafNames(groups, rootsState)),
+          visibleGroups,
+        )
+        : mergeProjectOrder(projectOrder.value, visibleGroups)
+      if (!areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
+        projectOrder.value = nextProjectOrder
+        if (!hasWorkspaceRootsState) {
+          saveProjectOrder(projectOrder.value)
+        }
       }
     }
 
-    const orderedGroups = orderGroupsByProjectOrder(visibleGroups, projectOrder.value)
+    const pinnedProjectNameSet = new Set(pinnedProjectOrder.value)
+    const recentProjectOrder = [
+      ...pinnedProjectOrder.value,
+      ...focusedProjectOrder.value.filter((projectName) => !pinnedProjectNameSet.has(projectName)),
+    ]
+    const orderedGroups = projectSortMode.value === 'manual'
+      ? orderGroupsByProjectOrder(visibleGroups, projectOrder.value)
+      : orderGroupsByPinnedProjectOrder(visibleGroups, recentProjectOrder)
     markServerListedThreads(new Set(flattenThreads(orderedGroups).map((thread) => thread.id)))
     const mergedWithInProgress = mergeIncomingWithLocalInProgressThreads(
       sourceGroups.value,
@@ -4967,6 +5057,13 @@ export function useDesktopState() {
       saveProjectOrder(projectOrder.value)
     }
 
+    const nextPinnedProjectOrder = pinnedProjectOrder.value.filter((name) => name !== projectName)
+    if (!areStringArraysEqual(pinnedProjectOrder.value, nextPinnedProjectOrder)) {
+      pinnedProjectOrder.value = nextPinnedProjectOrder
+      savePinnedProjectOrder(pinnedProjectOrder.value)
+    }
+    focusedProjectOrder.value = focusedProjectOrder.value.filter((name) => name !== projectName)
+
     sourceGroups.value = sourceGroups.value.filter((group) => group.projectName !== projectName)
 
     if (projectDisplayNameById.value[projectName] !== undefined) {
@@ -5019,15 +5116,45 @@ export function useDesktopState() {
     await persistProjectOrderToWorkspaceRoots()
   }
 
+  function setProjectSortMode(mode: ProjectSortMode): void {
+    if (projectSortMode.value === mode) return
+    projectSortMode.value = mode
+    saveProjectSortMode(mode)
+    applyThreadGroups(
+      loadedThreadListGroups.length > 0 ? loadedThreadListGroups : sourceGroups.value,
+      loadedThreadListRootsState,
+    )
+  }
+
   function reorderProject(projectName: string, toIndex: number): void {
     if (projectName.length === 0) return
     if (sourceGroups.value.length === 0) return
 
-    const visibleOrder = sourceGroups.value.map((group) => group.projectName)
+    const visibleOrder = projectGroups.value.map((group) => group.projectName)
     const fromIndex = visibleOrder.indexOf(projectName)
     if (fromIndex === -1) return
 
     const clampedToIndex = Math.max(0, Math.min(toIndex, visibleOrder.length - 1))
+
+    if (projectSortMode.value === 'recent') {
+      const nextPinnedProjectOrder = reorderPinnedProjectOrder(
+        visibleOrder,
+        pinnedProjectOrder.value,
+        projectName,
+        clampedToIndex,
+      )
+      const pinnedOrderChanged = !areStringArraysEqual(pinnedProjectOrder.value, nextPinnedProjectOrder)
+      if (!pinnedOrderChanged) return
+
+      pinnedProjectOrder.value = nextPinnedProjectOrder
+      savePinnedProjectOrder(pinnedProjectOrder.value)
+      applyThreadGroups(
+        loadedThreadListGroups.length > 0 ? loadedThreadListGroups : sourceGroups.value,
+        loadedThreadListRootsState,
+      )
+      return
+    }
+
     const reorderedVisibleOrder = reorderStringArray(visibleOrder, fromIndex, clampedToIndex)
     if (reorderedVisibleOrder === visibleOrder) return
 
@@ -5044,15 +5171,98 @@ export function useDesktopState() {
   function pinProjectToTop(projectName: string): void {
     const normalizedName = projectName.trim()
     if (!normalizedName) return
-    const nextOrder = [normalizedName, ...projectOrder.value.filter((name) => name !== normalizedName)]
-    if (areStringArraysEqual(projectOrder.value, nextOrder)) return
-    projectOrder.value = nextOrder
-    saveProjectOrder(projectOrder.value)
+    const nextPinnedProjectOrder = [normalizedName, ...pinnedProjectOrder.value.filter((name) => name !== normalizedName)]
+    const pinnedOrderChanged = !areStringArraysEqual(pinnedProjectOrder.value, nextPinnedProjectOrder)
 
+    if (pinnedOrderChanged) {
+      pinnedProjectOrder.value = nextPinnedProjectOrder
+      savePinnedProjectOrder(pinnedProjectOrder.value)
+    }
+
+    if (projectSortMode.value === 'recent') {
+      if (!pinnedOrderChanged) {
+        applyThreadFlags()
+        return
+      }
+      applyThreadGroups(
+        loadedThreadListGroups.length > 0 ? loadedThreadListGroups : sourceGroups.value,
+        loadedThreadListRootsState,
+      )
+      return
+    }
+
+    const nextProjectOrder = [normalizedName, ...projectOrder.value.filter((name) => name !== normalizedName)]
+    const projectOrderChanged = !areStringArraysEqual(projectOrder.value, nextProjectOrder)
+    if (!projectOrderChanged) {
+      applyThreadFlags()
+      return
+    }
+
+    projectOrder.value = nextProjectOrder
+    saveProjectOrder(projectOrder.value)
     const orderedGroups = orderGroupsByProjectOrder(sourceGroups.value, projectOrder.value)
     sourceGroups.value = mergeThreadGroups(sourceGroups.value, orderedGroups)
     applyThreadFlags()
     void persistProjectOrderToWorkspaceRoots()
+  }
+
+  function focusProjectToTop(projectName: string): void {
+    const normalizedName = projectName.trim()
+    if (!normalizedName) return
+
+    if (projectSortMode.value === 'recent') {
+      focusedProjectOrder.value = [
+        normalizedName,
+        ...focusedProjectOrder.value.filter((name) => name !== normalizedName),
+      ]
+      applyThreadGroups(
+        loadedThreadListGroups.length > 0 ? loadedThreadListGroups : sourceGroups.value,
+        loadedThreadListRootsState,
+      )
+      return
+    }
+
+    const nextProjectOrder = [normalizedName, ...projectOrder.value.filter((name) => name !== normalizedName)]
+    if (areStringArraysEqual(projectOrder.value, nextProjectOrder)) {
+      applyThreadFlags()
+      return
+    }
+
+    projectOrder.value = nextProjectOrder
+    saveProjectOrder(projectOrder.value)
+    const orderedGroups = orderGroupsByProjectOrder(sourceGroups.value, projectOrder.value)
+    sourceGroups.value = mergeThreadGroups(sourceGroups.value, orderedGroups)
+    applyThreadFlags()
+    void persistProjectOrderToWorkspaceRoots()
+  }
+
+  function unpinProject(projectName: string): void {
+    const normalizedName = projectName.trim()
+    if (!normalizedName) return
+    const nextPinnedProjectOrder = pinnedProjectOrder.value.filter((name) => name !== normalizedName)
+    if (areStringArraysEqual(pinnedProjectOrder.value, nextPinnedProjectOrder)) return
+
+    pinnedProjectOrder.value = nextPinnedProjectOrder
+    savePinnedProjectOrder(pinnedProjectOrder.value)
+    focusedProjectOrder.value = focusedProjectOrder.value.filter((name) => name !== normalizedName)
+    if (projectSortMode.value === 'recent') {
+      applyThreadGroups(
+        loadedThreadListGroups.length > 0 ? loadedThreadListGroups : sourceGroups.value,
+        loadedThreadListRootsState,
+      )
+      return
+    }
+    applyThreadFlags()
+  }
+
+  function toggleProjectPinned(projectName: string): void {
+    const normalizedName = projectName.trim()
+    if (!normalizedName) return
+    if (pinnedProjectOrder.value.includes(normalizedName)) {
+      unpinProject(normalizedName)
+      return
+    }
+    pinProjectToTop(normalizedName)
   }
 
   async function persistProjectOrderToWorkspaceRoots(): Promise<void> {
@@ -5324,6 +5534,8 @@ export function useDesktopState() {
     selectedLiveOverlay,
     codexQuota,
     selectedThreadId,
+    projectSortMode,
+    pinnedProjectOrder,
     availableCollaborationModes,
     availableModelIds,
     selectedCollaborationMode,
@@ -5372,7 +5584,11 @@ export function useDesktopState() {
     renameProject,
     removeProject,
     reorderProject,
+    setProjectSortMode,
     pinProjectToTop,
+    focusProjectToTop,
+    unpinProject,
+    toggleProjectPinned,
     startPolling,
     stopPolling,
     primeSelectedThread,

--- a/src/style.css
+++ b/src/style.css
@@ -239,6 +239,10 @@
   @apply text-zinc-300;
 }
 
+:root.dark .project-pin-indicator {
+  @apply text-zinc-400;
+}
+
 :root.dark .thread-composer-shell {
   @apply border-zinc-700 bg-zinc-800;
 }
@@ -431,6 +435,12 @@
 
 :root.dark .project-menu-item {
   @apply text-zinc-300 hover:bg-zinc-700;
+}
+
+:root.dark .project-reorder-button,
+:root.dark .project-move-done-button,
+:root.dark .project-move-handle {
+  @apply border-zinc-600 bg-zinc-800 text-zinc-300 hover:bg-zinc-700;
 }
 
 :root.dark .thread-menu-panel {

--- a/tests.md
+++ b/tests.md
@@ -19,6 +19,39 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - <cleanup action, if any>
 
+### Feature: Project recency sort, pins, and mobile move mode
+
+#### Prerequisites
+- App is running from this repository on `feature/project-recency-sort-upstream`.
+- At least two visible projects exist with threads updated at different times.
+- Light and dark themes are both available from Settings.
+
+#### Steps
+1. Open the sidebar in light theme.
+2. Open Projects -> Organize and confirm `Recent projects` is selected by default.
+3. Confirm projects appear in descending recent thread activity order.
+4. Tap the Projects header reorder icon and confirm move mode starts, all current project thread lists collapse, and drag handles are visible.
+5. Drag a non-top project above the first project while still in recent mode.
+6. Confirm the moved project appears in the pinned prefix, recent mode remains selected, and project threads do not expand from the drag release.
+7. Tap `Done`, open the moved project's menu, choose `Unpin project`, and confirm it returns to its recency-derived position.
+8. Switch to `Manual project order`, drag a project, and confirm the manual order sticks independently of recent-mode pins.
+9. Enter sidebar search text and confirm project move mode/dragging cannot start while the project list is filtered.
+10. Repeat steps 1-9 in dark theme.
+
+#### Expected Results
+- Recent mode ignores saved manual `projectOrder` except for explicit pinned project overrides.
+- Recent-mode drags pin the moved project without switching the persisted sort mode to manual.
+- Recent-mode drag and pin actions update only the pinned project override list and do not rewrite saved manual order.
+- Unpinning removes the override and restores the project to recency order.
+- Manual project order remains a separate full-list ordering mode.
+- Move mode collapses project thread lists, restores prior expansion state on exit, and is blocked while search filters the sidebar.
+- Reorder icon, `Done`, drag handles, pin labels, and menus remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Tap `Done` to leave move mode.
+- Reset the sidebar Organize menu to the preferred project sort mode.
+- Remove any temporary chats or workspace roots created for verification.
+
 ### Feature: Thread heartbeat automations
 
 #### Prerequisites


### PR DESCRIPTION
## Summary

- add a Recent projects sort mode for the sidebar, with Manual project order still available from Organize
- support project pinning while in recent mode, so drag-reordered projects stay above recency ordering until unpinned
- add a Projects header reorder control and touch-friendly move mode for project reordering
- collapse project thread lists while move mode is active and restore prior expansion state on exit

## Testing

- `pnpm exec vitest run src/components/sidebar/projectMoveMode.test.ts src/composables/useDesktopState.test.ts`
- `pnpm run build:frontend`
- `git diff --check main..HEAD`
