### PR TITLE
Open selected skill markdown from composer chip

### DIFF
--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -64,7 +64,15 @@
 
       <div v-if="selectedSkills.length > 0" class="thread-composer-skill-chips">
         <span v-for="skill in selectedSkills" :key="skill.path" class="thread-composer-skill-chip">
-          <span class="thread-composer-skill-chip-name">{{ skill.displayName || skill.name }}</span>
+          <button
+            class="thread-composer-skill-chip-name"
+            type="button"
+            :title="skillMarkdownPath(skill.path)"
+            :aria-label="`Open ${skill.displayName || skill.name} SKILL.md`"
+            @click="openSkillMarkdown(skill)"
+          >
+            {{ skill.displayName || skill.name }}
+          </button>
           <button
             class="thread-composer-skill-chip-remove"
             type="button"
@@ -1146,6 +1154,18 @@ function removeSkill(path: string): void {
   selectedSkills.value = selectedSkills.value.filter((s) => s.path !== path)
 }
 
+function skillMarkdownPath(path: string): string {
+  const trimmed = path.trim()
+  if (!trimmed) return ''
+  return trimmed.endsWith('/SKILL.md') ? trimmed : `${trimmed.replace(/\/+$/, '')}/SKILL.md`
+}
+
+function openSkillMarkdown(skill: SkillItem): void {
+  const markdownPath = skillMarkdownPath(skill.path)
+  if (!markdownPath || typeof window === 'undefined') return
+  window.open(`/codex-local-browse${encodeURI(markdownPath)}`, '_blank', 'noopener,noreferrer')
+}
+
 function removeFileAttachment(fsPath: string): void {
   fileAttachments.value = fileAttachments.value.filter((a) => a.fsPath !== fsPath)
 }
@@ -1887,7 +1907,7 @@ watch(
 }
 
 .thread-composer-skill-chip-name {
-  @apply font-medium;
+  @apply min-w-0 max-w-[12rem] truncate border-0 bg-transparent p-0 text-left font-medium text-inherit underline-offset-2 transition hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-500;
 }
 
 .thread-composer-skill-chip-remove {

--- a/tests.md
+++ b/tests.md
@@ -254,6 +254,9 @@ Unread thread state uses a local cutoff timestamp so existing threads are not al
 
 #### Rollback/Cleanup
 - Remove any disposable test threads created for this validation.
+
+---
+
 ### CLI password output redaction
 
 #### Feature/Change Name
@@ -280,6 +283,38 @@ CLI startup output no longer prints the configured password or embeds it in the 
 
 #### Rollback/Cleanup
 - Stop the disposable CLI process.
+
+---
+
+### Composer skill chip opens SKILL.md
+
+#### Feature/Change Name
+Selected skill labels in the thread composer open that skill's `SKILL.md` in the web file browser.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. At least one installed skill is available in the composer skill picker
+3. Browser pop-ups from the local dev origin are allowed
+4. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, open any thread with the composer enabled.
+2. Open the `Skills` picker and select an installed skill.
+3. Confirm the selected skill appears as a green chip above the input field.
+4. Click the skill name on the green chip.
+5. Confirm a new tab opens to `/codex-local-browse.../SKILL.md` for that skill.
+6. Return to the composer and click the chip `x`.
+7. Confirm the skill is removed and no file-browser tab is opened by the remove action.
+8. Switch to dark theme and repeat steps 2 through 7.
+
+#### Expected Results
+- The skill chip label is clickable and opens the selected skill's `SKILL.md` in the web file browser.
+- Skill paths that point at a skill directory are normalized to the nested `SKILL.md` file.
+- The remove button still only removes the skill from the composer.
+- The chip and focus/hover states remain readable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Close any file-browser tabs opened during validation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Make selected composer skill chip labels open their SKILL.md in the web file browser
- Keep the remove button behavior separate
- Add manual light/dark verification coverage to tests.md

## Tests
- pnpm run build:frontend