### PR TITLE
Fix terminal quick command dropdown

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1014,9 +1014,7 @@ const { t, uiLanguage, uiLanguageOptions, setUiLanguage } = useUiLanguage()
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'codex-web-local.sidebar-collapsed.v1'
 const ACCOUNTS_SECTION_COLLAPSED_STORAGE_KEY = 'codex-web-local.accounts-section-collapsed.v1'
 const TERMINAL_QUICK_COMMAND_STORAGE_KEY = 'codex-web-local.terminal-quick-commands.v1'
-const ADD_TERMINAL_COMMAND_VALUE = '__add_terminal_command__'
 const TOGGLE_TERMINAL_COMMAND_VALUE = '__toggle_terminal__'
-const MAX_HEADER_TERMINAL_COMMANDS = 5
 const worktreeName = import.meta.env.VITE_WORKTREE_NAME ?? 'unknown'
 const appVersion = import.meta.env.VITE_APP_VERSION ?? 'unknown'
 const SETTINGS_HELP = {
@@ -1730,16 +1728,13 @@ const terminalHeaderQuickCommands = computed<TerminalHeaderQuickCommand[]>(() =>
       custom: false,
       sourceIndex: index,
     })),
-    ...terminalStoredQuickCommands.value.filter((command) => command.custom === true),
   ]
   return combined
     .sort(compareTerminalQuickCommands)
-    .slice(0, MAX_HEADER_TERMINAL_COMMANDS)
 })
 const terminalHeaderDropdownOptions = computed(() => [
-  ...terminalHeaderQuickCommands.value.map((command) => ({ label: command.label, value: command.value })),
-  { label: 'Add command...', value: ADD_TERMINAL_COMMAND_VALUE },
   { label: isComposerTerminalOpen.value ? t('Hide terminal') : t('Open terminal'), value: TOGGLE_TERMINAL_COMMAND_VALUE },
+  ...terminalHeaderQuickCommands.value.map((command) => ({ label: command.label, value: command.value })),
 ])
 const contentStyle = computed(() => {
   const preset = CHAT_WIDTH_PRESETS[chatWidth.value]
@@ -2508,17 +2503,10 @@ function onSelectHeaderTerminalCommand(command: string): void {
     toggleComposerTerminal()
     return
   }
-  if (command === ADD_TERMINAL_COMMAND_VALUE) {
-    if (typeof window === 'undefined') return
-    const customCommand = normalizeTerminalQuickCommandValue(window.prompt('Add command') ?? '')
-    if (!customCommand) return
-    void openTerminalAndRunCommand(customCommand, true)
-    return
-  }
-  void openTerminalAndRunCommand(command, false)
+  void openTerminalAndRunCommand(command)
 }
 
-async function openTerminalAndRunCommand(command: string, custom: boolean): Promise<void> {
+async function openTerminalAndRunCommand(command: string): Promise<void> {
   if (!isThreadTerminalAvailable.value || !composerCwd.value) return
   if (isHomeRoute.value) {
     homeTerminalOpen.value = true
@@ -2530,18 +2518,19 @@ async function openTerminalAndRunCommand(command: string, custom: boolean): Prom
   const panel = await waitForTerminalPanel()
   if (!panel) return
   try {
-    await panel.runQuickCommand(command, custom)
-    recordHeaderTerminalCommandUse(command, custom)
+    await panel.runQuickCommand(command)
+    recordHeaderTerminalCommandUse(command)
   } catch {
     // ThreadTerminalPanel renders the terminal-specific error in place.
   }
 }
 
 async function waitForTerminalPanel(): Promise<ThreadTerminalPanelExposed | null> {
-  for (let attempt = 0; attempt < 5; attempt += 1) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
     await nextTick()
     const panel = isHomeRoute.value ? homeTerminalPanelRef.value : threadTerminalPanelRef.value
     if (panel) return panel
+    await new Promise((resolve) => window.setTimeout(resolve, 25))
   }
   return null
 }
@@ -2559,16 +2548,17 @@ async function refreshTerminalQuickCommands(): Promise<void> {
   }
 }
 
-function recordHeaderTerminalCommandUse(command: string, custom: boolean): void {
+function recordHeaderTerminalCommandUse(command: string): void {
   const normalized = normalizeTerminalQuickCommandValue(command)
   if (!normalized) return
   const existing = terminalStoredQuickCommands.value.find((row) => row.value === normalized)
   const projectCommandIndex = terminalProjectQuickCommands.value.findIndex((row) => row.value === normalized)
   const projectCommand = projectCommandIndex >= 0 ? terminalProjectQuickCommands.value[projectCommandIndex] : null
+  if (!projectCommand) return
   const nextCommand: TerminalHeaderQuickCommand = {
     label: existing?.label || projectCommand?.label || normalized,
     value: normalized,
-    custom: existing?.custom === true || (!projectCommand && custom),
+    custom: false,
     usageCount: (existing?.usageCount ?? 0) + 1,
     lastUsedAt: Date.now(),
     sourceIndex: projectCommandIndex >= 0 ? projectCommandIndex : undefined,

--- a/src/components/content/ThreadTerminalPanel.vue
+++ b/src/components/content/ThreadTerminalPanel.vue
@@ -79,6 +79,7 @@ let fitAddon: FitAddon | null = null
 let resizeObserver: ResizeObserver | null = null
 let unsubscribeNotifications: (() => void) | null = null
 let resizeFrame = 0
+let attachPromise: Promise<void> | null = null
 const { t } = useUiLanguage()
 
 type TerminalTab = {
@@ -195,6 +196,22 @@ function createTerminal(): void {
 }
 
 async function attachToThread(newSession: boolean, targetSessionId = ''): Promise<void> {
+  if (attachPromise && !newSession && !targetSessionId) {
+    await attachPromise
+    return
+  }
+  const nextAttach = doAttachToThread(newSession, targetSessionId)
+  attachPromise = nextAttach
+  try {
+    await nextAttach
+  } finally {
+    if (attachPromise === nextAttach) {
+      attachPromise = null
+    }
+  }
+}
+
+async function doAttachToThread(newSession: boolean, targetSessionId = ''): Promise<void> {
   if (!props.threadId || !props.cwd || !terminal) return
   errorMessage.value = ''
   await nextTick()
@@ -455,6 +472,7 @@ async function refreshProjectQuickCommands(): Promise<void> {
 async function runQuickCommand(command: string, custom = false): Promise<void> {
   const value = normalizeQuickCommandValue(command)
   if (!value) return
+  await waitForTerminalReady()
   if (!activeSessionId.value) {
     await attachToThread(false)
   }
@@ -469,6 +487,14 @@ async function runQuickCommand(command: string, custom = false): Promise<void> {
     errorMessage.value = error instanceof Error ? error.message : 'Quick command failed'
     throw error
   }
+}
+
+async function waitForTerminalReady(): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (terminal) return
+    await new Promise((resolve) => window.setTimeout(resolve, 25))
+  }
+  throw new Error('Terminal is not ready')
 }
 
 defineExpose<ThreadTerminalPanelExposed>({

--- a/tests.md
+++ b/tests.md
@@ -3330,23 +3330,21 @@ Each local/worktree thread has an integrated xterm terminal that can be toggled 
 8. Confirm `terminal-ok` appears in the xterm output
 9. Choose `npm run dev` from the `Run...` quick-command menu
 10. Confirm the command is submitted to the active terminal
-11. Choose `Add command...` from the `Run...` menu
-12. Enter a custom command in the prompt and confirm it runs immediately
-13. Fetch `/codex-api/thread-terminal-snapshot?threadId=<thread-id>`
-14. Confirm the JSON `session.buffer` contains `terminal-ok`
-15. Refresh the page and reopen the same thread
-16. Toggle the terminal open again
-17. Click `New`
-18. Confirm a second terminal tab appears and becomes active
-19. Click the first terminal tab
-20. Confirm its previous output is restored
-21. Resize the browser window
-22. Click `Close`
-23. Open the new-chat screen
-24. Confirm a working folder is selected
-25. Click the terminal button in the top-right header
-26. Confirm the terminal opens below the new-chat composer before a thread exists
-27. Run `pwd` and confirm it matches the selected folder
+11. Fetch `/codex-api/thread-terminal-snapshot?threadId=<thread-id>`
+12. Confirm the JSON `session.buffer` contains `terminal-ok`
+13. Refresh the page and reopen the same thread
+14. Toggle the terminal open again
+15. Click `New`
+16. Confirm a second terminal tab appears and becomes active
+17. Click the first terminal tab
+18. Confirm its previous output is restored
+19. Resize the browser window
+20. Click `Close`
+21. Open the new-chat screen
+22. Confirm a working folder is selected
+23. Click the terminal button in the top-right header
+24. Confirm the terminal opens below the new-chat composer before a thread exists
+25. Run `pwd` and confirm it matches the selected folder
 
 #### Expected Results
 - The terminal button shows a pressed state when the drawer is open
@@ -3357,8 +3355,8 @@ Each local/worktree thread has an integrated xterm terminal that can be toggled 
 - The terminal resizes without clipping the prompt
 - The snapshot endpoint returns `{ session: { cwd, shell, buffer, truncated } }` while a session exists
 - The quick-command menu sends common project commands such as `npm run dev` into the current PTY
-- Custom quick commands can be added from the `Run...` menu prompt and run immediately
-- The `Run...` menu shows only the five most-used/recent commands before `Add command...`
+- The terminal open/hide action is the first item in the `Run...` menu
+- The `Run...` menu shows discovered project commands in usage order and scrolls when the list is longer than the visible menu
 - `New` adds another tab without killing the previous PTY
 - `Close` terminates the active PTY and hides the drawer only after the last tab is closed
 
@@ -4153,8 +4151,9 @@ Terminal quick commands are discovered from the current project instead of using
 5. Verify root-level `*.sh` / `*.cmd` files appear as `./<file>`
 6. Verify `scripts/*.sh` and `scripts/*.cmd` files appear as `./scripts/<file>`
 7. Select one discovered command and confirm it is sent to the terminal
-8. Use `Add command...` to add a custom command
-9. Reopen the dropdown after running commands multiple times
+8. Reopen the dropdown after running commands multiple times
+9. If the project has more commands than fit in the menu, scroll the dropdown and verify lower-priority entries such as `./scripts/<file>.sh` remain reachable
+10. From a closed terminal state on a remote server, select a command immediately after opening the `Run...` menu and confirm it runs after the terminal attaches
 
 #### Expected Results
 - The dropdown is based on the current project `cwd`
@@ -4162,12 +4161,11 @@ Terminal quick commands are discovered from the current project instead of using
 - Package script commands use the lockfile-preferred package manager
 - Make targets are listed after package scripts
 - Root and `scripts/` script-file commands are listed after Make targets
-- Only the top five commands are shown, sorted by most-used and then most-recent usage
-- Custom commands still work and are included in the same usage sorting
+- Commands are sorted by most-used and then most-recent usage, and the dropdown scrolls instead of hiding entries beyond the first five
+- Selecting a command while the terminal is still mounting waits for the attach flow instead of dropping the command
 
 #### Rollback/Cleanup
 - Remove any temporary files created under the project root or `scripts/`
-- Remove custom quick commands from browser local storage if needed
 
 ---
 


### PR DESCRIPTION
## Summary
- remove the Add command action from the terminal quick-command dropdown
- keep the open/hide terminal action first
- allow all discovered commands to remain reachable through the existing scrollable dropdown
- wait for terminal mount/attach before sending quick-command input on slow remote servers

## Tests
- git diff --check
- pnpm run build:frontend (blocked: local node_modules missing, vue-tsc not found)