### PR TITLE
Defer project git status checks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,7 @@
             @archive="onArchiveThread" @start-new-thread="onStartNewThread" @rename-project="onRenameProject"
             @browse-thread-files="onBrowseThreadFiles"
             @browse-project-files="onBrowseProjectFiles"
+            @request-project-git-status="onRequestProjectGitStatus"
             @create-project-worktree="onCreateProjectWorktree"
             @rename-thread="onRenameThread"
             @fork-thread="onForkThread"
@@ -1268,6 +1269,7 @@ const hasInitialized = ref(false)
 const newThreadCwd = ref('')
 const newThreadRuntime = ref<'local' | 'worktree'>('local')
 const gitRepoStatusByCwd = ref<Record<string, boolean>>({})
+const gitRepoStatusRequestByCwd = new Map<string, Promise<boolean>>()
 const newWorktreeBaseBranch = ref('')
 const worktreeBranchOptions = ref<WorktreeBranchOption[]>([])
 const isLoadingWorktreeBranches = ref(false)
@@ -2399,17 +2401,32 @@ function onStartNewThreadFromToolbar(): void {
 async function loadGitRepoStatus(cwdRaw: string): Promise<void> {
   const cwd = cwdRaw.trim()
   if (!cwd || Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) return
-  try {
-    const status = await getGitRepositoryStatus(cwd)
-    gitRepoStatusByCwd.value = {
-      ...gitRepoStatusByCwd.value,
-      [cwd]: status.isGitRepo,
+
+  const existingRequest = gitRepoStatusRequestByCwd.get(cwd)
+  if (existingRequest) {
+    const isGitRepo = await existingRequest
+    if (!Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) {
+      gitRepoStatusByCwd.value = {
+        ...gitRepoStatusByCwd.value,
+        [cwd]: isGitRepo,
+      }
     }
-  } catch {
-    gitRepoStatusByCwd.value = {
-      ...gitRepoStatusByCwd.value,
-      [cwd]: false,
-    }
+    return
+  }
+
+  const request = getGitRepositoryStatus(cwd)
+    .then((status) => status.isGitRepo)
+    .catch(() => false)
+    .finally(() => {
+      gitRepoStatusRequestByCwd.delete(cwd)
+    })
+  gitRepoStatusRequestByCwd.set(cwd, request)
+
+  const isGitRepo = await request
+  if (Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) return
+  gitRepoStatusByCwd.value = {
+    ...gitRepoStatusByCwd.value,
+    [cwd]: isGitRepo,
   }
 }
 
@@ -2429,6 +2446,12 @@ async function onRemoveProject(projectName: string): Promise<void> {
 
 function onReorderProject(payload: { projectName: string; toIndex: number }): void {
   reorderProject(payload.projectName, payload.toIndex)
+}
+
+function onRequestProjectGitStatus(projectName: string): void {
+  const group = projectGroups.value.find((entry) => entry.projectName === projectName)
+  const cwd = resolvePreferredLocalCwd(projectName, group?.threads[0]?.cwd?.trim() ?? '')
+  void loadGitRepoStatus(cwd)
 }
 
 function onSetProjectSortMode(mode: 'recent' | 'manual'): void {
@@ -3979,16 +4002,6 @@ watch(
   () => newThreadCwd.value,
   (cwd) => {
     void loadGitRepoStatus(cwd)
-  },
-  { immediate: true },
-)
-
-watch(
-  () => projectGroups.value.map((group) => resolvePreferredLocalCwd(group.projectName, group.threads[0]?.cwd?.trim() ?? '')).filter(Boolean),
-  (cwds) => {
-    for (const cwd of cwds) {
-      void loadGitRepoStatus(cwd)
-    }
   },
   { immediate: true },
 )

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -824,6 +824,7 @@ const emit = defineEmits<{
   'start-new-thread': [projectName: string]
   'browse-thread-files': [threadId: string]
   'browse-project-files': [projectName: string]
+  'request-project-git-status': [projectName: string]
   'create-project-worktree': [projectName: string]
   'rename-project': [payload: { projectName: string; displayName: string }]
   'rename-thread': [payload: { threadId: string; title: string }]
@@ -1630,6 +1631,7 @@ function toggleProjectMenu(projectName: string): void {
   openProjectMenuId.value = projectName
   projectMenuMode.value = 'actions'
   projectRenameDraft.value = getProjectDisplayName(projectName)
+  emit('request-project-git-status', projectName)
   nextTick(() => {
     updateProjectMenuDirection(projectName)
   })

--- a/tests.md
+++ b/tests.md
@@ -4675,3 +4675,33 @@ Newly created temporary and permanent worktrees are persisted in workspace roots
 - Remove temporary test worktrees with `git worktree remove --force <worktree-path>`.
 - Delete any empty temporary parent directory left under `$CODEX_HOME/worktrees/<id>`.
 - Remove permanent test worktrees with `git worktree remove --force <worktree-path>` and delete their test branch if needed.
+
+---
+
+### Lazy project Git status checks
+
+#### Feature/Change Name
+Project Git repository status is loaded lazily from the project action menu instead of scanning every visible project during startup.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. Sidebar contains multiple projects, including at least one Git-backed project
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, load the home route and confirm the Projects section renders normally.
+2. Open browser devtools or the runtime profile output and confirm startup does not issue one `/codex-api/git/repository-status` request per visible project.
+3. Open the action menu for a Git-backed project.
+4. Confirm the menu remains readable and the `New worktree` item appears after the Git status check completes.
+5. Open the action menu for a non-Git project.
+6. Confirm the menu remains readable and `New worktree` is not shown.
+7. Switch to dark theme and repeat steps 3 through 6.
+
+#### Expected Results
+- Startup avoids eager Git status scans for all project rows.
+- Opening a project menu still loads that project's Git status on demand.
+- `New worktree` remains available for Git-backed projects and hidden for non-Git projects.
+- Project menus remain usable and visually consistent in both light and dark themes.
+
+#### Rollback/Cleanup
+- None.


### PR DESCRIPTION
## Summary
- stop eagerly checking Git repository status for every visible project during startup
- load project Git status on demand when opening a project action menu
- keep per-cwd in-flight dedupe and document manual light/dark verification

## Measurement
- Before thread profile: 34 startup `/codex-api/git/repository-status` calls
- After thread profile: 0 startup `/codex-api/git/repository-status` calls
- Startup API rows: 61 -> 26 in the measured thread route profile

## Tests
- `pnpm run build:frontend`
- `pnpm run test:unit -- src/components/sidebar/projectMoveMode.test.ts src/composables/useDesktopState.test.ts`
- Playwright smoke: startup git-status calls = 0; Git-backed menu shows `New worktree`; non-Git menu hides `New worktree`