### PR TITLE
Show selected skills on chat messages

### DIFF
--- a/src/api/normalizers/v2.test.ts
+++ b/src/api/normalizers/v2.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeThreadMessagesV2 } from './v2'
+import type { ThreadReadResponse } from '../appServerDtos'
+
+function threadReadResponseWithContent(content: ThreadReadResponse['thread']['turns'][number]['items'][number][]): ThreadReadResponse {
+  return {
+    thread: {
+      id: 'thread-1',
+      preview: 'Use a skill',
+      modelProvider: 'openai',
+      createdAt: 1,
+      updatedAt: 2,
+      path: null,
+      cwd: '/tmp/project',
+      cliVersion: 'test',
+      source: 'appServer',
+      gitInfo: null,
+      turns: [{
+        id: 'turn-1',
+        status: 'completed',
+        error: null,
+        items: content,
+      }],
+    },
+  }
+}
+
+describe('normalizeThreadMessagesV2', () => {
+  it('preserves selected skill inputs on the rendered user message', () => {
+    const messages = normalizeThreadMessagesV2(threadReadResponseWithContent([{
+      type: 'userMessage',
+      id: 'user-1',
+      content: [
+        { type: 'text', text: 'Use the browser skill', text_elements: [] },
+        { type: 'skill', name: 'browser-use:browser', path: '/Users/igor/.codex/skills/browser/SKILL.md' },
+      ],
+    }]))
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({
+      id: 'user-1',
+      role: 'user',
+      text: 'Use the browser skill',
+      skills: [{ name: 'browser-use:browser', path: '/Users/igor/.codex/skills/browser/SKILL.md' }],
+    })
+  })
+
+  it('renders skill-only user messages instead of dropping them as raw blocks', () => {
+    const messages = normalizeThreadMessagesV2(threadReadResponseWithContent([{
+      type: 'userMessage',
+      id: 'user-2',
+      content: [
+        { type: 'skill', name: 'composio-cli', path: '/Users/igor/.codex/skills/composio-cli/SKILL.md' },
+      ],
+    }]))
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({
+      id: 'user-2',
+      role: 'user',
+      text: '',
+      skills: [{ name: 'composio-cli', path: '/Users/igor/.codex/skills/composio-cli/SKILL.md' }],
+    })
+    expect(messages[0].isUnhandled).toBeUndefined()
+  })
+})

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -110,17 +110,19 @@ function parseUserMessageContent(
 ): {
   text: string
   images: string[]
+  skills: Array<{ name: string; path: string }>
   fileAttachments: UiFileAttachment[]
   rawBlocks: UiMessage[]
   isAutomationRun: boolean
   automationDisplayName: string | null
 } {
   if (!Array.isArray(content)) {
-    return { text: '', images: [], fileAttachments: [], rawBlocks: [], isAutomationRun: false, automationDisplayName: null }
+    return { text: '', images: [], skills: [], fileAttachments: [], rawBlocks: [], isAutomationRun: false, automationDisplayName: null }
   }
 
   const textChunks: string[] = []
   const images: string[] = []
+  const skills: Array<{ name: string; path: string }> = []
   const rawBlocks: UiMessage[] = []
 
   for (const [index, block] of content.entries()) {
@@ -133,8 +135,15 @@ function parseUserMessageContent(
     if (block.type === 'localImage' && typeof block.path === 'string' && block.path.trim().length > 0) {
       images.push(toLocalImageUrl(block.path.trim()))
     }
+    if (block.type === 'skill') {
+      const name = typeof block.name === 'string' ? block.name.trim() : ''
+      const path = typeof block.path === 'string' ? block.path.trim() : ''
+      if (name && path) {
+        skills.push({ name, path })
+      }
+    }
 
-    if (block.type !== 'text' && block.type !== 'image' && block.type !== 'localImage') {
+    if (block.type !== 'text' && block.type !== 'image' && block.type !== 'localImage' && block.type !== 'skill') {
       rawBlocks.push({
         id: `${itemId}:user-content:${index}`,
         role: 'user',
@@ -153,6 +162,7 @@ function parseUserMessageContent(
   return {
     text: heartbeat?.instructions ?? extractCodexUserRequestText(fullText),
     images,
+    skills,
     fileAttachments,
     rawBlocks,
     isAutomationRun: heartbeat !== null,
@@ -390,7 +400,7 @@ function toUiMessages(item: ThreadItem): UiMessage[] {
   if (item.type === 'userMessage') {
     const parsed = parseUserMessageContent(item.id, item.content as UserInput[] | undefined)
     const messages: UiMessage[] = []
-    const hasRenderableUserContent = parsed.text.length > 0 || parsed.images.length > 0 || parsed.fileAttachments.length > 0
+    const hasRenderableUserContent = parsed.text.length > 0 || parsed.images.length > 0 || parsed.fileAttachments.length > 0 || parsed.skills.length > 0
 
     if (hasRenderableUserContent) {
       messages.push({
@@ -398,6 +408,7 @@ function toUiMessages(item: ThreadItem): UiMessage[] {
         role: parsed.isAutomationRun ? 'system' : 'user',
         text: parsed.text,
         images: parsed.images,
+        skills: parsed.skills.length > 0 ? parsed.skills : undefined,
         fileAttachments: parsed.fileAttachments.length > 0 ? parsed.fileAttachments : undefined,
         messageType: item.type,
         isAutomationRun: parsed.isAutomationRun,

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -230,6 +230,13 @@
                 </span>
               </div>
 
+              <div v-if="message.skills && message.skills.length > 0" class="message-skill-attachments">
+                <span v-for="skill in message.skills" :key="`${message.id}:${skill.path}`" class="message-skill-chip" :title="skill.path">
+                  <span class="message-skill-chip-prefix">Skill</span>
+                  <span class="message-skill-chip-name">{{ skill.name }}</span>
+                </span>
+              </div>
+
               <article v-if="message.text.length > 0" class="message-card" :data-role="message.role">
                 <div v-if="message.messageType === 'worked'" class="worked-separator-wrap" aria-live="polite">
                   <button type="button" class="worked-separator" @click="toggleWorkedExpand(message)">
@@ -4467,8 +4474,24 @@ onBeforeUnmount(() => {
   @apply mb-2 flex flex-wrap gap-1.5;
 }
 
+.message-skill-attachments {
+  @apply mb-2 flex flex-wrap justify-end gap-1.5;
+}
+
 .message-file-chip {
   @apply inline-flex items-center gap-1 rounded-md border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-xs text-zinc-700;
+}
+
+.message-skill-chip {
+  @apply inline-flex max-w-full items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-800;
+}
+
+.message-skill-chip-prefix {
+  @apply shrink-0 font-medium text-emerald-700;
+}
+
+.message-skill-chip-name {
+  @apply min-w-0 max-w-48 truncate font-mono;
 }
 
 .message-file-chip-icon {
@@ -4834,6 +4857,18 @@ onBeforeUnmount(() => {
 .message-card[data-role='assistant'],
 .message-card[data-role='system'] {
   @apply px-0 py-0 bg-transparent border-none rounded-none;
+}
+
+:global(.dark) .message-file-chip {
+  @apply border-zinc-700 bg-zinc-900 text-zinc-200;
+}
+
+:global(.dark) .message-skill-chip {
+  @apply border-emerald-800/70 bg-emerald-950/50 text-emerald-100;
+}
+
+:global(.dark) .message-skill-chip-prefix {
+  @apply text-emerald-300;
 }
 
 .conversation-item[data-message-type='worked'] .message-stack,

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -231,10 +231,16 @@
               </div>
 
               <div v-if="message.skills && message.skills.length > 0" class="message-skill-attachments">
-                <span v-for="skill in message.skills" :key="`${message.id}:${skill.path}`" class="message-skill-chip" :title="skill.path">
+                <a
+                  v-for="skill in message.skills"
+                  :key="`${message.id}:${skill.path}`"
+                  class="message-skill-chip"
+                  :href="toBrowseUrl(skill.path)"
+                  :title="skill.path"
+                >
                   <span class="message-skill-chip-prefix">Skill</span>
                   <span class="message-skill-chip-name">{{ skill.name }}</span>
-                </span>
+                </a>
               </div>
 
               <article v-if="message.text.length > 0" class="message-card" :data-role="message.role">
@@ -4483,7 +4489,7 @@ onBeforeUnmount(() => {
 }
 
 .message-skill-chip {
-  @apply inline-flex max-w-full items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-800;
+  @apply inline-flex max-w-full items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-800 no-underline transition hover:border-emerald-300 hover:bg-emerald-100 hover:text-emerald-900;
 }
 
 .message-skill-chip-prefix {

--- a/src/server/codexAppServerBridge.inlinePayload.test.ts
+++ b/src/server/codexAppServerBridge.inlinePayload.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
+import { mergeSessionSkillInputsIntoTurns, sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
 
 const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 const pngDataUrl = `data:image/png;base64,${pngBase64}`
@@ -224,5 +224,76 @@ describe('thread inline media sanitization', () => {
     const result = await sanitizeThreadTurnsInlinePayloads('thread/list', payload)
 
     expect(result).toBe(payload)
+  })
+})
+
+describe('thread session skill recovery', () => {
+  it('adds selected skill inputs from session JSONL to matching user messages', () => {
+    const turns = [{
+      id: 'turn-1',
+      items: [{
+        id: 'item-1',
+        type: 'userMessage',
+        content: [{ type: 'text', text: 'use a skill', text_elements: [] }],
+      }],
+    }]
+    const sessionLog = [
+      JSON.stringify({ type: 'turn_context', payload: { turn_id: 'turn-1' } }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'use a skill' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<skill>\n<name>browser-use:browser</name>\n<path>/Users/igor/.codex/plugins/browser/SKILL.md</path>\n---\n# Browser\n</skill>',
+          }],
+        },
+      }),
+    ].join('\n')
+
+    const merged = mergeSessionSkillInputsIntoTurns(turns, sessionLog) as typeof turns
+    expect(merged[0].items[0].content).toEqual([
+      { type: 'text', text: 'use a skill', text_elements: [] },
+      { type: 'skill', name: 'browser-use:browser', path: '/Users/igor/.codex/plugins/browser/SKILL.md' },
+    ])
+  })
+
+  it('does not duplicate skill inputs that are already present', () => {
+    const turns = [{
+      id: 'turn-1',
+      items: [{
+        id: 'item-1',
+        type: 'userMessage',
+        content: [
+          { type: 'text', text: 'use a skill', text_elements: [] },
+          { type: 'skill', name: 'browser-use:browser', path: '/Users/igor/.codex/plugins/browser/SKILL.md' },
+        ],
+      }],
+    }]
+    const sessionLog = [
+      JSON.stringify({ type: 'turn_context', payload: { turn_id: 'turn-1' } }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{
+            type: 'input_text',
+            text: '<skill>\n<name>browser-use:browser</name>\n<path>/Users/igor/.codex/plugins/browser/SKILL.md</path>\n</skill>',
+          }],
+        },
+      }),
+    ].join('\n')
+
+    expect(mergeSessionSkillInputsIntoTurns(turns, sessionLog)).toBe(turns)
   })
 })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -243,6 +243,145 @@ type SessionRecoveredTurnFileChanges = {
   fileChanges: SessionRecoveredFileChange[]
 }
 
+type SessionRecoveredSkillInput = {
+  name: string
+  path: string
+}
+
+function parseSessionSkillText(value: string): SessionRecoveredSkillInput | null {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('<skill>')) return null
+  const name = trimmed.match(/<name>\s*([\s\S]*?)\s*<\/name>/u)?.[1]?.trim() ?? ''
+  const path = trimmed.match(/<path>\s*([\s\S]*?)\s*<\/path>/u)?.[1]?.trim() ?? ''
+  if (!name || !path) return null
+  return { name, path }
+}
+
+function buildSessionSkillInputsByTurn(sessionLogRaw: string, turnIds: Set<string>): Map<string, SessionRecoveredSkillInput[]> {
+  let currentTurnId = ''
+  const skillsByTurnId = new Map<string, SessionRecoveredSkillInput[]>()
+
+  for (const line of sessionLogRaw.split('\n')) {
+    if (!line.trim()) continue
+    let row: Record<string, unknown> | null = null
+    try {
+      row = JSON.parse(line) as Record<string, unknown>
+    } catch {
+      continue
+    }
+
+    if (row.type === 'turn_context') {
+      const payloadRecord = asRecord(row.payload)
+      currentTurnId = readNonEmptyString(payloadRecord?.turn_id) || currentTurnId
+      continue
+    }
+    if (row.type === 'event_msg') {
+      const payloadRecord = asRecord(row.payload)
+      if (payloadRecord?.type === 'task_started') {
+        currentTurnId = readNonEmptyString(payloadRecord.turn_id) || currentTurnId
+      }
+      continue
+    }
+
+    if (row.type !== 'response_item' || !currentTurnId || !turnIds.has(currentTurnId)) continue
+    const payloadRecord = asRecord(row.payload)
+    if (payloadRecord?.type !== 'message' || payloadRecord.role !== 'user') continue
+    const content = Array.isArray(payloadRecord.content) ? payloadRecord.content : []
+
+    for (const contentItem of content) {
+      const contentRecord = asRecord(contentItem)
+      if (contentRecord?.type !== 'input_text' || typeof contentRecord.text !== 'string') continue
+      const skill = parseSessionSkillText(contentRecord.text)
+      if (!skill) continue
+      const existing = skillsByTurnId.get(currentTurnId) ?? []
+      if (!existing.some((item) => item.path === skill.path)) {
+        existing.push(skill)
+        skillsByTurnId.set(currentTurnId, existing)
+      }
+    }
+  }
+
+  return skillsByTurnId
+}
+
+export function mergeSessionSkillInputsIntoTurns(turns: unknown[], sessionLogRaw: string): unknown[] {
+  const turnIds = new Set<string>()
+  for (const turn of turns) {
+    const turnRecord = asRecord(turn)
+    const turnId = readNonEmptyString(turnRecord?.id)
+    if (turnId) turnIds.add(turnId)
+  }
+  if (turnIds.size === 0) return turns
+
+  const skillsByTurnId = buildSessionSkillInputsByTurn(sessionLogRaw, turnIds)
+  if (skillsByTurnId.size === 0) return turns
+
+  let changed = false
+  const nextTurns = turns.map((turn) => {
+    const turnRecord = asRecord(turn)
+    const turnId = readNonEmptyString(turnRecord?.id)
+    const skills = turnId ? skillsByTurnId.get(turnId) : undefined
+    const items = Array.isArray(turnRecord?.items) ? turnRecord.items : null
+    if (!turnRecord || !skills || skills.length === 0 || !items) return turn
+
+    let addedToTurn = false
+    const nextItems = items.map((item) => {
+      const itemRecord = asRecord(item)
+      const content = Array.isArray(itemRecord?.content) ? itemRecord.content : null
+      if (addedToTurn || itemRecord?.type !== 'userMessage' || !content) return item
+
+      const existingSkillPaths = new Set(
+        content.flatMap((contentItem) => {
+          const contentRecord = asRecord(contentItem)
+          const path = typeof contentRecord?.path === 'string' ? contentRecord.path.trim() : ''
+          return contentRecord?.type === 'skill' && path ? [path] : []
+        }),
+      )
+      const missingSkills = skills.filter((skill) => !existingSkillPaths.has(skill.path))
+      if (missingSkills.length === 0) return item
+
+      addedToTurn = true
+      changed = true
+      return {
+        ...itemRecord,
+        content: [
+          ...content,
+          ...missingSkills.map((skill) => ({ type: 'skill', name: skill.name, path: skill.path })),
+        ],
+      }
+    })
+
+    return addedToTurn ? { ...turnRecord, items: nextItems } : turn
+  })
+
+  return changed ? nextTurns : turns
+}
+
+async function mergeSessionSkillInputsIntoThreadResult(result: unknown): Promise<unknown> {
+  const record = asRecord(result)
+  const thread = asRecord(record?.thread)
+  const turns = Array.isArray(thread?.turns) ? thread.turns : null
+  const sessionPath = readNonEmptyString(thread?.path)
+  if (!record || !thread || !turns || turns.length === 0 || !sessionPath || !isAbsolute(sessionPath)) {
+    return result
+  }
+
+  try {
+    const sessionLogRaw = await readFile(sessionPath, 'utf8')
+    const mergedTurns = mergeSessionSkillInputsIntoTurns(turns, sessionLogRaw)
+    if (mergedTurns === turns) return result
+    return {
+      ...record,
+      thread: {
+        ...thread,
+        turns: mergedTurns,
+      },
+    }
+  } catch {
+    return result
+  }
+}
+
 function readEnvValueFromFile(filePath: string, key: string): string | null {
   try {
     const content = readFileSync(filePath, 'utf8')
@@ -5405,7 +5544,10 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
         const rpcResult = await callRpcWithArchiveRecovery(appServer, body.method, body.params ?? null)
         const trimmedResult = trimThreadTurnsInRpcResult(body.method, rpcResult)
-        const result = await sanitizeThreadTurnsInlinePayloads(body.method, trimmedResult)
+        const sanitizedResult = await sanitizeThreadTurnsInlinePayloads(body.method, trimmedResult)
+        const result = THREAD_METHODS_WITH_TURNS.has(body.method)
+          ? await mergeSessionSkillInputsIntoThreadResult(sanitizedResult)
+          : sanitizedResult
 
         if (THREAD_METHODS_WITH_TURNS.has(body.method)) {
           const rpcRecord = asRecord(result)

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -206,6 +206,7 @@ export type UiMessage = {
   role: 'user' | 'assistant' | 'system'
   text: string
   images?: string[]
+  skills?: Array<{ name: string; path: string }>
   fileAttachments?: UiFileAttachment[]
   fileChanges?: UiFileChange[]
   fileChangeStatus?: UiFileChangeStatus

--- a/tests.md
+++ b/tests.md
@@ -462,123 +462,34 @@ The accidental `npx run dev` command starts the repository dev wrapper instead o
 
 ---
 
-### Unread thread cutoff state
+### Selected skills visible on sent chat messages
 
 #### Feature/Change Name
-Unread thread state uses a local cutoff timestamp so existing threads are not all marked unread after first load.
-
-#### Prerequisites/Setup
-1. Dev server running (`pnpm run dev`).
-2. Browser localStorage is available for the app origin.
-3. At least two existing threads are present.
-4. Light theme and dark theme are available from the appearance switcher.
-
-#### Steps
-1. Clear only `codex-web-local.thread-unread-cutoff.v1` from localStorage for the app origin.
-2. Load the app in light theme.
-3. Confirm existing threads are not all marked unread on first load.
-4. Create or receive an update in a different thread after the app has loaded.
-5. Confirm that updated thread can show unread when it is not selected or in progress.
-6. Create or receive an update in a second unselected thread.
-7. Open the first updated thread and confirm only that thread's unread indicator clears.
-8. Confirm the second updated thread remains unread until it is opened.
-9. Switch to dark theme and repeat steps 4 through 8.
-
-#### Expected Results
-- Missing cutoff state initializes to the current time instead of treating every thread as unread.
-- Threads updated after the cutoff can still become unread.
-- Opening a thread updates only that thread's read state and clears only that thread's unread indicator.
-- Unread indicators remain readable in both light theme and dark theme.
-
-#### Rollback/Cleanup
-- Remove any disposable test threads created for this validation.
-
----
-
-### CLI password output redaction
-
-#### Feature/Change Name
-CLI startup output no longer prints the configured password or embeds it in the tunnel URL.
-
-#### Prerequisites/Setup
-1. Project dependencies are installed.
-2. CLI build is available from the current branch.
-
-#### Steps
-1. Run `pnpm run build:cli`.
-2. Start the CLI with a disposable password: `node dist-cli/index.js --no-tunnel --no-open --port 5998 --password TEST_SECRET_SHOULD_NOT_PRINT`.
-3. Confirm startup output includes the local and network URLs.
-4. Confirm startup output does not include `Password:` or `TEST_SECRET_SHOULD_NOT_PRINT`.
-5. Start the CLI without an explicit password and confirm startup output prints `Generated password file:` with a path under `$CODEX_HOME`.
-6. Confirm the generated password file exists, is readable by the current user, and has `0600` permissions.
-7. If tunnel testing is available, start with tunnel enabled and confirm the printed tunnel URL and QR code do not include `/password=`.
-
-#### Expected Results
-- Password-protected startup still works.
-- The password is not printed as a standalone line.
-- Auto-generated passwords remain discoverable through the generated password file path.
-- Tunnel output does not include an autologin URL containing the password.
-
-#### Rollback/Cleanup
-- Stop the disposable CLI process.
-
----
-
-### Composer skill chip opens SKILL.md
-
-#### Feature/Change Name
-Selected skill labels in the thread composer open that skill's `SKILL.md` in the web file browser.
+Selected composer skills are shown as skill chips on the user message after send/history load.
 
 #### Prerequisites/Setup
 1. Dev server running (`pnpm run dev`)
-2. At least one installed skill is available in the composer skill picker
-3. Browser pop-ups from the local dev origin are allowed
-4. Light theme and dark theme are available from the appearance switcher
+2. At least one installed skill is available in the composer `Skills` dropdown
+3. Light theme and dark theme both available from the appearance switcher
 
 #### Steps
-1. In light theme, open any thread with the composer enabled.
-2. Open the `Skills` picker and select an installed skill.
-3. Confirm the selected skill appears as a green chip above the input field.
-4. Click the skill name on the green chip.
-5. Confirm a new tab opens to `/codex-local-browse.../SKILL.md` for that skill.
-6. Return to the composer and click the chip `x`.
-7. Confirm the skill is removed and no file-browser tab is opened by the remove action.
-8. Switch to dark theme and repeat steps 2 through 7.
+1. In light theme, open an existing thread or start a new thread.
+2. Open the composer `Skills` dropdown and select one skill.
+3. Type and send a short message.
+4. Confirm the sent user message shows a `Skill` chip with the selected skill name.
+5. Click the skill chip and confirm the current browser tab opens the skill `SKILL.md` file through the local browse view.
+6. Refresh or reopen the thread and confirm the same skill chip remains visible and clickable in history.
+7. Switch to dark theme and repeat steps 2-6 with another message.
 
 #### Expected Results
-- The skill chip label is clickable and opens the selected skill's `SKILL.md` in the web file browser.
-- Skill paths that point at a skill directory are normalized to the nested `SKILL.md` file.
-- The remove button still only removes the skill from the composer.
-- The chip and focus/hover states remain readable in light theme and dark theme.
+- Selected skills are visible on the user message, not only in the composer before send.
+- Skill chips show the skill name and expose the skill path in the tooltip.
+- Skill chips link to the selected skill file using the local browse route in the current tab.
+- Skill chips remain visible after thread history reload.
+- Skill chips are readable in both light and dark themes.
 
 #### Rollback/Cleanup
-- Close any file-browser tabs opened during validation.
-
----
-
-### npx run dev compatibility shim
-
-#### Feature/Change Name
-The accidental `npx run dev` command starts the repository dev wrapper instead of failing with a missing `dev` module.
-
-#### Prerequisites/Setup
-1. Run from the repository root.
-2. Local dependencies are available, or the dev wrapper can install them with `pnpm install`.
-3. Port 5173 is free, or Vite can select the next available port.
-
-#### Steps
-1. Run `npx run dev`.
-2. Confirm the command reaches the existing `scripts/dev.cjs` wrapper and starts Vite.
-3. Stop the dev server with Ctrl-C.
-4. Repeat with `npx run dev --host 127.0.0.1 --port 4173`.
-
-#### Expected Results
-- `npx run dev` no longer fails with `Cannot find module '<repo>/dev'`.
-- The command starts the same dev server path as `npm run dev` / `pnpm run dev`.
-- Host and port arguments are passed through to Vite.
-
-#### Rollback/Cleanup
-- Stop any dev server process started for validation.
+- Remove disposable test messages/threads if needed.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -462,6 +462,126 @@ The accidental `npx run dev` command starts the repository dev wrapper instead o
 
 ---
 
+### Unread thread cutoff state
+
+#### Feature/Change Name
+Unread thread state uses a local cutoff timestamp so existing threads are not all marked unread after first load.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`).
+2. Browser localStorage is available for the app origin.
+3. At least two existing threads are present.
+4. Light theme and dark theme are available from the appearance switcher.
+
+#### Steps
+1. Clear only `codex-web-local.thread-unread-cutoff.v1` from localStorage for the app origin.
+2. Load the app in light theme.
+3. Confirm existing threads are not all marked unread on first load.
+4. Create or receive an update in a different thread after the app has loaded.
+5. Confirm that updated thread can show unread when it is not selected or in progress.
+6. Create or receive an update in a second unselected thread.
+7. Open the first updated thread and confirm only that thread's unread indicator clears.
+8. Confirm the second updated thread remains unread until it is opened.
+9. Switch to dark theme and repeat steps 4 through 8.
+
+#### Expected Results
+- Missing cutoff state initializes to the current time instead of treating every thread as unread.
+- Threads updated after the cutoff can still become unread.
+- Opening a thread updates only that thread's read state and clears only that thread's unread indicator.
+- Unread indicators remain readable in both light theme and dark theme.
+
+#### Rollback/Cleanup
+- Remove any disposable test threads created for this validation.
+
+---
+
+### CLI password output redaction
+
+#### Feature/Change Name
+CLI startup output no longer prints the configured password or embeds it in the tunnel URL.
+
+#### Prerequisites/Setup
+1. Project dependencies are installed.
+2. CLI build is available from the current branch.
+
+#### Steps
+1. Run `pnpm run build:cli`.
+2. Start the CLI with a disposable password: `node dist-cli/index.js --no-tunnel --no-open --port 5998 --password TEST_SECRET_SHOULD_NOT_PRINT`.
+3. Confirm startup output includes the local and network URLs.
+4. Confirm startup output does not include `Password:` or `TEST_SECRET_SHOULD_NOT_PRINT`.
+5. Start the CLI without an explicit password and confirm startup output prints `Generated password file:` with a path under `$CODEX_HOME`.
+6. Confirm the generated password file exists, is readable by the current user, and has `0600` permissions.
+7. If tunnel testing is available, start with tunnel enabled and confirm the printed tunnel URL and QR code do not include `/password=`.
+
+#### Expected Results
+- Password-protected startup still works.
+- The password is not printed as a standalone line.
+- Auto-generated passwords remain discoverable through the generated password file path.
+- Tunnel output does not include an autologin URL containing the password.
+
+#### Rollback/Cleanup
+- Stop the disposable CLI process.
+
+---
+
+### Composer skill chip opens SKILL.md
+
+#### Feature/Change Name
+Selected skill labels in the thread composer open that skill's `SKILL.md` in the web file browser.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. At least one installed skill is available in the composer skill picker
+3. Browser pop-ups from the local dev origin are allowed
+4. Light theme and dark theme are available from the appearance switcher
+
+#### Steps
+1. In light theme, open any thread with the composer enabled.
+2. Open the `Skills` picker and select an installed skill.
+3. Confirm the selected skill appears as a green chip above the input field.
+4. Click the skill name on the green chip.
+5. Confirm a new tab opens to `/codex-local-browse.../SKILL.md` for that skill.
+6. Return to the composer and click the chip `x`.
+7. Confirm the skill is removed and no file-browser tab is opened by the remove action.
+8. Switch to dark theme and repeat steps 2 through 7.
+
+#### Expected Results
+- The skill chip label is clickable and opens the selected skill's `SKILL.md` in the web file browser.
+- Skill paths that point at a skill directory are normalized to the nested `SKILL.md` file.
+- The remove button still only removes the skill from the composer.
+- The chip and focus/hover states remain readable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Close any file-browser tabs opened during validation.
+
+---
+
+### npx run dev compatibility shim
+
+#### Feature/Change Name
+The accidental `npx run dev` command starts the repository dev wrapper instead of failing with a missing `dev` module.
+
+#### Prerequisites/Setup
+1. Run from the repository root.
+2. Local dependencies are available, or the dev wrapper can install them with `pnpm install`.
+3. Port 5173 is free, or Vite can select the next available port.
+
+#### Steps
+1. Run `npx run dev`.
+2. Confirm the command reaches the existing `scripts/dev.cjs` wrapper and starts Vite.
+3. Stop the dev server with Ctrl-C.
+4. Repeat with `npx run dev --host 127.0.0.1 --port 4173`.
+
+#### Expected Results
+- `npx run dev` no longer fails with `Cannot find module '<repo>/dev'`.
+- The command starts the same dev server path as `npm run dev` / `pnpm run dev`.
+- Host and port arguments are passed through to Vite.
+
+#### Rollback/Cleanup
+- Stop any dev server process started for validation.
+
+---
+
 ### Skills sync idempotent commits and nested shared skills handling
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- render selected composer skills as chips on sent user messages
- recover selected skill metadata from session history when app-server thread reads omit skill blocks
- make message skill chips open the underlying SKILL.md via local browse

## Tests
- pnpm vitest run src/api/normalizers/v2.test.ts src/server/codexAppServerBridge.inlinePayload.test.ts
- pnpm exec vue-tsc --noEmit
- Browser check in TestChat: skill chip visible and opens /codex-local-browse/.../SKILL.md