### PR TITLE
Show all sidebar chats

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,6 @@
             :selected-thread-id="selectedThreadId" :is-loading="isLoadingThreads"
             :search-query="sidebarSearchQuery"
             :search-matched-thread-ids="serverMatchedThreadIds"
-            :filter-active="isSidebarSearchVisible"
             @select="onSelectThread"
             @archive="onArchiveThread" @start-new-thread="onStartNewThread" @rename-project="onRenameProject"
             @browse-thread-files="onBrowseThreadFiles"
@@ -80,8 +79,7 @@
             @set-project-sort-mode="onSetProjectSortMode"
             @toggle-project-pinned="onToggleProjectPinned"
             @export-thread="onExportThread"
-            @start-new-chat="onStartNewThreadFromToolbar"
-            @toggle-filter="toggleSidebarSearch" />
+            @start-new-chat="onStartNewThreadFromToolbar" />
         </div>
 
         <div

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -533,16 +533,6 @@
             <button
               class="chats-section-action"
               type="button"
-              :aria-pressed="filterActive"
-              :aria-label="filterActive ? t('Hide chat filters') : t('Filter chats')"
-              :title="filterActive ? t('Hide chat filters') : t('Filter chats')"
-              @click.stop="$emit('toggle-filter')"
-            >
-              <IconTablerFilter class="thread-icon" />
-            </button>
-            <button
-              class="chats-section-action"
-              type="button"
               :aria-label="t('New chat')"
               :title="t('New chat')"
               @click.stop="$emit('start-new-chat')"
@@ -790,7 +780,6 @@ import IconTablerFilePencil from '../icons/IconTablerFilePencil.vue'
 import IconTablerFolder from '../icons/IconTablerFolder.vue'
 import IconTablerFolderOpen from '../icons/IconTablerFolderOpen.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
-import IconTablerFilter from '../icons/IconTablerFilter.vue'
 import IconTablerGripVertical from '../icons/IconTablerGripVertical.vue'
 import IconTablerPin from '../icons/IconTablerPin.vue'
 import IconTablerTrash from '../icons/IconTablerTrash.vue'
@@ -813,7 +802,6 @@ const props = defineProps<{
   isLoading: boolean
   searchQuery: string
   searchMatchedThreadIds: string[] | null
-  filterActive: boolean
 }>()
 
 const { t } = useUiLanguage()
@@ -834,7 +822,6 @@ const emit = defineEmits<{
   'export-thread': [threadId: string]
   'fork-thread': [threadId: string]
   'start-new-chat': []
-  'toggle-filter': []
 }>()
 
 type PendingProjectDrag = {
@@ -1103,7 +1090,6 @@ const chatThreads = computed(() => {
       const secondTimestamp = new Date(second[timestampKey] || second.updatedAtIso || second.createdAtIso).getTime()
       return secondTimestamp - firstTimestamp
     })
-    .slice(0, 4)
 })
 
 const threadById = computed(() => {

--- a/src/composables/useUiLanguage.ts
+++ b/src/composables/useUiLanguage.ts
@@ -17,8 +17,6 @@ const zhCN: Record<string, string> = {
   'Sort by': '排序',
   'Created': '创建时间',
   'Updated': '更新时间',
-  'Filter chats': '筛选聊天',
-  'Hide chat filters': '隐藏聊天筛选',
   'New chat': '新聊天',
   'No chats': '没有聊天',
   'Skills Hub': '技能中心',

--- a/tests.md
+++ b/tests.md
@@ -4675,3 +4675,32 @@ Newly created temporary and permanent worktrees are persisted in workspace roots
 - Remove temporary test worktrees with `git worktree remove --force <worktree-path>`.
 - Delete any empty temporary parent directory left under `$CODEX_HOME/worktrees/<id>`.
 - Remove permanent test worktrees with `git worktree remove --force <worktree-path>` and delete their test branch if needed.
+
+---
+
+### Sidebar chats show all projectless chats
+
+#### Feature/Change Name
+The sidebar Chats section lists all projectless chats and no longer shows the per-section filter button.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Thread history contains more than five projectless chats
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open the sidebar Chats section.
+2. Count the visible projectless chat rows and confirm older rows beyond the latest five are present.
+3. Confirm the Chats section header only shows the New chat action and does not show a filter button.
+4. Use the main sidebar search button and confirm global thread search still opens and filters chats/projects.
+5. Switch to dark theme and repeat steps 1-4.
+
+#### Expected Results
+- All projectless chats are listed in the Chats section according to the selected chat sort mode.
+- The Chats header does not include a filter action.
+- The New chat action remains available.
+- The main sidebar search remains functional.
+- Rows and header actions remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- None.


### PR DESCRIPTION
## Summary
- show all projectless chats in the sidebar Chats section instead of limiting the list
- remove the Chats header filter button and its unused wiring
- document manual verification for the sidebar Chats behavior

## Tests
- pnpm run build:frontend
- pnpm run test:unit