### PR TITLE
Fix markdown file links with backticked labels

### DIFF
--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -2445,118 +2445,125 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
 }
 
 function parseInlineSegmentsUncached(text: string): InlineSegment[] {
-  if (text.includes('](')) {
-    const linkFirstSegments = splitTextByFileUrls(text)
-    if (linkFirstSegments.some((segment) => segment.kind === 'file' || segment.kind === 'url') && !text.includes('`')) {
-      return linkFirstSegments
-    }
+  const linkFirstSegments = splitTextByFileUrls(text)
+  if (!text.includes('`')) return linkFirstSegments
+  if (!linkFirstSegments.some((segment) => segment.kind === 'text' && segment.value.includes('`'))) {
+    return linkFirstSegments
   }
 
-  if (!text.includes('`')) return splitTextByFileUrls(text)
+  const parseCodeAwareTextSegments = (value: string): InlineSegment[] => {
+    if (!value.includes('`')) return splitPlainTextByLinks(value)
 
-  const segments: InlineSegment[] = []
-  let cursor = 0
-  let textStart = 0
+    const segments: InlineSegment[] = []
+    let cursor = 0
+    let textStart = 0
 
-  while (cursor < text.length) {
-    if (text[cursor] !== '`') {
-      cursor += 1
-      continue
-    }
-
-    let openLength = 1
-    while (cursor + openLength < text.length && text[cursor + openLength] === '`') {
-      openLength += 1
-    }
-    const delimiter = '`'.repeat(openLength)
-
-    let searchFrom = cursor + openLength
-    let closingStart = -1
-    while (searchFrom < text.length) {
-      const candidate = text.indexOf(delimiter, searchFrom)
-      if (candidate < 0) break
-
-      const hasBacktickBefore = candidate > 0 && text[candidate - 1] === '`'
-      const hasBacktickAfter =
-        candidate + openLength < text.length && text[candidate + openLength] === '`'
-      const hasNewLineInside = text.slice(cursor + openLength, candidate).includes('\n')
-
-      if (!hasBacktickBefore && !hasBacktickAfter && !hasNewLineInside) {
-        closingStart = candidate
-        break
+    while (cursor < value.length) {
+      if (value[cursor] !== '`') {
+        cursor += 1
+        continue
       }
-      searchFrom = candidate + 1
-    }
 
-    if (closingStart < 0) {
-      cursor += openLength
-      continue
-    }
+      let openLength = 1
+      while (cursor + openLength < value.length && value[cursor + openLength] === '`') {
+        openLength += 1
+      }
+      const delimiter = '`'.repeat(openLength)
 
-    if (cursor > textStart) {
-      segments.push(...splitTextByFileUrls(text.slice(textStart, cursor)))
-    }
+      let searchFrom = cursor + openLength
+      let closingStart = -1
+      while (searchFrom < value.length) {
+        const candidate = value.indexOf(delimiter, searchFrom)
+        if (candidate < 0) break
 
-    const token = text.slice(cursor + openLength, closingStart)
-    if (token.length > 0) {
-      const markdownLink = parseMarkdownLinkToken(token)
-      if (markdownLink) {
-        if (/^https?:\/\//u.test(markdownLink.target)) {
+        const hasBacktickBefore = candidate > 0 && value[candidate - 1] === '`'
+        const hasBacktickAfter =
+          candidate + openLength < value.length && value[candidate + openLength] === '`'
+        const hasNewLineInside = value.slice(cursor + openLength, candidate).includes('\n')
+
+        if (!hasBacktickBefore && !hasBacktickAfter && !hasNewLineInside) {
+          closingStart = candidate
+          break
+        }
+        searchFrom = candidate + 1
+      }
+
+      if (closingStart < 0) {
+        cursor += openLength
+        continue
+      }
+
+      if (cursor > textStart) {
+        segments.push(...splitPlainTextByLinks(value.slice(textStart, cursor)))
+      }
+
+      const token = value.slice(cursor + openLength, closingStart)
+      if (token.length > 0) {
+        const markdownLink = parseMarkdownLinkToken(token)
+        if (markdownLink) {
+          if (/^https?:\/\//u.test(markdownLink.target)) {
+            segments.push({
+              kind: 'url',
+              value: markdownLink.label || markdownLink.target,
+              href: markdownLink.target,
+            })
+          } else {
+            const markdownFileReference = parseFileReference(markdownLink.target)
+            if (markdownFileReference) {
+              segments.push({
+                kind: 'file',
+                value: markdownLink.target,
+                path: markdownFileReference.path,
+                displayPath: markdownLink.label || markdownLink.target,
+                downloadName: getBasename(markdownFileReference.path),
+              })
+            } else {
+              segments.push({ kind: 'code', value: token })
+            }
+          }
+        } else if (/^https?:\/\/[^\s]+$/u.test(token)) {
           segments.push({
             kind: 'url',
-            value: markdownLink.label || markdownLink.target,
-            href: markdownLink.target,
+            value: token,
+            href: token,
           })
         } else {
-          const markdownFileReference = parseFileReference(markdownLink.target)
-          if (markdownFileReference) {
+          const fileReference = parseFileReference(token)
+          if (fileReference) {
+            const displayPath = fileReference.line
+              ? `${fileReference.path}:${String(fileReference.line)}`
+              : fileReference.path
             segments.push({
               kind: 'file',
-              value: markdownLink.target,
-              path: markdownFileReference.path,
-              displayPath: markdownLink.label || markdownLink.target,
-              downloadName: getBasename(markdownFileReference.path),
+              value: token,
+              path: fileReference.path,
+              displayPath,
+              downloadName: getBasename(fileReference.path),
             })
           } else {
             segments.push({ kind: 'code', value: token })
           }
         }
-      } else if (/^https?:\/\/[^\s]+$/u.test(token)) {
-        segments.push({
-          kind: 'url',
-          value: token,
-          href: token,
-        })
       } else {
-        const fileReference = parseFileReference(token)
-        if (fileReference) {
-          const displayPath = fileReference.line
-            ? `${fileReference.path}:${String(fileReference.line)}`
-            : fileReference.path
-          segments.push({
-            kind: 'file',
-            value: token,
-            path: fileReference.path,
-            displayPath,
-            downloadName: getBasename(fileReference.path),
-          })
-        } else {
-          segments.push({ kind: 'code', value: token })
-        }
+        segments.push({ kind: 'text', value: `${delimiter}${delimiter}` })
       }
-    } else {
-      segments.push({ kind: 'text', value: `${delimiter}${delimiter}` })
+
+      cursor = closingStart + openLength
+      textStart = cursor
     }
 
-    cursor = closingStart + openLength
-    textStart = cursor
+    if (textStart < value.length) {
+      segments.push(...splitPlainTextByLinks(value.slice(textStart)))
+    }
+
+    return segments
   }
 
-  if (textStart < text.length) {
-    segments.push(...splitTextByFileUrls(text.slice(textStart)))
-  }
-
-  return segments
+  return linkFirstSegments.flatMap((segment) => (
+    segment.kind === 'text'
+      ? parseCodeAwareTextSegments(segment.value)
+      : [segment]
+  ))
 }
 
 function getInlineSegments(text: string): InlineSegment[] {

--- a/tests.md
+++ b/tests.md
@@ -410,26 +410,30 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 #### Rollback/Cleanup
 - Reset appearance to the previous user preference.
 
-### Feature: Markdown file links with backticks and parentheses render correctly
+### Feature: Markdown file links with backticked filename labels render correctly
 
 #### Prerequisites
 - App is running from this repository.
 - An active thread is open.
-- Local file exists at `/root/New Project (1)/qwe.txt`.
+- Light and dark themes are both available.
+- Local file exists at `/home/ubuntu/andClaw-srcmatch/app/src/main/java/com/coderred/andclaw/ui/util/TrustedBrowserLauncher.kt`.
 
 #### Steps
-1. Send a message containing: `Done. Created [`/root/New Project (1)/qwe.txt`](/root/New Project (1)/qwe.txt) with content:`.
-2. In the rendered assistant message, click the `/root/New Project (1)/qwe.txt` link.
-3. Right-click the same link and choose `Copy link` from the context menu.
-4. Paste the copied link into a text field and inspect it.
+1. In light theme, send a message containing: `Added [`TrustedBrowserLauncher.kt`](/home/ubuntu/andClaw-srcmatch/app/src/main/java/com/coderred/andclaw/ui/util/TrustedBrowserLauncher.kt)`.
+2. Confirm the rendered message shows one clickable file link with visible text `TrustedBrowserLauncher.kt`.
+3. Click the link and confirm it opens local browse for `/home/ubuntu/andClaw-srcmatch/app/src/main/java/com/coderred/andclaw/ui/util/TrustedBrowserLauncher.kt`.
+4. Right-click the same link and choose `Copy link`, then paste it into a text field and inspect it.
+5. Switch to dark theme and repeat steps 1-4.
 
 #### Expected Results
-- The markdown link renders as one clickable file link (not split into partial tokens).
+- The markdown link renders as one clickable file link instead of splitting around backticks.
+- The visible link text is the markdown label `TrustedBrowserLauncher.kt`, without backtick glyphs.
 - Clicking opens the local browse route for the full file path.
 - Copied link includes the full encoded path and still resolves to the same file.
+- Light and dark theme message surfaces keep the link readable and styled consistently.
 
 #### Rollback/Cleanup
-- Delete `/root/New Project (1)/qwe.txt` if it was created only for this test.
+- No cleanup required.
 
 ### Feature: Deferred ancillary startup refreshes
 


### PR DESCRIPTION
## Summary
- preserve markdown file links before inline-code parsing so backticked link labels stay clickable
- keep the rendered link text equal to the markdown label for local file links
- update manual regression coverage for the TrustedBrowserLauncher.kt case in light and dark themes

## Testing
- pnpm run build:frontend
- node output/playwright/testchat-backticked-file-link-cjs.cjs