### PR TITLE
Persist worktree roots when creating worktrees

### DIFF
--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3518,18 +3518,69 @@ async function writeWorkspaceRootsState(nextState: WorkspaceRootsState): Promise
   await writeFile(statePath, JSON.stringify(payload), 'utf8')
 }
 
-async function persistWorkspaceRoot(workspaceRoot: string): Promise<void> {
+let workspaceRootsMutation: Promise<void> = Promise.resolve()
+
+function queueWorkspaceRootsMutation<T>(mutation: () => Promise<T>): Promise<T> {
+  const run = workspaceRootsMutation.catch(() => undefined).then(mutation)
+  workspaceRootsMutation = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
+
+function prependUniqueString(value: string, items: string[]): string[] {
+  return [value, ...items.filter((item) => item !== value)]
+}
+
+async function updateWorkspaceRootsState(
+  updater: (existingState: WorkspaceRootsState) => WorkspaceRootsState,
+): Promise<void> {
+  await queueWorkspaceRootsMutation(async () => {
+    const existingState = await readWorkspaceRootsState()
+    await writeWorkspaceRootsState(updater(existingState))
+  })
+}
+
+async function persistWorkspaceRoot(workspaceRoot: string, label = ''): Promise<void> {
   const normalizedRoot = workspaceRoot.trim()
   if (!normalizedRoot) return
 
-  const existingState = await readWorkspaceRootsState()
-  await writeWorkspaceRootsState({
-    order: [normalizedRoot, ...existingState.order.filter((item) => item !== normalizedRoot)],
-    labels: existingState.labels,
-    active: [normalizedRoot, ...existingState.active.filter((item) => item !== normalizedRoot)],
-    projectOrder: [normalizedRoot, ...existingState.projectOrder.filter((item) => item !== normalizedRoot)],
-    remoteProjects: existingState.remoteProjects,
+  await updateWorkspaceRootsState((existingState) => {
+    const nextLabels = { ...existingState.labels }
+    const trimmedLabel = label.trim()
+    if (trimmedLabel.length > 0) {
+      nextLabels[normalizedRoot] = trimmedLabel
+    }
+    return {
+      order: prependUniqueString(normalizedRoot, existingState.order),
+      labels: nextLabels,
+      active: prependUniqueString(normalizedRoot, existingState.active),
+      projectOrder: prependUniqueString(normalizedRoot, existingState.projectOrder),
+      remoteProjects: existingState.remoteProjects,
+    }
   })
+}
+
+async function rollbackCreatedWorktree(
+  gitRoot: string,
+  worktreeCwd: string,
+  cleanupDirectory?: string,
+  branchName?: string,
+): Promise<void> {
+  try {
+    await runCommand('git', ['worktree', 'remove', '--force', worktreeCwd], { cwd: gitRoot })
+  } catch {
+    await rm(worktreeCwd, { recursive: true, force: true }).catch(() => undefined)
+  }
+
+  if (cleanupDirectory && cleanupDirectory !== worktreeCwd) {
+    await rm(cleanupDirectory, { recursive: true, force: true }).catch(() => undefined)
+  }
+
+  if (branchName) {
+    await runCommand('git', ['branch', '-D', branchName], { cwd: gitRoot }).catch(() => undefined)
+  }
 }
 
 function normalizeTelegramBridgeConfig(value: unknown): TelegramBridgeConfigState {
@@ -5769,7 +5820,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             await ensureRepoHasInitialCommit(gitRoot)
             await runCommand('git', ['worktree', 'add', '--detach', worktreeCwd, startPoint], { cwd: gitRoot })
           }
-          await persistWorkspaceRoot(worktreeCwd)
+          try {
+            await persistWorkspaceRoot(worktreeCwd)
+          } catch (error) {
+            await rollbackCreatedWorktree(gitRoot, worktreeCwd, worktreeParent)
+            throw error
+          }
 
           setJson(res, 200, {
             data: {
@@ -5839,7 +5895,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             await ensureRepoHasInitialCommit(gitRoot)
             await runCommand('git', ['worktree', 'add', '-b', branchName, worktreeCwd, 'HEAD'], { cwd: gitRoot })
           }
-          await persistWorkspaceRoot(worktreeCwd)
+          try {
+            await persistWorkspaceRoot(worktreeCwd)
+          } catch (error) {
+            await rollbackCreatedWorktree(gitRoot, worktreeCwd, undefined, branchName)
+            throw error
+          }
 
           setJson(res, 200, {
             data: {
@@ -6174,8 +6235,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           setJson(res, 400, { error: 'Invalid body: expected object' })
           return
         }
-        const existingState = await readWorkspaceRootsState()
-        const nextState: WorkspaceRootsState = {
+        await updateWorkspaceRootsState((existingState) => ({
           order: normalizeStringArray(record.order),
           labels: normalizeStringRecord(record.labels),
           active: normalizeStringArray(record.active),
@@ -6183,8 +6243,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             ? normalizeStringArray(record.projectOrder)
             : existingState.projectOrder,
           remoteProjects: existingState.remoteProjects,
-        }
-        await writeWorkspaceRootsState(nextState)
+        }))
         setJson(res, 200, { ok: true })
         return
       }
@@ -6231,20 +6290,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
 
-        const existingState = await readWorkspaceRootsState()
-        const nextOrder = [normalizedPath, ...existingState.order.filter((item) => item !== normalizedPath)]
-        const nextActive = [normalizedPath, ...existingState.active.filter((item) => item !== normalizedPath)]
-        const nextLabels = { ...existingState.labels }
-        if (label.trim().length > 0) {
-          nextLabels[normalizedPath] = label.trim()
-        }
-        await writeWorkspaceRootsState({
-          order: nextOrder,
-          labels: nextLabels,
-          active: nextActive,
-          projectOrder: [normalizedPath, ...existingState.projectOrder.filter((item) => item !== normalizedPath)],
-          remoteProjects: existingState.remoteProjects,
-        })
+        await persistWorkspaceRoot(normalizedPath, label)
         setJson(res, 200, { data: { path: normalizedPath } })
         return
       }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3518,6 +3518,20 @@ async function writeWorkspaceRootsState(nextState: WorkspaceRootsState): Promise
   await writeFile(statePath, JSON.stringify(payload), 'utf8')
 }
 
+async function persistWorkspaceRoot(workspaceRoot: string): Promise<void> {
+  const normalizedRoot = workspaceRoot.trim()
+  if (!normalizedRoot) return
+
+  const existingState = await readWorkspaceRootsState()
+  await writeWorkspaceRootsState({
+    order: [normalizedRoot, ...existingState.order.filter((item) => item !== normalizedRoot)],
+    labels: existingState.labels,
+    active: [normalizedRoot, ...existingState.active.filter((item) => item !== normalizedRoot)],
+    projectOrder: [normalizedRoot, ...existingState.projectOrder.filter((item) => item !== normalizedRoot)],
+    remoteProjects: existingState.remoteProjects,
+  })
+}
+
 function normalizeTelegramBridgeConfig(value: unknown): TelegramBridgeConfigState {
   const record = asRecord(value)
   if (!record) return { botToken: '', chatIds: [], allowedUserIds: [] }
@@ -5755,6 +5769,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             await ensureRepoHasInitialCommit(gitRoot)
             await runCommand('git', ['worktree', 'add', '--detach', worktreeCwd, startPoint], { cwd: gitRoot })
           }
+          await persistWorkspaceRoot(worktreeCwd)
 
           setJson(res, 200, {
             data: {
@@ -5824,6 +5839,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             await ensureRepoHasInitialCommit(gitRoot)
             await runCommand('git', ['worktree', 'add', '-b', branchName, worktreeCwd, 'HEAD'], { cwd: gitRoot })
           }
+          await persistWorkspaceRoot(worktreeCwd)
 
           setJson(res, 200, {
             data: {

--- a/tests.md
+++ b/tests.md
@@ -4555,3 +4555,38 @@ Managed worktree threads remain visible under their matching canonical workspace
 
 #### Rollback/Cleanup
 - None.
+
+---
+
+### Worktree creation persists across refresh
+
+#### Feature/Change Name
+Newly created temporary and permanent worktrees are persisted in workspace roots so their threads remain visible after a full browser refresh.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. A Git-backed workspace root is registered and selected in the Start new thread screen
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open Start new thread for the Git-backed workspace root.
+2. Select `New worktree`, send a unique first prompt, and wait for the thread page to open.
+3. Note the created worktree path from the selected folder or thread metadata.
+4. Refresh the browser tab.
+5. Confirm the new worktree-backed project/thread remains visible in the sidebar and can be opened.
+6. Open the project action menu for the original Git-backed project and create a permanent named worktree.
+7. Confirm the permanent worktree appears in the folder/project list, then refresh the browser tab.
+8. Confirm the permanent worktree remains visible after refresh.
+9. Switch to dark theme and repeat steps 1 through 5 with a second unique temporary worktree prompt.
+
+#### Expected Results
+- Temporary worktree creation writes the new worktree cwd to persisted workspace roots.
+- Permanent worktree creation writes the new worktree cwd to persisted workspace roots.
+- Full page refresh does not hide the newly created worktree project or its thread.
+- The same behavior works in light theme and dark theme.
+- If workspace-root persistence fails after `git worktree add`, the request fails cleanly and best-effort rollback removes the created worktree instead of leaving retry-prone orphaned worktrees.
+
+#### Rollback/Cleanup
+- Remove temporary test worktrees with `git worktree remove --force <worktree-path>`.
+- Delete any empty temporary parent directory left under `$CODEX_HOME/worktrees/<id>`.
+- Remove permanent test worktrees with `git worktree remove --force <worktree-path>` and delete their test branch if needed.


### PR DESCRIPTION
## Summary
- Persist newly-created worktree roots into the global workspace roots state.
- Update both temporary and permanent worktree creation flows so refreshes keep the new project visible.

## Root Cause
`/codex-api/worktree/create` and `/codex-api/worktree/create-permanent` created the Git worktree and returned its `cwd`, but never wrote that `cwd` to `electron-saved-workspace-roots`, `active-workspace-roots`, or `project-order`. The new thread can appear in-memory right after creation, but after a full page refresh the sidebar filters projects by persisted workspace roots and the worktree-backed thread disappears.

## Validation
- `pnpm install --no-frozen-lockfile`
- `pnpm run build:cli`
- `pnpm run test:unit -- --runInBand` (35 tests passed)
