### PR TITLE
Defer project git status checks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,7 @@
             @archive="onArchiveThread" @start-new-thread="onStartNewThread" @rename-project="onRenameProject"
             @browse-thread-files="onBrowseThreadFiles"
             @browse-project-files="onBrowseProjectFiles"
+            @request-project-git-status="onRequestProjectGitStatus"
             @create-project-worktree="onCreateProjectWorktree"
             @rename-thread="onRenameThread"
             @fork-thread="onForkThread"
@@ -1266,6 +1267,7 @@ const hasInitialized = ref(false)
 const newThreadCwd = ref('')
 const newThreadRuntime = ref<'local' | 'worktree'>('local')
 const gitRepoStatusByCwd = ref<Record<string, boolean>>({})
+const gitRepoStatusRequestByCwd = new Map<string, Promise<boolean>>()
 const newWorktreeBaseBranch = ref('')
 const worktreeBranchOptions = ref<WorktreeBranchOption[]>([])
 const isLoadingWorktreeBranches = ref(false)
@@ -2397,17 +2399,32 @@ function onStartNewThreadFromToolbar(): void {
 async function loadGitRepoStatus(cwdRaw: string): Promise<void> {
   const cwd = cwdRaw.trim()
   if (!cwd || Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) return
-  try {
-    const status = await getGitRepositoryStatus(cwd)
-    gitRepoStatusByCwd.value = {
-      ...gitRepoStatusByCwd.value,
-      [cwd]: status.isGitRepo,
+
+  const existingRequest = gitRepoStatusRequestByCwd.get(cwd)
+  if (existingRequest) {
+    const isGitRepo = await existingRequest
+    if (!Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) {
+      gitRepoStatusByCwd.value = {
+        ...gitRepoStatusByCwd.value,
+        [cwd]: isGitRepo,
+      }
     }
-  } catch {
-    gitRepoStatusByCwd.value = {
-      ...gitRepoStatusByCwd.value,
-      [cwd]: false,
-    }
+    return
+  }
+
+  const request = getGitRepositoryStatus(cwd)
+    .then((status) => status.isGitRepo)
+    .catch(() => false)
+    .finally(() => {
+      gitRepoStatusRequestByCwd.delete(cwd)
+    })
+  gitRepoStatusRequestByCwd.set(cwd, request)
+
+  const isGitRepo = await request
+  if (Object.prototype.hasOwnProperty.call(gitRepoStatusByCwd.value, cwd)) return
+  gitRepoStatusByCwd.value = {
+    ...gitRepoStatusByCwd.value,
+    [cwd]: isGitRepo,
   }
 }
 
@@ -2427,6 +2444,12 @@ async function onRemoveProject(projectName: string): Promise<void> {
 
 function onReorderProject(payload: { projectName: string; toIndex: number }): void {
   reorderProject(payload.projectName, payload.toIndex)
+}
+
+function onRequestProjectGitStatus(projectName: string): void {
+  const group = projectGroups.value.find((entry) => entry.projectName === projectName)
+  const cwd = resolvePreferredLocalCwd(projectName, group?.threads[0]?.cwd?.trim() ?? '')
+  void loadGitRepoStatus(cwd)
 }
 
 function onSetProjectSortMode(mode: 'recent' | 'manual'): void {
@@ -3977,16 +4000,6 @@ watch(
   () => newThreadCwd.value,
   (cwd) => {
     void loadGitRepoStatus(cwd)
-  },
-  { immediate: true },
-)
-
-watch(
-  () => projectGroups.value.map((group) => resolvePreferredLocalCwd(group.projectName, group.threads[0]?.cwd?.trim() ?? '')).filter(Boolean),
-  (cwds) => {
-    for (const cwd of cwds) {
-      void loadGitRepoStatus(cwd)
-    }
   },
   { immediate: true },
 )

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1606,6 +1606,13 @@ function setProjectSortMode(mode: 'recent' | 'manual'): void {
   emit('set-project-sort-mode', mode)
 }
 
+function requestProjectGitStatusAndUpdateMenuDirection(projectName: string): void {
+  emit('request-project-git-status', projectName)
+  nextTick(() => {
+    updateProjectMenuDirection(projectName)
+  })
+}
+
 function toggleProjectMenu(projectName: string): void {
   if (openProjectMenuId.value === projectName) {
     closeProjectMenu()
@@ -1617,10 +1624,7 @@ function toggleProjectMenu(projectName: string): void {
   openProjectMenuId.value = projectName
   projectMenuMode.value = 'actions'
   projectRenameDraft.value = getProjectDisplayName(projectName)
-  emit('request-project-git-status', projectName)
-  nextTick(() => {
-    updateProjectMenuDirection(projectName)
-  })
+  requestProjectGitStatusAndUpdateMenuDirection(projectName)
 }
 
 function openProjectContextMenu(projectName: string): void {
@@ -1629,9 +1633,7 @@ function openProjectContextMenu(projectName: string): void {
   openProjectMenuId.value = projectName
   projectMenuMode.value = 'actions'
   projectRenameDraft.value = getProjectDisplayName(projectName)
-  nextTick(() => {
-    updateProjectMenuDirection(projectName)
-  })
+  requestProjectGitStatusAndUpdateMenuDirection(projectName)
 }
 
 function getProjectRenameDraftName(group: UiProjectGroup): string {
@@ -2380,6 +2382,22 @@ watch(
     if (Object.keys(nextMeasuredHeights).length !== Object.keys(measuredHeightByProject.value).length) {
       measuredHeightByProject.value = nextMeasuredHeights
     }
+  },
+)
+
+watch(
+  () => {
+    const projectName = openProjectMenuId.value
+    return projectName ? props.projectGitRepoByName[projectName] : undefined
+  },
+  () => {
+    const projectName = openProjectMenuId.value
+    if (!projectName) return
+    nextTick(() => {
+      if (openProjectMenuId.value === projectName) {
+        updateProjectMenuDirection(projectName)
+      }
+    })
   },
 )
 

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -812,6 +812,7 @@ const emit = defineEmits<{
   'start-new-thread': [projectName: string]
   'browse-thread-files': [threadId: string]
   'browse-project-files': [projectName: string]
+  'request-project-git-status': [projectName: string]
   'create-project-worktree': [projectName: string]
   'rename-project': [payload: { projectName: string; displayName: string }]
   'rename-thread': [payload: { threadId: string; title: string }]
@@ -1616,6 +1617,7 @@ function toggleProjectMenu(projectName: string): void {
   openProjectMenuId.value = projectName
   projectMenuMode.value = 'actions'
   projectRenameDraft.value = getProjectDisplayName(projectName)
+  emit('request-project-git-status', projectName)
   nextTick(() => {
     updateProjectMenuDirection(projectName)
   })

--- a/tests.md
+++ b/tests.md
@@ -279,6 +279,39 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Lazy project Git status checks
+
+#### Feature/Change Name
+Project Git repository status is loaded lazily from project menus instead of scanning every visible project during startup.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. Sidebar contains multiple projects, including at least one Git-backed project and one non-Git project
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, load the home route and confirm the Projects section renders normally.
+2. Open browser devtools or runtime profile output and confirm startup does not issue one `/codex-api/git/repository-status` request per visible project.
+3. Open the action menu for a Git-backed project.
+4. Confirm the menu remains readable and the `New worktree` item appears after the Git status check completes.
+5. Right-click the header row for the same Git-backed project.
+6. Confirm the context menu remains readable and the `New worktree` item appears after the Git status check completes.
+7. Open the action menu for a non-Git project.
+8. Confirm the menu remains readable and `New worktree` is not shown.
+9. Switch to dark theme and repeat steps 3 through 8.
+
+#### Expected Results
+- Startup avoids eager Git status scans for all project rows.
+- Opening a project menu through click or right-click still loads that project's Git status on demand.
+- Menus re-measure placement after async Git status updates add the `New worktree` row.
+- `New worktree` remains available for Git-backed projects and hidden for non-Git projects.
+- Project menus remain usable and visually consistent in both light and dark themes.
+
+#### Rollback/Cleanup
+- None.
+
+---
+
 ### Thread archive recovery and sidebar pruning
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- defer project Git status checks from startup to project menu open
- support both click and right-click project menus
- remeasure menu placement after async Git status adds the New worktree row
- document light/dark manual regression coverage

## Tests
- `pnpm run build:frontend`
- `pnpm run test:unit -- src/components/sidebar/projectMoveMode.test.ts src/composables/useDesktopState.test.ts`

## Browser verification from previous run
- startup git-status calls stayed at 0
- Git-backed project menus showed `New worktree`
- non-Git TestChat menu hid `New worktree`