### PR TITLE
Support multiple thread automations and run-now visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@
 - Reproduce the issue with a focused test when feasible; if direct reproduction is impractical, document the exact reasoning and code evidence used to accept or reject the finding.
 - Prefer adding or updating a regression test for every accepted review-bot bug before or alongside the fix.
 - Do not patch purely to satisfy a bot comment if the behavior is correct, stale, already fixed, or the proposed change would make the implementation worse.
+- After pushing any commit to an open PR, check for Qodo/review-bot comments and PR review status before reporting the push workflow as complete.
 - After fixing an accepted review-bot finding, run the narrow regression test plus the relevant build/typecheck command, push the commit, and re-check the PR comments/status.
 - In the completion report, distinguish confirmed fixes from stale or rejected bot comments.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,16 @@
 
 - Before merging to local `main`, diff-compare all changes on the current branch against `main`.
 
+## PR Review Bot Workflow (MANDATORY)
+
+- Treat Qodo and other review-bot comments as advisory findings, not authoritative fix instructions.
+- Before applying a suggested review-bot fix, inspect the relevant code path and decide whether the reported behavior is technically correct.
+- Reproduce the issue with a focused test when feasible; if direct reproduction is impractical, document the exact reasoning and code evidence used to accept or reject the finding.
+- Prefer adding or updating a regression test for every accepted review-bot bug before or alongside the fix.
+- Do not patch purely to satisfy a bot comment if the behavior is correct, stale, already fixed, or the proposed change would make the implementation worse.
+- After fixing an accepted review-bot finding, run the narrow regression test plus the relevant build/typecheck command, push the commit, and re-check the PR comments/status.
+- In the completion report, distinguish confirmed fixes from stale or rejected bot comments.
+
 ## Tests Documentation Rule (MANDATORY)
 
 - After every feature implementation, update `tests.md` in the repository root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@
 - Reproduce the issue with a focused test when feasible; if direct reproduction is impractical, document the exact reasoning and code evidence used to accept or reject the finding.
 - Prefer adding or updating a regression test for every accepted review-bot bug before or alongside the fix.
 - Do not patch purely to satisfy a bot comment if the behavior is correct, stale, already fixed, or the proposed change would make the implementation worse.
-- After pushing any commit to an open PR, check for Qodo/review-bot comments and PR review status before reporting the push workflow as complete.
+- After pushing any commit to an open PR, wait and poll for Qodo/review-bot comments and PR review status for about 30 seconds before reporting the push workflow as complete.
 - After fixing an accepted review-bot finding, run the narrow regression test plus the relevant build/typecheck command, push the commit, and re-check the PR comments/status.
 - In the completion report, distinguish confirmed fixes from stale or rejected bot comments.
 

--- a/llm-wiki/raw/features/thread-heartbeat-automations.md
+++ b/llm-wiki/raw/features/thread-heartbeat-automations.md
@@ -1,0 +1,23 @@
+# Thread heartbeat automations source notes
+
+Captured: 2026-05-09
+
+## Scope
+
+Thread heartbeat automations are local Codex automation records stored under `$CODEX_HOME/automations/<automation-id>/automation.toml`. Each record can attach to a chat thread through `target_thread_id`.
+
+## Multiple automations per thread
+
+The thread automation bridge supports multiple heartbeat automations with the same `target_thread_id`. Backend listing returns a map from thread id to an ordered automation array. Individual automation edit and delete operations use both `threadId` and `automationId`, so removing one automation does not remove the other automations attached to that thread.
+
+The sidebar thread menu shows `Manage automations...` when at least one automation exists. The manager lists existing automations, lets the user select one for editing, and includes `Add another automation` to create an additional automation for the same thread.
+
+## Manual run
+
+The automation manager includes `Run now` for saved automations. The run endpoint validates the `threadId` and `automationId`, builds the same heartbeat envelope used for scheduled runs, appends it as a default-mode queued message for the target thread, and schedules the backend queue processor immediately.
+
+Manual runs use the persisted thread queue rather than directly interrupting or steering a turn. If the target thread is idle, the queue can start the automation turn immediately. If the thread is already running, the automation waits in queue order until the thread is available.
+
+## Verification expectations
+
+Manual verification should cover light and dark themes, multiple automations on one thread, selecting and editing each automation independently, `Run now` while idle, `Run now` while another turn is active, and cleanup of all test automations.

--- a/llm-wiki/raw/features/thread-heartbeat-automations.md
+++ b/llm-wiki/raw/features/thread-heartbeat-automations.md
@@ -14,9 +14,9 @@ The sidebar thread menu shows `Manage automations...` when at least one automati
 
 ## Manual run
 
-The automation manager includes `Run now` for saved automations. The run endpoint validates the `threadId` and `automationId`, appends the saved automation prompt as a default-mode queued message for the target thread, and schedules the backend queue processor immediately.
+The automation manager includes `Run now` for saved automations. The run endpoint validates the `threadId` and `automationId`, appends a Codex.app-style heartbeat payload as a default-mode queued message for the target thread, and schedules the backend queue processor immediately.
 
-Manual runs intentionally do not inject the raw `<heartbeat>` envelope into the queued message. That envelope is a renderer-specific marker in `codex-web-local`; Codex.app displays it as normal user text when it is written into thread history.
+Manual run heartbeat payloads include `automation_id`, `current_time_iso`, and `instructions`, matching the fields Codex.app requires for heartbeat user-message parsing. Incomplete heartbeat payloads must be treated as normal text so malformed internal XML does not get mislabeled as an automation run.
 
 Manual runs use the persisted thread queue rather than directly interrupting or steering a turn. If the target thread is idle, the queue can start the automation turn immediately. If the thread is already running, the automation waits in queue order until the thread is available.
 

--- a/llm-wiki/raw/features/thread-heartbeat-automations.md
+++ b/llm-wiki/raw/features/thread-heartbeat-automations.md
@@ -20,6 +20,8 @@ Manual run heartbeat payloads include `automation_id`, `current_time_iso`, and `
 
 Manual runs use the persisted thread queue rather than directly interrupting or steering a turn. If the target thread is idle, the queue can start the automation turn immediately. If the thread is already running, the automation waits in queue order until the thread is available.
 
+Heartbeat user messages render as visible user-side automation prompt cards labeled `Sent via automation`. The renderer shows the parsed `instructions` text and never shows the raw heartbeat XML for valid payloads.
+
 ## Verification expectations
 
-Manual verification should cover light and dark themes, multiple automations on one thread, selecting and editing each automation independently, `Run now` while idle, `Run now` while another turn is active, and cleanup of all test automations.
+Manual verification should cover light and dark themes, multiple automations on one thread, selecting and editing each automation independently, `Run now` while idle, `Run now` while another turn is active, visible automation prompt cards in selected threads, and cleanup of all test automations.

--- a/llm-wiki/raw/features/thread-heartbeat-automations.md
+++ b/llm-wiki/raw/features/thread-heartbeat-automations.md
@@ -14,7 +14,9 @@ The sidebar thread menu shows `Manage automations...` when at least one automati
 
 ## Manual run
 
-The automation manager includes `Run now` for saved automations. The run endpoint validates the `threadId` and `automationId`, builds the same heartbeat envelope used for scheduled runs, appends it as a default-mode queued message for the target thread, and schedules the backend queue processor immediately.
+The automation manager includes `Run now` for saved automations. The run endpoint validates the `threadId` and `automationId`, appends the saved automation prompt as a default-mode queued message for the target thread, and schedules the backend queue processor immediately.
+
+Manual runs intentionally do not inject the raw `<heartbeat>` envelope into the queued message. That envelope is a renderer-specific marker in `codex-web-local`; Codex.app displays it as normal user text when it is written into thread history.
 
 Manual runs use the persisted thread queue rather than directly interrupting or steering a turn. If the target thread is idle, the queue can start the automation turn immediately. If the thread is already running, the automation waits in queue order until the thread is available.
 

--- a/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
+++ b/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
@@ -17,11 +17,11 @@ The thread overflow menu shows `Add automation...` when no automation is attache
 
 ## Run Now
 
-Saved automations have a `Run now` action. The backend validates the selected automation, appends the saved prompt to the persisted thread queue, and schedules immediate queue drain.
+Saved automations have a `Run now` action. The backend validates the selected automation, appends a Codex.app-style heartbeat payload to the persisted thread queue, and schedules immediate queue drain.
 
 This keeps manual runs aligned with normal thread behavior: an idle thread can start the run immediately, while a busy thread receives the automation run as a queued turn instead of being interrupted.
 
-Manual runs must not write the raw `<heartbeat>` envelope into thread history because Codex.app renders that XML as normal user-visible text.
+Manual run heartbeat payloads include `automation_id`, `current_time_iso`, and `instructions`, matching the fields Codex.app requires for heartbeat user-message parsing. Incomplete heartbeat payloads remain normal text instead of being labeled as automation runs.
 
 ## Testing
 

--- a/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
+++ b/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
@@ -1,0 +1,26 @@
+# Thread Heartbeat Automations
+
+Thread heartbeat automations are local Codex automation records stored under `$CODEX_HOME/automations/<automation-id>/automation.toml`. The web bridge reads those records and attaches them to sidebar threads by `target_thread_id`.
+
+Source: [thread-heartbeat-automations.md](../../raw/features/thread-heartbeat-automations.md)
+
+## Model
+
+- A single thread can have multiple heartbeat automations.
+- The bridge exposes automations as `threadId -> automation[]`, ordered by creation time and id.
+- Edit and delete operations identify a specific automation with both `threadId` and `automationId`.
+- Deleting a thread removes all automations attached to that thread, while deleting one automation from the manager leaves sibling automations intact.
+
+## Sidebar UI
+
+The thread overflow menu shows `Add automation...` when no automation is attached and `Manage automations...` when one or more automations exist. The manager lists saved automations, supports selecting one automation for editing, and exposes `Add another automation` for creating another record with the same `target_thread_id`.
+
+## Run Now
+
+Saved automations have a `Run now` action. The backend validates the selected automation, wraps the saved prompt in a heartbeat envelope, appends it to the persisted thread queue, and schedules immediate queue drain.
+
+This keeps manual runs aligned with normal thread behavior: an idle thread can start the run immediately, while a busy thread receives the automation run as a queued turn instead of being interrupted.
+
+## Testing
+
+Regression coverage should verify multiple automations on one thread, independent edit/remove behavior, idle `Run now`, busy-thread queued `Run now`, and readable light/dark theme states.

--- a/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
+++ b/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
@@ -23,6 +23,8 @@ This keeps manual runs aligned with normal thread behavior: an idle thread can s
 
 Manual run heartbeat payloads include `automation_id`, `current_time_iso`, and `instructions`, matching the fields Codex.app requires for heartbeat user-message parsing. Incomplete heartbeat payloads remain normal text instead of being labeled as automation runs.
 
+Valid heartbeat user messages render as visible user-side prompt cards labeled `Sent via automation`. The card shows parsed instructions instead of raw heartbeat XML, so selected threads show both automation prompts and assistant replies.
+
 ## Testing
 
-Regression coverage should verify multiple automations on one thread, independent edit/remove behavior, idle `Run now`, busy-thread queued `Run now`, and readable light/dark theme states.
+Regression coverage should verify multiple automations on one thread, independent edit/remove behavior, idle `Run now`, busy-thread queued `Run now`, visible automation prompt cards in selected threads, and readable light/dark theme states.

--- a/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
+++ b/llm-wiki/wiki/concepts/thread-heartbeat-automations.md
@@ -17,9 +17,11 @@ The thread overflow menu shows `Add automation...` when no automation is attache
 
 ## Run Now
 
-Saved automations have a `Run now` action. The backend validates the selected automation, wraps the saved prompt in a heartbeat envelope, appends it to the persisted thread queue, and schedules immediate queue drain.
+Saved automations have a `Run now` action. The backend validates the selected automation, appends the saved prompt to the persisted thread queue, and schedules immediate queue drain.
 
 This keeps manual runs aligned with normal thread behavior: an idle thread can start the run immediately, while a busy thread receives the automation run as a queued turn instead of being interrupted.
+
+Manual runs must not write the raw `<heartbeat>` envelope into thread history because Codex.app renders that XML as normal user-visible text.
 
 ## Testing
 

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -13,11 +13,13 @@
 - [concepts/opencode-zen-big-pickle.md](./concepts/opencode-zen-big-pickle.md): OpenCode Zen Big Pickle model configuration for Codex CLI and OpenCode CLI.
 - [concepts/realtime-chat-rendering.md](./concepts/realtime-chat-rendering.md): realtime chat rendering, sync-churn reduction, and inline media sanitization.
 - [concepts/skills-route-ui.md](./concepts/skills-route-ui.md): Skills route naming, first-launch Plugins card persistence, dark-theme fixes, and verification lessons.
+- [concepts/thread-heartbeat-automations.md](./concepts/thread-heartbeat-automations.md): thread-scoped heartbeat automation storage, multi-automation management, and manual run behavior.
 
 ## Sources
 - [../raw/features/integrated-terminal.md](../raw/features/integrated-terminal.md): source facts for the integrated terminal implementation and follow-up tests.
 - [../raw/features/directory-hub-composio-skills-search.md](../raw/features/directory-hub-composio-skills-search.md): source facts for Directory Hub, Composio connectors, Skills search/install, and edge-case tests.
 - [../raw/features/realtime-chat-rendering-inline-media.md](../raw/features/realtime-chat-rendering-inline-media.md): source facts for realtime chat rendering and inline media sanitization.
 - [../raw/features/skills-route-ui-and-first-launch-card.md](../raw/features/skills-route-ui-and-first-launch-card.md): source facts for the Skills route rename, first-launch Plugins card, dark-theme fix, and dev-server workflow adjustment.
+- [../raw/features/thread-heartbeat-automations.md](../raw/features/thread-heartbeat-automations.md): source facts for thread heartbeat automations, multiple automations per thread, and Run now queue behavior.
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## [2026-05-09] ingest | thread heartbeat automations
+- Added source: `raw/features/thread-heartbeat-automations.md`.
+- Created wiki page: `concepts/thread-heartbeat-automations.md`.
+- Documents: multiple heartbeat automations per thread, ID-aware manager operations, and manual `Run now` behavior through the persisted thread queue.
+- Updated `index.md`.
+
 ## [2026-05-02] ingest | Directory Hub Composio and Skills search
 - Added source: `raw/features/directory-hub-composio-skills-search.md`.
 - Created wiki page: `concepts/directory-hub-composio-skills.md`.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,11 +1,5 @@
 # Log
 
-## [2026-05-09] ingest | thread heartbeat automations
-- Added source: `raw/features/thread-heartbeat-automations.md`.
-- Created wiki page: `concepts/thread-heartbeat-automations.md`.
-- Documents: multiple heartbeat automations per thread, ID-aware manager operations, and manual `Run now` behavior through the persisted thread queue.
-- Updated `index.md`.
-
 ## [2026-05-02] ingest | Directory Hub Composio and Skills search
 - Added source: `raw/features/directory-hub-composio-skills-search.md`.
 - Created wiki page: `concepts/directory-hub-composio-skills.md`.
@@ -40,3 +34,9 @@
 - Added source: `raw/projects/codex-web-local.md`.
 - Created wiki pages: `overview.md`, `entities/codex-web-local.md`, `concepts/merge-to-main-workflow.md`.
 - Updated `index.md` with initial catalog entries.
+
+## [2026-05-09] ingest | thread heartbeat automations
+- Added source: `raw/features/thread-heartbeat-automations.md`.
+- Created wiki page: `concepts/thread-heartbeat-automations.md`.
+- Documents: multiple heartbeat automations per thread, ID-aware manager operations, and manual `Run now` behavior through the persisted thread queue.
+- Updated `index.md`.

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1024,33 +1024,47 @@ function asAutomation(record: unknown): UiThreadAutomation | null {
   }
 }
 
-export async function getThreadAutomationMap(): Promise<Record<string, UiThreadAutomation>> {
+function asAutomationArray(value: unknown): UiThreadAutomation[] {
+  if (Array.isArray(value)) return value.flatMap((item) => {
+    const automation = asAutomation(item)
+    return automation ? [automation] : []
+  })
+  const automation = asAutomation(value)
+  return automation ? [automation] : []
+}
+
+export async function getThreadAutomationMap(): Promise<Record<string, UiThreadAutomation[]>> {
   const response = await fetch('/codex-api/thread-automations')
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, 'Failed to load thread automations'))
   }
   const data = asRecord(asRecord(payload)?.data)
-  const next: Record<string, UiThreadAutomation> = {}
+  const next: Record<string, UiThreadAutomation[]> = {}
   if (!data) return next
   for (const [threadId, value] of Object.entries(data)) {
-    const automation = asAutomation(value)
-    if (automation) next[threadId] = automation
+    const automations = asAutomationArray(value)
+    if (automations.length > 0) next[threadId] = automations
   }
   return next
 }
 
-export async function getThreadAutomation(threadId: string): Promise<UiThreadAutomation | null> {
-  const response = await fetch(`/codex-api/thread-automation?threadId=${encodeURIComponent(threadId)}`)
+export async function getThreadAutomation(threadId: string, automationId?: string): Promise<UiThreadAutomation | null> {
+  const query = new URLSearchParams({ threadId })
+  if (automationId) query.set('automationId', automationId)
+  const response = await fetch(`/codex-api/thread-automation?${query.toString()}`)
   const payload = await response.json().catch(() => null)
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, 'Failed to load thread automation'))
   }
-  return asAutomation(asRecord(payload)?.data)
+  const data = asRecord(payload)?.data
+  if (automationId) return asAutomation(data)
+  return asAutomationArray(data)[0] ?? null
 }
 
 export async function upsertThreadAutomation(input: {
   threadId: string
+  id?: string
   name: string
   prompt: string
   rrule: string
@@ -1070,8 +1084,10 @@ export async function upsertThreadAutomation(input: {
   return automation
 }
 
-export async function deleteThreadAutomation(threadId: string): Promise<void> {
-  const response = await fetch(`/codex-api/thread-automation?threadId=${encodeURIComponent(threadId)}`, {
+export async function deleteThreadAutomation(threadId: string, automationId?: string): Promise<void> {
+  const query = new URLSearchParams({ threadId })
+  if (automationId) query.set('automationId', automationId)
+  const response = await fetch(`/codex-api/thread-automation?${query.toString()}`, {
     method: 'DELETE',
   })
   const payload = await response.json().catch(() => null)

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1096,6 +1096,18 @@ export async function deleteThreadAutomation(threadId: string, automationId?: st
   }
 }
 
+export async function runThreadAutomationNow(threadId: string, automationId: string): Promise<void> {
+  const response = await fetch('/codex-api/thread-automation/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ threadId, automationId }),
+  })
+  const payload = await response.json().catch(() => null)
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to run thread automation'))
+  }
+}
+
 export function subscribeCodexNotifications(onNotification: (value: RpcNotification) => void): () => void {
   return subscribeRpcNotifications(onNotification)
 }

--- a/src/api/normalizers/v2.test.ts
+++ b/src/api/normalizers/v2.test.ts
@@ -63,4 +63,31 @@ describe('normalizeThreadMessagesV2', () => {
     })
     expect(messages[0].isUnhandled).toBeUndefined()
   })
+
+  it('decodes escaped heartbeat instructions without exposing raw XML', () => {
+    const messages = normalizeThreadMessagesV2(threadReadResponseWithContent([{
+      type: 'userMessage',
+      id: 'automation-user-1',
+      content: [{
+        type: 'text',
+        text: `<heartbeat>
+<automation_id>automation-1</automation_id>
+<current_time_iso>2026-05-09T00:00:00.000Z</current_time_iso>
+<instructions>
+Reply with &lt;/instructions&gt; and A &amp; B
+</instructions>
+</heartbeat>`,
+        text_elements: [],
+      }],
+    }]))
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({
+      id: 'automation-user-1',
+      role: 'user',
+      text: 'Reply with </instructions> and A & B',
+      isAutomationRun: true,
+      automationDisplayName: 'automation-1',
+    })
+  })
 })

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -88,9 +88,16 @@ function toImageGenerationUrl(value: string): string {
   return `data:image/png;base64,${compact}`
 }
 
+function decodeHeartbeatXmlText(value: string): string {
+  return value
+    .replace(/&lt;/giu, '<')
+    .replace(/&gt;/giu, '>')
+    .replace(/&amp;/giu, '&')
+}
+
 function readHeartbeatField(value: string, field: string): string {
   const match = new RegExp(`<${field}>\\s*([\\s\\S]*?)\\s*</${field}>`, 'iu').exec(value)
-  return match?.[1]?.trim() ?? ''
+  return match?.[1] ? decodeHeartbeatXmlText(match[1].trim()) : ''
 }
 
 function parseHeartbeatEnvelope(value: string): { automationId: string; currentTimeIso: string; instructions: string } | null {

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -407,7 +407,7 @@ function toUiMessages(item: ThreadItem): UiMessage[] {
     if (hasRenderableUserContent) {
       messages.push({
         id: item.id,
-        role: parsed.isAutomationRun ? 'system' : 'user',
+        role: 'user',
         text: parsed.text,
         images: parsed.images,
         skills: parsed.skills.length > 0 ? parsed.skills : undefined,

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -93,13 +93,15 @@ function readHeartbeatField(value: string, field: string): string {
   return match?.[1]?.trim() ?? ''
 }
 
-function parseHeartbeatEnvelope(value: string): { automationId: string; instructions: string } | null {
+function parseHeartbeatEnvelope(value: string): { automationId: string; currentTimeIso: string; instructions: string } | null {
   const trimmed = value.trim()
   if (!trimmed.startsWith('<heartbeat>') || !trimmed.endsWith('</heartbeat>')) return null
+  const currentTimeIso = readHeartbeatField(trimmed, 'current_time_iso')
   const instructions = readHeartbeatField(trimmed, 'instructions')
-  if (!instructions) return null
+  if (!currentTimeIso || !instructions) return null
   return {
     automationId: readHeartbeatField(trimmed, 'automation_id'),
+    currentTimeIso,
     instructions,
   }
 }

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -244,6 +244,10 @@
               </div>
 
               <article v-if="message.text.length > 0" class="message-card" :data-role="message.role">
+                <div v-if="message.isAutomationRun" class="automation-message-label">
+                  <span>Sent via automation</span>
+                  <code v-if="message.automationDisplayName">{{ message.automationDisplayName }}</code>
+                </div>
                 <div v-if="message.messageType === 'worked'" class="worked-separator-wrap" aria-live="polite">
                   <button type="button" class="worked-separator" @click="toggleWorkedExpand(message)">
                     <span class="worked-separator-line" aria-hidden="true" />
@@ -4858,6 +4862,14 @@ onBeforeUnmount(() => {
   width: fit-content;
   margin-left: auto;
   align-self: flex-end;
+}
+
+.automation-message-label {
+  @apply mb-2 flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500;
+}
+
+.automation-message-label code {
+  @apply rounded-full bg-white/70 px-2 py-0.5 text-[10px] normal-case tracking-normal text-slate-600;
 }
 
 .message-card[data-role='assistant'],

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -754,21 +754,31 @@
           </label>
 
           <p v-if="automationDialogError" class="rename-thread-subtitle automation-thread-error">{{ automationDialogError }}</p>
+          <p v-else-if="automationDialogNotice" class="rename-thread-subtitle automation-thread-notice">{{ automationDialogNotice }}</p>
 
           <div class="rename-thread-actions">
             <button
               v-if="automationDialogMode === 'edit'"
+              class="rename-thread-button"
+              type="button"
+              :disabled="isSavingAutomation || isRunningAutomation"
+              @click="onRunAutomationFromDialog"
+            >
+              {{ isRunningAutomation ? 'Running…' : 'Run now' }}
+            </button>
+            <button
+              v-if="automationDialogMode === 'edit'"
               class="rename-thread-button rename-thread-button-danger"
               type="button"
-              :disabled="isSavingAutomation"
+              :disabled="isSavingAutomation || isRunningAutomation"
               @click="onDeleteAutomationFromDialog"
             >
               Remove
             </button>
-            <button class="rename-thread-button" type="button" :disabled="isSavingAutomation" @click="closeAutomationDialog">
+            <button class="rename-thread-button" type="button" :disabled="isSavingAutomation || isRunningAutomation" @click="closeAutomationDialog">
               {{ t('Cancel') }}
             </button>
-            <button class="rename-thread-button rename-thread-button-primary" type="button" :disabled="isSavingAutomation" @click="submitAutomationDialog">
+            <button class="rename-thread-button rename-thread-button-primary" type="button" :disabled="isSavingAutomation || isRunningAutomation" @click="submitAutomationDialog">
               {{ isSavingAutomation ? 'Saving…' : 'Save' }}
             </button>
           </div>
@@ -786,6 +796,7 @@ import {
   getPinnedThreadState,
   getThreadAutomationMap,
   persistPinnedThreadIds,
+  runThreadAutomationNow,
   upsertThreadAutomation,
 } from '../../api/codexGateway'
 import type { UiProjectGroup, UiThread, UiThreadAutomation, UiThreadAutomationStatus } from '../../types/codex'
@@ -912,7 +923,9 @@ const automationDialogThreadId = ref('')
 const automationDialogAutomationId = ref('')
 const automationDialogMode = ref<'create' | 'edit'>('create')
 const automationDialogError = ref('')
+const automationDialogNotice = ref('')
 const isSavingAutomation = ref(false)
+const isRunningAutomation = ref(false)
 const automationDraft = ref<{
   name: string
   prompt: string
@@ -1488,6 +1501,7 @@ function deleteThreadById(threadId: string): void {
 function openAutomationDialog(threadId: string): void {
   automationDialogThreadId.value = threadId
   automationDialogError.value = ''
+  automationDialogNotice.value = ''
   const existing = automationByThreadId.value[threadId]?.[0]
   if (existing) {
     selectAutomationForEditing(existing.id)
@@ -1501,6 +1515,8 @@ function openAutomationDialog(threadId: string): void {
 function startNewAutomationDraft(): void {
   automationDialogAutomationId.value = ''
   automationDialogMode.value = 'create'
+  automationDialogError.value = ''
+  automationDialogNotice.value = ''
   automationDraft.value = {
     name: 'Thread automation',
     prompt: '',
@@ -1515,6 +1531,7 @@ function selectAutomationForEditing(automationId: string): void {
   automationDialogAutomationId.value = existing.id
   automationDialogMode.value = 'edit'
   automationDialogError.value = ''
+  automationDialogNotice.value = ''
   automationDraft.value = {
     name: existing.name,
     prompt: existing.prompt,
@@ -1528,7 +1545,9 @@ function closeAutomationDialog(): void {
   automationDialogThreadId.value = ''
   automationDialogAutomationId.value = ''
   automationDialogError.value = ''
+  automationDialogNotice.value = ''
   isSavingAutomation.value = false
+  isRunningAutomation.value = false
 }
 
 function omitAutomationThread(state: Record<string, UiThreadAutomation[]>, threadId: string): Record<string, UiThreadAutomation[]> {
@@ -1565,6 +1584,7 @@ async function submitAutomationDialog(): Promise<void> {
   if (!threadId) return
   isSavingAutomation.value = true
   automationDialogError.value = ''
+  automationDialogNotice.value = ''
   try {
     const saved = await upsertThreadAutomation({
       threadId,
@@ -1576,6 +1596,7 @@ async function submitAutomationDialog(): Promise<void> {
     })
     automationByThreadId.value = updateAutomationForThread(automationByThreadId.value, threadId, saved)
     selectAutomationForEditing(saved.id)
+    automationDialogNotice.value = 'Automation saved.'
     isSavingAutomation.value = false
   } catch (error) {
     automationDialogError.value = error instanceof Error ? error.message : 'Failed to save automation'
@@ -1589,6 +1610,7 @@ async function onDeleteAutomationFromDialog(): Promise<void> {
   if (!threadId || !automationId) return
   isSavingAutomation.value = true
   automationDialogError.value = ''
+  automationDialogNotice.value = ''
   try {
     await deleteThreadAutomation(threadId, automationId)
     automationByThreadId.value = removeAutomationForThread(automationByThreadId.value, threadId, automationId)
@@ -1602,6 +1624,23 @@ async function onDeleteAutomationFromDialog(): Promise<void> {
   } catch (error) {
     automationDialogError.value = error instanceof Error ? error.message : 'Failed to remove automation'
     isSavingAutomation.value = false
+  }
+}
+
+async function onRunAutomationFromDialog(): Promise<void> {
+  const threadId = automationDialogThreadId.value
+  const automationId = automationDialogAutomationId.value
+  if (!threadId || !automationId) return
+  isRunningAutomation.value = true
+  automationDialogError.value = ''
+  automationDialogNotice.value = ''
+  try {
+    await runThreadAutomationNow(threadId, automationId)
+    automationDialogNotice.value = 'Automation run queued.'
+  } catch (error) {
+    automationDialogError.value = error instanceof Error ? error.message : 'Failed to run automation'
+  } finally {
+    isRunningAutomation.value = false
   }
 }
 
@@ -2986,5 +3025,9 @@ onBeforeUnmount(() => {
 
 .automation-thread-error {
   @apply mb-0 text-rose-600;
+}
+
+.automation-thread-notice {
+  @apply mb-0 text-emerald-600;
 }
 </style>

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -632,7 +632,7 @@
         @click.stop
       >
         <button class="thread-menu-item" type="button" @click="openAutomationDialog(openThreadMenuThread.id)">
-          {{ threadHasAutomation(openThreadMenuThread.id) ? 'Edit automation…' : 'Add automation…' }}
+          {{ threadHasAutomation(openThreadMenuThread.id) ? 'Manage automations…' : 'Add automation…' }}
         </button>
         <button class="thread-menu-item" type="button" @click="onBrowseThreadFiles(openThreadMenuThread.id)">
           Browse files
@@ -683,10 +683,10 @@
     <Teleport to="body">
       <div v-if="deleteThreadDialogVisible" class="rename-thread-overlay" @click.self="closeDeleteThreadDialog">
         <div class="rename-thread-panel" role="dialog" aria-modal="true" aria-label="Delete thread">
-          <h3 class="rename-thread-title">{{ deleteThreadHasAutomation ? 'Archive chat and remove automation?' : 'Delete thread?' }}</h3>
+          <h3 class="rename-thread-title">{{ deleteThreadHasAutomation ? 'Archive chat and remove automations?' : 'Delete thread?' }}</h3>
           <p class="rename-thread-subtitle">
             <template v-if="deleteThreadHasAutomation">
-              This will archive the thread "{{ deleteThreadTitle }}" and remove the attached heartbeat automation.
+              This will archive the thread "{{ deleteThreadTitle }}" and remove the attached heartbeat automations.
             </template>
             <template v-else>
               This will archive the thread "{{ deleteThreadTitle }}". You can find it later in archived threads.
@@ -706,7 +706,24 @@
       <div v-if="automationDialogVisible" class="rename-thread-overlay" @click.self="closeAutomationDialog">
         <div class="rename-thread-panel automation-thread-panel" role="dialog" aria-modal="true" aria-label="Thread automation">
           <h3 class="rename-thread-title">{{ automationDialogMode === 'edit' ? 'Edit automation' : 'Add automation' }}</h3>
-          <p class="rename-thread-subtitle">This creates a heartbeat automation attached to the selected thread.</p>
+          <p class="rename-thread-subtitle">This creates heartbeat automations attached to the selected thread.</p>
+
+          <div v-if="automationDialogAutomations.length > 0" class="automation-thread-list" aria-label="Thread automations">
+            <button
+              v-for="automation in automationDialogAutomations"
+              :key="automation.id"
+              class="automation-thread-list-item"
+              :class="{ 'is-active': automation.id === automationDialogAutomationId }"
+              type="button"
+              @click="selectAutomationForEditing(automation.id)"
+            >
+              <span>{{ automation.name }}</span>
+              <small>{{ automation.status === 'PAUSED' ? 'Paused' : 'Active' }}</small>
+            </button>
+            <button class="automation-thread-list-item automation-thread-list-add" type="button" @click="startNewAutomationDraft">
+              Add another automation
+            </button>
+          </div>
 
           <label class="automation-thread-field">
             <span class="automation-thread-label">Name</span>
@@ -889,9 +906,10 @@ const renameThreadInputRef = ref<HTMLInputElement | null>(null)
 const deleteThreadDialogVisible = ref(false)
 const deleteThreadDialogThreadId = ref('')
 const deleteThreadTitle = ref('')
-const automationByThreadId = ref<Record<string, UiThreadAutomation>>({})
+const automationByThreadId = ref<Record<string, UiThreadAutomation[]>>({})
 const automationDialogVisible = ref(false)
 const automationDialogThreadId = ref('')
+const automationDialogAutomationId = ref('')
 const automationDialogMode = ref<'create' | 'edit'>('create')
 const automationDialogError = ref('')
 const isSavingAutomation = ref(false)
@@ -905,6 +923,10 @@ const automationDraft = ref<{
   prompt: '',
   rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
   status: 'ACTIVE',
+})
+const automationDialogAutomations = computed(() => {
+  const threadId = automationDialogThreadId.value
+  return threadId ? (automationByThreadId.value[threadId] ?? []) : []
 })
 const groupsContainerRef = ref<HTMLElement | null>(null)
 const pendingProjectDrag = ref<PendingProjectDrag | null>(null)
@@ -1294,12 +1316,17 @@ function onSelect(threadId: string): void {
 }
 
 function threadHasAutomation(threadId: string): boolean {
-  return Boolean(automationByThreadId.value[threadId])
+  return (automationByThreadId.value[threadId]?.length ?? 0) > 0
 }
 
 function threadAutomationTooltip(threadId: string): string {
-  const automation = automationByThreadId.value[threadId]
-  if (!automation) return ''
+  const automations = automationByThreadId.value[threadId] ?? []
+  if (automations.length === 0) return ''
+  if (automations.length > 1) {
+    const activeCount = automations.filter((automation) => automation.status === 'ACTIVE').length
+    return `${automations.length} automations • ${activeCount} active`
+  }
+  const [automation] = automations
   const nextRunLabel = automation.status === 'PAUSED'
     ? '-'
     : automation.nextRunAtMs
@@ -1454,32 +1481,83 @@ function deleteThreadById(threadId: string): void {
 
   if (threadHasAutomation(threadId)) {
     void deleteThreadAutomation(threadId).catch(() => undefined)
-    automationByThreadId.value = Object.fromEntries(
-      Object.entries(automationByThreadId.value).filter(([id]) => id !== threadId),
-    )
+    automationByThreadId.value = omitAutomationThread(automationByThreadId.value, threadId)
   }
 }
 
 function openAutomationDialog(threadId: string): void {
-  const existing = automationByThreadId.value[threadId]
   automationDialogThreadId.value = threadId
-  automationDialogMode.value = existing ? 'edit' : 'create'
   automationDialogError.value = ''
-  automationDraft.value = {
-    name: existing?.name ?? 'Thread automation',
-    prompt: existing?.prompt ?? '',
-    rrule: existing?.rrule ?? 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
-    status: existing?.status ?? 'ACTIVE',
+  const existing = automationByThreadId.value[threadId]?.[0]
+  if (existing) {
+    selectAutomationForEditing(existing.id)
+  } else {
+    startNewAutomationDraft()
   }
   automationDialogVisible.value = true
   closeThreadMenu()
 }
 
+function startNewAutomationDraft(): void {
+  automationDialogAutomationId.value = ''
+  automationDialogMode.value = 'create'
+  automationDraft.value = {
+    name: 'Thread automation',
+    prompt: '',
+    rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+    status: 'ACTIVE',
+  }
+}
+
+function selectAutomationForEditing(automationId: string): void {
+  const existing = automationDialogAutomations.value.find((automation) => automation.id === automationId)
+  if (!existing) return
+  automationDialogAutomationId.value = existing.id
+  automationDialogMode.value = 'edit'
+  automationDialogError.value = ''
+  automationDraft.value = {
+    name: existing.name,
+    prompt: existing.prompt,
+    rrule: existing.rrule,
+    status: existing.status,
+  }
+}
+
 function closeAutomationDialog(): void {
   automationDialogVisible.value = false
   automationDialogThreadId.value = ''
+  automationDialogAutomationId.value = ''
   automationDialogError.value = ''
   isSavingAutomation.value = false
+}
+
+function omitAutomationThread(state: Record<string, UiThreadAutomation[]>, threadId: string): Record<string, UiThreadAutomation[]> {
+  return Object.fromEntries(Object.entries(state).filter(([id]) => id !== threadId))
+}
+
+function updateAutomationForThread(
+  state: Record<string, UiThreadAutomation[]>,
+  threadId: string,
+  saved: UiThreadAutomation,
+): Record<string, UiThreadAutomation[]> {
+  const existing = state[threadId] ?? []
+  const index = existing.findIndex((automation) => automation.id === saved.id)
+  const next = [...existing]
+  if (index >= 0) {
+    next.splice(index, 1, saved)
+  } else {
+    next.push(saved)
+  }
+  return { ...state, [threadId]: next }
+}
+
+function removeAutomationForThread(
+  state: Record<string, UiThreadAutomation[]>,
+  threadId: string,
+  automationId: string,
+): Record<string, UiThreadAutomation[]> {
+  const next = (state[threadId] ?? []).filter((automation) => automation.id !== automationId)
+  return next.length > 0 ? { ...state, [threadId]: next } : omitAutomationThread(state, threadId)
 }
 
 async function submitAutomationDialog(): Promise<void> {
@@ -1490,16 +1568,15 @@ async function submitAutomationDialog(): Promise<void> {
   try {
     const saved = await upsertThreadAutomation({
       threadId,
+      id: automationDialogAutomationId.value || undefined,
       name: automationDraft.value.name,
       prompt: automationDraft.value.prompt,
       rrule: automationDraft.value.rrule,
       status: automationDraft.value.status,
     })
-    automationByThreadId.value = {
-      ...automationByThreadId.value,
-      [threadId]: saved,
-    }
-    closeAutomationDialog()
+    automationByThreadId.value = updateAutomationForThread(automationByThreadId.value, threadId, saved)
+    selectAutomationForEditing(saved.id)
+    isSavingAutomation.value = false
   } catch (error) {
     automationDialogError.value = error instanceof Error ? error.message : 'Failed to save automation'
     isSavingAutomation.value = false
@@ -1508,15 +1585,20 @@ async function submitAutomationDialog(): Promise<void> {
 
 async function onDeleteAutomationFromDialog(): Promise<void> {
   const threadId = automationDialogThreadId.value
-  if (!threadId) return
+  const automationId = automationDialogAutomationId.value
+  if (!threadId || !automationId) return
   isSavingAutomation.value = true
   automationDialogError.value = ''
   try {
-    await deleteThreadAutomation(threadId)
-    automationByThreadId.value = Object.fromEntries(
-      Object.entries(automationByThreadId.value).filter(([id]) => id !== threadId),
-    )
-    closeAutomationDialog()
+    await deleteThreadAutomation(threadId, automationId)
+    automationByThreadId.value = removeAutomationForThread(automationByThreadId.value, threadId, automationId)
+    const nextAutomation = automationByThreadId.value[threadId]?.[0]
+    if (nextAutomation) {
+      selectAutomationForEditing(nextAutomation.id)
+    } else {
+      startNewAutomationDraft()
+    }
+    isSavingAutomation.value = false
   } catch (error) {
     automationDialogError.value = error instanceof Error ? error.message : 'Failed to remove automation'
     isSavingAutomation.value = false
@@ -2871,6 +2953,26 @@ onBeforeUnmount(() => {
 
 .automation-thread-field {
   @apply mb-3 flex flex-col gap-1;
+}
+
+.automation-thread-list {
+  @apply mb-3 flex max-h-40 flex-col gap-1 overflow-y-auto rounded-lg border border-zinc-200 bg-zinc-50 p-1;
+}
+
+.automation-thread-list-item {
+  @apply flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left text-sm text-zinc-700 hover:bg-white;
+}
+
+.automation-thread-list-item.is-active {
+  @apply bg-white font-medium text-zinc-950 shadow-sm;
+}
+
+.automation-thread-list-item small {
+  @apply text-xs font-normal text-zinc-500;
+}
+
+.automation-thread-list-add {
+  @apply justify-center border border-dashed border-zinc-300 text-zinc-500;
 }
 
 .automation-thread-label {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -735,15 +735,76 @@
             <textarea v-model="automationDraft.prompt" class="automation-thread-textarea" rows="6" placeholder="Describe what the automation should do"></textarea>
           </label>
 
-          <label class="automation-thread-field">
-            <span class="automation-thread-label">Schedule (RRULE)</span>
+          <div class="automation-thread-field">
+            <span class="automation-thread-label">Schedule</span>
+            <div class="automation-schedule-mode-group" role="radiogroup" aria-label="Automation schedule type">
+              <button
+                class="automation-schedule-mode"
+                :class="{ 'is-active': automationScheduleDraft.mode === 'daily' }"
+                type="button"
+                @click="setAutomationScheduleMode('daily')"
+              >
+                Daily
+              </button>
+              <button
+                class="automation-schedule-mode"
+                :class="{ 'is-active': automationScheduleDraft.mode === 'interval' }"
+                type="button"
+                @click="setAutomationScheduleMode('interval')"
+              >
+                Interval
+              </button>
+              <button
+                class="automation-schedule-mode"
+                :class="{ 'is-active': automationScheduleDraft.mode === 'advanced' }"
+                type="button"
+                @click="setAutomationScheduleMode('advanced')"
+              >
+                RRULE
+              </button>
+            </div>
+
+            <div v-if="automationScheduleDraft.mode === 'daily'" class="automation-schedule-row">
+              <span class="automation-schedule-copy">Run every day at</span>
+              <input
+                v-model="automationScheduleDraft.dailyTime"
+                class="automation-schedule-time"
+                type="time"
+                @input="syncAutomationRruleFromScheduleDraft"
+              />
+            </div>
+
+            <div v-else-if="automationScheduleDraft.mode === 'interval'" class="automation-schedule-row">
+              <span class="automation-schedule-copy">Run every</span>
+              <input
+                v-model.number="automationScheduleDraft.interval"
+                class="automation-schedule-number"
+                type="number"
+                min="1"
+                step="1"
+                @input="syncAutomationRruleFromScheduleDraft"
+              />
+              <select
+                v-model="automationScheduleDraft.intervalUnit"
+                class="automation-schedule-unit"
+                @change="syncAutomationRruleFromScheduleDraft"
+              >
+                <option value="minutes">minutes</option>
+                <option value="hours">hours</option>
+                <option value="days">days</option>
+              </select>
+            </div>
+
             <input
+              v-if="automationScheduleDraft.mode === 'advanced'"
               v-model="automationDraft.rrule"
               class="rename-thread-input"
               type="text"
               placeholder="FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+              @input="syncAutomationScheduleDraftFromRrule"
             />
-          </label>
+            <p class="automation-schedule-preview">{{ automationSchedulePreview }}</p>
+          </div>
 
           <label class="automation-thread-field">
             <span class="automation-thread-label">Status</span>
@@ -884,6 +945,15 @@ type DragPointerSample = {
 
 type MenuDirection = 'up' | 'down'
 type ChatSortMode = 'created' | 'updated'
+type AutomationScheduleMode = 'daily' | 'interval' | 'advanced'
+type AutomationIntervalUnit = 'minutes' | 'hours' | 'days'
+
+type AutomationScheduleDraft = {
+  mode: AutomationScheduleMode
+  dailyTime: string
+  interval: number
+  intervalUnit: AutomationIntervalUnit
+}
 
 const DRAG_START_THRESHOLD_PX = 4
 const SUPPRESSED_PROJECT_TOGGLE_CLEAR_DELAY_MS = 100
@@ -937,10 +1007,17 @@ const automationDraft = ref<{
   rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
   status: 'ACTIVE',
 })
+const automationScheduleDraft = ref<AutomationScheduleDraft>({
+  mode: 'daily',
+  dailyTime: '09:00',
+  interval: 1,
+  intervalUnit: 'hours',
+})
 const automationDialogAutomations = computed(() => {
   const threadId = automationDialogThreadId.value
   return threadId ? (automationByThreadId.value[threadId] ?? []) : []
 })
+const automationSchedulePreview = computed(() => describeAutomationSchedule(automationDraft.value.rrule))
 const groupsContainerRef = ref<HTMLElement | null>(null)
 const pendingProjectDrag = ref<PendingProjectDrag | null>(null)
 const activeProjectDrag = ref<ActiveProjectDrag | null>(null)
@@ -1348,6 +1425,110 @@ function threadAutomationTooltip(threadId: string): string {
   return `${automation.name} • Next run: ${nextRunLabel}`
 }
 
+function padRruleNumber(value: number): string {
+  return String(Math.max(0, value)).padStart(2, '0')
+}
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(1, Math.floor(parsed))
+}
+
+function buildDailyRrule(time: string): string {
+  const [rawHour, rawMinute] = time.split(':')
+  const hour = Math.min(23, Math.max(0, Number(rawHour) || 0))
+  const minute = Math.min(59, Math.max(0, Number(rawMinute) || 0))
+  return `FREQ=DAILY;BYHOUR=${hour};BYMINUTE=${minute}`
+}
+
+function buildIntervalRrule(interval: number, unit: AutomationIntervalUnit): string {
+  const normalizedInterval = parsePositiveInteger(interval, 1)
+  if (unit === 'minutes') return `FREQ=MINUTELY;INTERVAL=${normalizedInterval}`
+  if (unit === 'hours') return `FREQ=HOURLY;INTERVAL=${normalizedInterval}`
+  return `FREQ=DAILY;INTERVAL=${normalizedInterval}`
+}
+
+function parseRruleParts(rrule: string): Record<string, string> {
+  return Object.fromEntries(
+    rrule
+      .split(';')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const [key, ...rest] = part.split('=')
+        return [key.toUpperCase(), rest.join('=').trim()]
+      })
+      .filter(([key, value]) => key && value),
+  )
+}
+
+function createScheduleDraftFromRrule(rrule: string): AutomationScheduleDraft {
+  const parts = parseRruleParts(rrule)
+  const frequency = parts.FREQ?.toUpperCase()
+  const interval = parsePositiveInteger(parts.INTERVAL, 1)
+  if (frequency === 'DAILY' && parts.BYHOUR !== undefined && parts.BYMINUTE !== undefined && interval === 1) {
+    const hour = Math.min(23, Math.max(0, Number(parts.BYHOUR) || 0))
+    const minute = Math.min(59, Math.max(0, Number(parts.BYMINUTE) || 0))
+    return {
+      mode: 'daily',
+      dailyTime: `${padRruleNumber(hour)}:${padRruleNumber(minute)}`,
+      interval: 1,
+      intervalUnit: 'hours',
+    }
+  }
+  if (frequency === 'MINUTELY' || frequency === 'HOURLY' || (frequency === 'DAILY' && parts.INTERVAL !== undefined)) {
+    return {
+      mode: 'interval',
+      dailyTime: '09:00',
+      interval,
+      intervalUnit: frequency === 'MINUTELY' ? 'minutes' : frequency === 'HOURLY' ? 'hours' : 'days',
+    }
+  }
+  return {
+    mode: 'advanced',
+    dailyTime: '09:00',
+    interval: 1,
+    intervalUnit: 'hours',
+  }
+}
+
+function describeAutomationSchedule(rrule: string): string {
+  const parts = parseRruleParts(rrule)
+  const frequency = parts.FREQ?.toUpperCase()
+  const interval = parsePositiveInteger(parts.INTERVAL, 1)
+  if (frequency === 'DAILY' && parts.BYHOUR !== undefined && parts.BYMINUTE !== undefined && interval === 1) {
+    const hour = Math.min(23, Math.max(0, Number(parts.BYHOUR) || 0))
+    const minute = Math.min(59, Math.max(0, Number(parts.BYMINUTE) || 0))
+    return `RRULE: ${rrule} · runs daily at ${padRruleNumber(hour)}:${padRruleNumber(minute)}`
+  }
+  if (frequency === 'MINUTELY') return `RRULE: ${rrule} · runs every ${interval} minute${interval === 1 ? '' : 's'}`
+  if (frequency === 'HOURLY') return `RRULE: ${rrule} · runs every ${interval} hour${interval === 1 ? '' : 's'}`
+  if (frequency === 'DAILY' && parts.INTERVAL !== undefined) return `RRULE: ${rrule} · runs every ${interval} day${interval === 1 ? '' : 's'}`
+  return rrule ? `RRULE: ${rrule}` : 'RRULE is required.'
+}
+
+function syncAutomationRruleFromScheduleDraft(): void {
+  const draft = automationScheduleDraft.value
+  if (draft.mode === 'daily') {
+    automationDraft.value.rrule = buildDailyRrule(draft.dailyTime)
+  } else if (draft.mode === 'interval') {
+    automationDraft.value.rrule = buildIntervalRrule(draft.interval, draft.intervalUnit)
+  }
+}
+
+function syncAutomationScheduleDraftFromRrule(): void {
+  automationScheduleDraft.value = createScheduleDraftFromRrule(automationDraft.value.rrule)
+}
+
+function setAutomationScheduleMode(mode: AutomationScheduleMode): void {
+  automationScheduleDraft.value = {
+    ...automationScheduleDraft.value,
+    mode,
+  }
+  syncAutomationRruleFromScheduleDraft()
+}
+
 function onExportThread(threadId: string): void {
   emit('export-thread', threadId)
   closeThreadMenu()
@@ -1523,6 +1704,7 @@ function startNewAutomationDraft(): void {
     rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
     status: 'ACTIVE',
   }
+  automationScheduleDraft.value = createScheduleDraftFromRrule(automationDraft.value.rrule)
 }
 
 function selectAutomationForEditing(automationId: string): void {
@@ -1538,6 +1720,7 @@ function selectAutomationForEditing(automationId: string): void {
     rrule: existing.rrule,
     status: existing.status,
   }
+  automationScheduleDraft.value = createScheduleDraftFromRrule(existing.rrule)
 }
 
 function closeAutomationDialog(): void {
@@ -1586,6 +1769,7 @@ async function submitAutomationDialog(): Promise<void> {
   automationDialogError.value = ''
   automationDialogNotice.value = ''
   try {
+    syncAutomationRruleFromScheduleDraft()
     const saved = await upsertThreadAutomation({
       threadId,
       id: automationDialogAutomationId.value || undefined,
@@ -3021,6 +3205,40 @@ onBeforeUnmount(() => {
 .automation-thread-textarea,
 .automation-thread-select {
   @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-schedule-mode-group {
+  @apply grid grid-cols-3 gap-1 rounded-lg border border-zinc-200 bg-zinc-100 p-1;
+}
+
+.automation-schedule-mode {
+  @apply rounded-md px-2 py-1.5 text-xs font-medium text-zinc-600 hover:bg-white;
+}
+
+.automation-schedule-mode.is-active {
+  @apply bg-white text-zinc-950 shadow-sm;
+}
+
+.automation-schedule-row {
+  @apply mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2;
+}
+
+.automation-schedule-copy {
+  @apply text-sm text-zinc-600;
+}
+
+.automation-schedule-time,
+.automation-schedule-number,
+.automation-schedule-unit {
+  @apply rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-schedule-number {
+  @apply w-20;
+}
+
+.automation-schedule-preview {
+  @apply mt-1 text-xs text-zinc-500;
 }
 
 .automation-thread-error {

--- a/src/server/codexAppServerBridge.inlinePayload.test.ts
+++ b/src/server/codexAppServerBridge.inlinePayload.test.ts
@@ -1,12 +1,17 @@
 import { existsSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
-import { mergeSessionSkillInputsIntoTurns, sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BackendQueueProcessor, mergeSessionSkillInputsIntoTurns, sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
 
 const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 const pngDataUrl = `data:image/png;base64,${pngBase64}`
 const gifBase64 = 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
 const jpegBase64 = '/9j/4AAQSkZJRgABAQAAAQABAAD/2w=='
 const webpBase64 = 'UklGRiIAAABXRUJQVlA4IC4AAAAwAQCdASoBAAEAAQAcJaQAA3AA/vuUAAA='
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 function localImagePathFromProxyUrl(value: string): string {
   const parsed = new URL(value, 'http://localhost')
@@ -339,5 +344,29 @@ describe('thread session skill recovery', () => {
       { type: 'text', text: 'second message', text_elements: [] },
       { type: 'skill', name: 'browser-use:browser', path: '/Users/igor/.codex/plugins/browser/SKILL.md' },
     ])
+  })
+})
+
+describe('backend queue scheduling', () => {
+  it('reschedules a pending drain when a run-now request needs an earlier drain', async () => {
+    vi.useFakeTimers()
+    const processor = new BackendQueueProcessor({
+      onNotification: () => () => undefined,
+    } as never)
+    const processThreadQueue = vi
+      .spyOn(processor as unknown as { processThreadQueue: (threadId: string) => Promise<void> }, 'processThreadQueue')
+      .mockResolvedValue(undefined)
+
+    processor.scheduleThreadQueueDrain('thread-1', 5000)
+    processor.scheduleThreadQueueDrain('thread-1', 0)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(processThreadQueue).toHaveBeenCalledTimes(1)
+    expect(processThreadQueue).toHaveBeenCalledWith('thread-1')
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(processThreadQueue).toHaveBeenCalledTimes(1)
+
+    processor.dispose()
   })
 })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -4772,6 +4772,7 @@ class AppServerProcess {
 class BackendQueueProcessor {
   private readonly processingThreadIds = new Set<string>()
   private readonly queueDrainTimersByThreadId = new Map<string, ReturnType<typeof setTimeout>>()
+  private readonly queueDrainDueAtByThreadId = new Map<string, number>()
   private readonly unsubscribe: () => void
 
   constructor(private readonly appServer: AppServerProcess) {
@@ -4790,6 +4791,7 @@ class BackendQueueProcessor {
       clearTimeout(timer)
     }
     this.queueDrainTimersByThreadId.clear()
+    this.queueDrainDueAtByThreadId.clear()
     this.processingThreadIds.clear()
   }
 
@@ -4805,13 +4807,25 @@ class BackendQueueProcessor {
   }
 
   scheduleThreadQueueDrain(threadId: string, delayMs = 5000): void {
-    if (!threadId || this.queueDrainTimersByThreadId.has(threadId)) return
+    if (!threadId) return
+    const normalizedDelayMs = Math.max(0, delayMs)
+    const nextDueAt = Date.now() + normalizedDelayMs
+    const existingDueAt = this.queueDrainDueAtByThreadId.get(threadId)
+    const existingTimer = this.queueDrainTimersByThreadId.get(threadId)
+    if (existingTimer) {
+      if (existingDueAt !== undefined && existingDueAt <= nextDueAt) return
+      clearTimeout(existingTimer)
+      this.queueDrainTimersByThreadId.delete(threadId)
+      this.queueDrainDueAtByThreadId.delete(threadId)
+    }
     const timer = setTimeout(() => {
       this.queueDrainTimersByThreadId.delete(threadId)
+      this.queueDrainDueAtByThreadId.delete(threadId)
       void this.processThreadQueue(threadId)
-    }, Math.max(0, delayMs))
+    }, normalizedDelayMs)
     timer.unref?.()
     this.queueDrainTimersByThreadId.set(threadId, timer)
+    this.queueDrainDueAtByThreadId.set(threadId, nextDueAt)
   }
 
   async processThreadQueue(threadId: string): Promise<void> {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3508,6 +3508,11 @@ type BackendQueuedTurn = {
   message: StoredQueuedMessage
 }
 
+type ThreadQueueStateUpdate<T> = {
+  nextState: ThreadQueueState
+  result: T
+}
+
 type ResolvedCollaborationModeSettings = {
   model: string
   reasoningEffort: ReasoningEffort | null
@@ -3572,6 +3577,8 @@ function normalizeThreadQueueState(value: unknown): ThreadQueueState {
   return state
 }
 
+let threadQueueMutationChain: Promise<unknown> = Promise.resolve()
+
 async function readThreadQueueState(): Promise<ThreadQueueState> {
   const statePath = getCodexGlobalStatePath()
   try {
@@ -3583,7 +3590,7 @@ async function readThreadQueueState(): Promise<ThreadQueueState> {
   }
 }
 
-async function writeThreadQueueState(nextState: ThreadQueueState): Promise<void> {
+async function writeThreadQueueStateUnlocked(nextState: ThreadQueueState): Promise<void> {
   const statePath = getCodexGlobalStatePath()
   let payload: Record<string, unknown> = {}
   try {
@@ -3601,14 +3608,36 @@ async function writeThreadQueueState(nextState: ThreadQueueState): Promise<void>
   await writeFile(statePath, JSON.stringify(payload), 'utf8')
 }
 
+async function withThreadQueueStateUpdate<T>(
+  update: (state: ThreadQueueState) => ThreadQueueStateUpdate<T> | Promise<ThreadQueueStateUpdate<T>>,
+): Promise<T> {
+  const run = threadQueueMutationChain.then(async () => {
+    const currentState = await readThreadQueueState()
+    const { nextState, result } = await update(currentState)
+    await writeThreadQueueStateUnlocked(nextState)
+    return result
+  })
+  threadQueueMutationChain = run.catch(() => {})
+  return run
+}
+
+async function writeThreadQueueState(nextState: ThreadQueueState): Promise<void> {
+  await withThreadQueueStateUpdate(() => ({
+    nextState: normalizeThreadQueueState(nextState),
+    result: undefined,
+  }))
+}
+
 async function appendThreadQueuedMessage(threadId: string, message: StoredQueuedMessage): Promise<void> {
   const normalizedThreadId = threadId.trim()
   if (!normalizedThreadId) throw new Error('threadId is required')
-  const state = await readThreadQueueState()
-  await writeThreadQueueState({
-    ...state,
-    [normalizedThreadId]: [...(state[normalizedThreadId] ?? []), message],
-  })
+  await withThreadQueueStateUpdate((state) => ({
+    nextState: {
+      ...state,
+      [normalizedThreadId]: [...(state[normalizedThreadId] ?? []), message],
+    },
+    result: undefined,
+  }))
 }
 
 function normalizeReasoningEffort(value: unknown): ReasoningEffort | '' {
@@ -3643,14 +3672,21 @@ function buildTextWithAttachments(prompt: string, files: StoredQueuedMessage['fi
   return `${prefix}\n## My request for Codex:\n\n${prompt}\n`
 }
 
+function escapeHeartbeatXmlText(value: string): string {
+  return value
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+}
+
 function buildHeartbeatQueuedMessage(automation: ThreadAutomationRecord): StoredQueuedMessage {
   return {
     id: `automation-${automation.id}-${Date.now()}-${randomBytes(3).toString('hex')}`,
     text: `<heartbeat>
-<automation_id>${automation.id}</automation_id>
+<automation_id>${escapeHeartbeatXmlText(automation.id)}</automation_id>
 <current_time_iso>${new Date().toISOString()}</current_time_iso>
 <instructions>
-${automation.prompt}
+${escapeHeartbeatXmlText(automation.prompt)}
 </instructions>
 </heartbeat>`,
     imageUrls: [],
@@ -4828,27 +4864,33 @@ class BackendQueueProcessor {
   }
 
   private async popNextQueuedTurn(threadId: string): Promise<BackendQueuedTurn | null> {
-    const state = await readThreadQueueState()
-    const queue = state[threadId]
-    if (!queue || queue.length === 0) return null
+    return withThreadQueueStateUpdate((state) => {
+      const queue = state[threadId]
+      if (!queue || queue.length === 0) {
+        return { nextState: state, result: null }
+      }
 
-    const [message, ...rest] = queue
-    const nextState = { ...state }
-    if (rest.length > 0) {
-      nextState[threadId] = rest
-    } else {
-      delete nextState[threadId]
-    }
-    await writeThreadQueueState(nextState)
-    return { threadId, message }
+      const [message, ...rest] = queue
+      const nextState = { ...state }
+      if (rest.length > 0) {
+        nextState[threadId] = rest
+      } else {
+        delete nextState[threadId]
+      }
+      return { nextState, result: { threadId, message } }
+    })
   }
 
   private async restoreQueuedTurn(turn: BackendQueuedTurn): Promise<void> {
-    const state = await readThreadQueueState()
-    const queue = state[turn.threadId] ?? []
-    await writeThreadQueueState({
-      ...state,
-      [turn.threadId]: [turn.message, ...queue],
+    await withThreadQueueStateUpdate((state) => {
+      const queue = state[turn.threadId] ?? []
+      return {
+        nextState: {
+          ...state,
+          [turn.threadId]: [turn.message, ...queue],
+        },
+        result: undefined,
+      }
     })
   }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3646,7 +3646,13 @@ function buildTextWithAttachments(prompt: string, files: StoredQueuedMessage['fi
 function buildHeartbeatQueuedMessage(automation: ThreadAutomationRecord): StoredQueuedMessage {
   return {
     id: `automation-${automation.id}-${Date.now()}-${randomBytes(3).toString('hex')}`,
-    text: automation.prompt,
+    text: `<heartbeat>
+<automation_id>${automation.id}</automation_id>
+<current_time_iso>${new Date().toISOString()}</current_time_iso>
+<instructions>
+${automation.prompt}
+</instructions>
+</heartbeat>`,
     imageUrls: [],
     skills: [],
     fileAttachments: [],

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -4769,7 +4769,7 @@ class AppServerProcess {
   }
 }
 
-class BackendQueueProcessor {
+export class BackendQueueProcessor {
   private readonly processingThreadIds = new Set<string>()
   private readonly queueDrainTimersByThreadId = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly queueDrainDueAtByThreadId = new Map<string, number>()

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3643,19 +3643,10 @@ function buildTextWithAttachments(prompt: string, files: StoredQueuedMessage['fi
   return `${prefix}\n## My request for Codex:\n\n${prompt}\n`
 }
 
-function buildHeartbeatAutomationPrompt(automation: ThreadAutomationRecord): string {
-  return [
-    '<heartbeat>',
-    `<automation_id>${automation.id}</automation_id>`,
-    `<instructions>${automation.prompt}</instructions>`,
-    '</heartbeat>',
-  ].join('\n')
-}
-
 function buildHeartbeatQueuedMessage(automation: ThreadAutomationRecord): StoredQueuedMessage {
   return {
     id: `automation-${automation.id}-${Date.now()}-${randomBytes(3).toString('hex')}`,
-    text: buildHeartbeatAutomationPrompt(automation),
+    text: automation.prompt,
     imageUrls: [],
     skills: [],
     fileAttachments: [],

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3601,6 +3601,16 @@ async function writeThreadQueueState(nextState: ThreadQueueState): Promise<void>
   await writeFile(statePath, JSON.stringify(payload), 'utf8')
 }
 
+async function appendThreadQueuedMessage(threadId: string, message: StoredQueuedMessage): Promise<void> {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) throw new Error('threadId is required')
+  const state = await readThreadQueueState()
+  await writeThreadQueueState({
+    ...state,
+    [normalizedThreadId]: [...(state[normalizedThreadId] ?? []), message],
+  })
+}
+
 function normalizeReasoningEffort(value: unknown): ReasoningEffort | '' {
   const allowed: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
   return typeof value === 'string' && allowed.includes(value as ReasoningEffort)
@@ -3631,6 +3641,26 @@ function buildTextWithAttachments(prompt: string, files: StoredQueuedMessage['fi
     prefix += `\n## ${f.label}: ${f.path}\n`
   }
   return `${prefix}\n## My request for Codex:\n\n${prompt}\n`
+}
+
+function buildHeartbeatAutomationPrompt(automation: ThreadAutomationRecord): string {
+  return [
+    '<heartbeat>',
+    `<automation_id>${automation.id}</automation_id>`,
+    `<instructions>${automation.prompt}</instructions>`,
+    '</heartbeat>',
+  ].join('\n')
+}
+
+function buildHeartbeatQueuedMessage(automation: ThreadAutomationRecord): StoredQueuedMessage {
+  return {
+    id: `automation-${automation.id}-${Date.now()}-${randomBytes(3).toString('hex')}`,
+    text: buildHeartbeatAutomationPrompt(automation),
+    imageUrls: [],
+    skills: [],
+    fileAttachments: [],
+    collaborationMode: 'default',
+  }
 }
 
 function fileNameFromPath(pathValue: string): string {
@@ -6830,6 +6860,25 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         }
         const automation = await writeThreadHeartbeatAutomation({ threadId, id, name, prompt, rrule, status })
         setJson(res, 200, { data: automation })
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread-automation/run') {
+        const payload = asRecord(await readJsonBody(req))
+        const threadId = typeof payload?.threadId === 'string' ? payload.threadId.trim() : ''
+        const automationId = typeof payload?.automationId === 'string' ? payload.automationId.trim() : ''
+        if (!threadId || !automationId) {
+          setJson(res, 400, { error: 'threadId and automationId are required' })
+          return
+        }
+        const automation = await readThreadHeartbeatAutomation(threadId, automationId)
+        if (!automation) {
+          setJson(res, 404, { error: 'Automation not found for thread' })
+          return
+        }
+        await appendThreadQueuedMessage(threadId, buildHeartbeatQueuedMessage(automation))
+        backendQueueProcessor.scheduleThreadQueueDrain(threadId, 0)
+        setJson(res, 200, { data: { queued: true } })
         return
       }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3215,9 +3215,9 @@ async function readAutomationRecordFromFile(filePath: string): Promise<ThreadAut
   }
 }
 
-async function listThreadHeartbeatAutomations(): Promise<Record<string, ThreadAutomationRecord>> {
+async function listThreadHeartbeatAutomations(): Promise<Record<string, ThreadAutomationRecord[]>> {
   const automationRoot = getCodexAutomationsDir()
-  const next: Record<string, ThreadAutomationRecord> = {}
+  const next: Record<string, ThreadAutomationRecord[]> = {}
   let entries
   try {
     entries = await readdir(automationRoot, { withFileTypes: true })
@@ -3229,19 +3229,45 @@ async function listThreadHeartbeatAutomations(): Promise<Record<string, ThreadAu
     if (!entry.isDirectory()) continue
     const automation = await readAutomationRecordFromFile(join(automationRoot, entry.name, 'automation.toml'))
     if (!automation || automation.kind !== 'heartbeat' || !automation.targetThreadId) continue
-    next[automation.targetThreadId] = automation
+    next[automation.targetThreadId] = [...(next[automation.targetThreadId] ?? []), automation]
+  }
+
+  for (const automations of Object.values(next)) {
+    automations.sort((first, second) => {
+      const firstCreatedAt = first.createdAtMs ?? 0
+      const secondCreatedAt = second.createdAtMs ?? 0
+      if (firstCreatedAt !== secondCreatedAt) return firstCreatedAt - secondCreatedAt
+      return first.id.localeCompare(second.id)
+    })
   }
 
   return next
 }
 
-async function readThreadHeartbeatAutomation(threadId: string): Promise<ThreadAutomationRecord | null> {
+async function readThreadHeartbeatAutomations(threadId: string): Promise<ThreadAutomationRecord[]> {
   const all = await listThreadHeartbeatAutomations()
-  return all[threadId] ?? null
+  return all[threadId] ?? []
+}
+
+async function readThreadHeartbeatAutomation(threadId: string, automationId = ''): Promise<ThreadAutomationRecord | null> {
+  const automations = await readThreadHeartbeatAutomations(threadId)
+  if (automationId) return automations.find((automation) => automation.id === automationId) ?? null
+  return automations[0] ?? null
+}
+
+function resolveUniqueAutomationId(existingIds: Set<string>, threadId: string, name: string): string {
+  const baseId = slugifyAutomationId(threadId, name)
+  if (!existingIds.has(baseId)) return baseId
+  for (let index = 2; index < 1000; index += 1) {
+    const candidate = `${baseId}-${index}`
+    if (!existingIds.has(candidate)) return candidate
+  }
+  return `${baseId}-${randomBytes(4).toString('hex')}`
 }
 
 async function writeThreadHeartbeatAutomation(input: {
   threadId: string
+  id?: string
   name: string
   prompt: string
   rrule: string
@@ -3257,8 +3283,10 @@ async function writeThreadHeartbeatAutomation(input: {
 
   const automationRoot = getCodexAutomationsDir()
   await mkdir(automationRoot, { recursive: true })
-  const existing = await readThreadHeartbeatAutomation(threadId)
-  const id = existing?.id ?? slugifyAutomationId(threadId, name)
+  const existing = input.id ? await readThreadHeartbeatAutomation(threadId, input.id.trim()) : null
+  const entries = await readdir(automationRoot, { withFileTypes: true }).catch(() => [])
+  const existingIds = new Set(entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name))
+  const id = existing?.id ?? resolveUniqueAutomationId(existingIds, threadId, name)
   const automationDir = join(automationRoot, id)
   const now = Date.now()
   const record: ThreadAutomationRecord = {
@@ -3285,10 +3313,19 @@ async function writeThreadHeartbeatAutomation(input: {
   return record
 }
 
-async function deleteThreadHeartbeatAutomation(threadId: string): Promise<boolean> {
-  const automation = await readThreadHeartbeatAutomation(threadId.trim())
-  if (!automation) return false
-  await rm(join(getCodexAutomationsDir(), automation.id), { recursive: true, force: true })
+async function deleteThreadHeartbeatAutomation(threadId: string, automationId = ''): Promise<boolean> {
+  const normalizedThreadId = threadId.trim()
+  const normalizedAutomationId = automationId.trim()
+  if (normalizedAutomationId) {
+    const automation = await readThreadHeartbeatAutomation(normalizedThreadId, normalizedAutomationId)
+    if (!automation) return false
+    await rm(join(getCodexAutomationsDir(), automation.id), { recursive: true, force: true })
+    return true
+  }
+
+  const automations = await readThreadHeartbeatAutomations(normalizedThreadId)
+  if (automations.length === 0) return false
+  await Promise.all(automations.map((automation) => rm(join(getCodexAutomationsDir(), automation.id), { recursive: true, force: true })))
   return true
 }
 
@@ -6716,11 +6753,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'GET' && url.pathname === '/codex-api/thread-automation') {
         const threadId = url.searchParams.get('threadId')?.trim() ?? ''
+        const automationId = url.searchParams.get('automationId')?.trim() ?? ''
         if (!threadId) {
           setJson(res, 400, { error: 'Missing threadId' })
           return
         }
-        const automation = await readThreadHeartbeatAutomation(threadId)
+        const automation = automationId
+          ? await readThreadHeartbeatAutomation(threadId, automationId)
+          : await readThreadHeartbeatAutomations(threadId)
         setJson(res, 200, { data: automation })
         return
       }
@@ -6779,6 +6819,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       if (req.method === 'PUT' && url.pathname === '/codex-api/thread-automation') {
         const payload = asRecord(await readJsonBody(req))
         const threadId = typeof payload?.threadId === 'string' ? payload.threadId.trim() : ''
+        const id = typeof payload?.id === 'string' ? payload.id.trim() : ''
         const name = typeof payload?.name === 'string' ? payload.name.trim() : ''
         const prompt = typeof payload?.prompt === 'string' ? payload.prompt.trim() : ''
         const rrule = typeof payload?.rrule === 'string' ? payload.rrule.trim() : ''
@@ -6787,18 +6828,19 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           setJson(res, 400, { error: 'threadId, name, prompt, and rrule are required' })
           return
         }
-        const automation = await writeThreadHeartbeatAutomation({ threadId, name, prompt, rrule, status })
+        const automation = await writeThreadHeartbeatAutomation({ threadId, id, name, prompt, rrule, status })
         setJson(res, 200, { data: automation })
         return
       }
 
       if (req.method === 'DELETE' && url.pathname === '/codex-api/thread-automation') {
         const threadId = url.searchParams.get('threadId')?.trim() ?? ''
+        const automationId = url.searchParams.get('automationId')?.trim() ?? ''
         if (!threadId) {
           setJson(res, 400, { error: 'Missing threadId' })
           return
         }
-        const removed = await deleteThreadHeartbeatAutomation(threadId)
+        const removed = await deleteThreadHeartbeatAutomation(threadId, automationId)
         setJson(res, 200, { data: { removed } })
         return
       }

--- a/src/style.css
+++ b/src/style.css
@@ -580,6 +580,14 @@
   @apply bg-zinc-700;
 }
 
+:root.dark .automation-message-label {
+  @apply text-zinc-400;
+}
+
+:root.dark .automation-message-label code {
+  @apply bg-zinc-800/80 text-zinc-300;
+}
+
 :root.dark .message-copy-button {
   @apply border-zinc-700 bg-zinc-800/90 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-100;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -475,6 +475,31 @@
   @apply border-zinc-600 bg-zinc-700 text-zinc-100;
 }
 
+:root.dark .automation-thread-list {
+  @apply border-zinc-700 bg-zinc-900;
+}
+
+:root.dark .automation-thread-list-item {
+  @apply text-zinc-300 hover:bg-zinc-800;
+}
+
+:root.dark .automation-thread-list-item.is-active {
+  @apply bg-zinc-800 text-zinc-50 shadow-none;
+}
+
+:root.dark .automation-thread-list-item small {
+  @apply text-zinc-500;
+}
+
+:root.dark .automation-thread-list-add {
+  @apply border-zinc-700 text-zinc-400;
+}
+
+:root.dark .automation-thread-select,
+:root.dark .automation-thread-textarea {
+  @apply border-zinc-600 bg-zinc-700 text-zinc-100;
+}
+
 :root.dark .rename-thread-button {
   @apply text-zinc-300 hover:bg-zinc-700;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -500,6 +500,10 @@
   @apply border-zinc-600 bg-zinc-700 text-zinc-100;
 }
 
+:root.dark .automation-thread-notice {
+  @apply text-emerald-400;
+}
+
 :root.dark .rename-thread-button {
   @apply text-zinc-300 hover:bg-zinc-700;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -500,6 +500,33 @@
   @apply border-zinc-600 bg-zinc-700 text-zinc-100;
 }
 
+:root.dark .automation-schedule-mode-group {
+  @apply border-zinc-700 bg-zinc-900;
+}
+
+:root.dark .automation-schedule-mode {
+  @apply text-zinc-400 hover:bg-zinc-800;
+}
+
+:root.dark .automation-schedule-mode.is-active {
+  @apply bg-zinc-800 text-zinc-50 shadow-none;
+}
+
+:root.dark .automation-schedule-row {
+  @apply border-zinc-700 bg-zinc-900;
+}
+
+:root.dark .automation-schedule-copy,
+:root.dark .automation-schedule-preview {
+  @apply text-zinc-400;
+}
+
+:root.dark .automation-schedule-time,
+:root.dark .automation-schedule-number,
+:root.dark .automation-schedule-unit {
+  @apply border-zinc-600 bg-zinc-700 text-zinc-100;
+}
+
 :root.dark .automation-thread-notice {
   @apply text-emerald-400;
 }

--- a/tests.md
+++ b/tests.md
@@ -92,13 +92,17 @@ This file tracks manual regression and feature verification steps.
 7. Open `Manage automations…`, confirm the saved values are prefilled, then click `Add another automation`.
 8. Fill a second automation with a different name and RRULE, save it, and confirm both automations appear in the dialog list.
 9. Select each automation from the list and confirm its own prompt, RRULE, and status load independently.
-10. Remove one automation and confirm the other remains attached to the same thread.
-11. Switch to dark theme, reopen `Manage automations…`, and confirm the list, inputs, textarea, and status select remain readable.
-12. Remove the final automation and confirm the thread menu returns to `Add automation…`.
+10. Click `Run now` for one saved automation while the thread is idle and confirm the automation run is queued or starts in the selected thread.
+11. Start a normal thread turn, reopen `Manage automations…`, click `Run now` for another saved automation, and confirm it waits in the queue until the active turn can finish.
+12. Remove one automation and confirm the other remains attached to the same thread.
+13. Switch to dark theme, reopen `Manage automations…`, and confirm the list, inputs, textarea, status select, `Run now`, and queued-run notice remain readable.
+14. Remove the final automation and confirm the thread menu returns to `Add automation…`.
 
 #### Expected Results
 - Multiple thread-scoped heartbeat automations can be created under the Codex automations store with the same `target_thread_id`.
 - The automation manager is hosted from the thread menu and supports adding, selecting, editing, and removing individual automations.
+- `Run now` enqueues the selected automation immediately using that automation's saved prompt, without requiring a schedule tick.
+- Manual runs use the existing thread queue, so they do not interrupt an active turn and run in order when the thread is available.
 - Removing one automation does not remove other automations attached to the same thread.
 - Removing the final automation removes the thread row automation chip and returns the menu to `Add automation…`.
 - Light and dark theme automation manager surfaces remain readable.

--- a/tests.md
+++ b/tests.md
@@ -80,23 +80,31 @@ This file tracks manual regression and feature verification steps.
 - App is running from this repository.
 - At least one local thread exists in the sidebar.
 - Local Codex home is writable (`$CODEX_HOME` or `~/.codex`).
+- Light and dark themes are both available from Settings.
 
 #### Steps
-1. Open the sidebar thread menu for a thread without an attached automation.
+1. In light theme, open the sidebar thread menu for a thread without an attached automation.
 2. Confirm the menu shows `Add automation…`.
 3. Click `Add automation…`.
 4. Fill name, prompt, RRULE schedule, and set status to `Paused`.
 5. Save the automation and reopen the same thread menu.
-6. Confirm the menu now shows `Edit automation…` and the thread row shows an automation chip.
-7. Open `Edit automation…`, confirm the saved values are prefilled, then remove the automation.
+6. Confirm the menu now shows `Manage automations…` and the thread row shows an automation chip.
+7. Open `Manage automations…`, confirm the saved values are prefilled, then click `Add another automation`.
+8. Fill a second automation with a different name and RRULE, save it, and confirm both automations appear in the dialog list.
+9. Select each automation from the list and confirm its own prompt, RRULE, and status load independently.
+10. Remove one automation and confirm the other remains attached to the same thread.
+11. Switch to dark theme, reopen `Manage automations…`, and confirm the list, inputs, textarea, and status select remain readable.
+12. Remove the final automation and confirm the thread menu returns to `Add automation…`.
 
 #### Expected Results
-- Thread-scoped heartbeat automations are created under the Codex automations store and attached by `target_thread_id`.
-- The automation editor is hosted from the thread menu and uses Codex.app wording.
-- Removing the automation removes the thread row automation chip and returns the menu to `Add automation…`.
+- Multiple thread-scoped heartbeat automations can be created under the Codex automations store with the same `target_thread_id`.
+- The automation manager is hosted from the thread menu and supports adding, selecting, editing, and removing individual automations.
+- Removing one automation does not remove other automations attached to the same thread.
+- Removing the final automation removes the thread row automation chip and returns the menu to `Add automation…`.
+- Light and dark theme automation manager surfaces remain readable.
 
 #### Rollback/Cleanup
-- Remove any test automation from the thread automation dialog or delete its folder under `$CODEX_HOME/automations/<automation-id>/`.
+- Remove any test automations from the thread automation dialog or delete their folders under `$CODEX_HOME/automations/<automation-id>/`.
 
 ### Feature: Projectless new chat folders
 
@@ -4338,7 +4346,7 @@ The thread overflow menu includes a `Copy path` item that copies the selected th
 5. Reopen the same menu in dark theme and verify the item remains readable and in the same position
 
 #### Expected Results
-- The menu order is `Add automation...`, `Browse files`, `Copy path`, `Export chat`, `Create chat fork`, `Rename thread`, `Delete thread`
+- The menu order is `Add automation...` or `Manage automations...`, `Browse files`, `Copy path`, `Export chat`, `Create chat fork`, `Rename thread`, `Delete thread`
 - Clicking `Copy path` closes the menu
 - Clipboard contents equal the thread's `cwd` path
 - Light theme and dark theme both keep the menu item readable

--- a/tests.md
+++ b/tests.md
@@ -96,12 +96,14 @@ This file tracks manual regression and feature verification steps.
 11. Start a normal thread turn, reopen `Manage automations…`, click `Run now` for another saved automation, and confirm it waits in the queue until the active turn can finish.
 12. Remove one automation and confirm the other remains attached to the same thread.
 13. Switch to dark theme, reopen `Manage automations…`, and confirm the list, inputs, textarea, status select, `Run now`, and queued-run notice remain readable.
-14. Remove the final automation and confirm the thread menu returns to `Add automation…`.
+14. Select a thread that already contains automation runs and confirm both the automation prompt card and the assistant reply are visible.
+15. Remove the final automation and confirm the thread menu returns to `Add automation…`.
 
 #### Expected Results
 - Multiple thread-scoped heartbeat automations can be created under the Codex automations store with the same `target_thread_id`.
 - The automation manager is hosted from the thread menu and supports adding, selecting, editing, and removing individual automations.
 - `Run now` enqueues the selected automation immediately using a Codex.app-style heartbeat payload with `automation_id`, `current_time_iso`, and `instructions`, without requiring a schedule tick.
+- Automation heartbeat prompts render as visible user-side cards labeled `Sent via automation`; raw heartbeat XML is not shown.
 - Manual runs use the existing thread queue, so they do not interrupt an active turn and run in order when the thread is available.
 - Removing one automation does not remove other automations attached to the same thread.
 - Removing the final automation removes the thread row automation chip and returns the menu to `Add automation…`.

--- a/tests.md
+++ b/tests.md
@@ -101,7 +101,7 @@ This file tracks manual regression and feature verification steps.
 #### Expected Results
 - Multiple thread-scoped heartbeat automations can be created under the Codex automations store with the same `target_thread_id`.
 - The automation manager is hosted from the thread menu and supports adding, selecting, editing, and removing individual automations.
-- `Run now` enqueues the selected automation immediately using that automation's saved prompt, without requiring a schedule tick.
+- `Run now` enqueues the selected automation immediately using a Codex.app-style heartbeat payload with `automation_id`, `current_time_iso`, and `instructions`, without requiring a schedule tick.
 - Manual runs use the existing thread queue, so they do not interrupt an active turn and run in order when the thread is available.
 - Removing one automation does not remove other automations attached to the same thread.
 - Removing the final automation removes the thread row automation chip and returns the menu to `Add automation…`.


### PR DESCRIPTION
## Summary
- support multiple heartbeat automations attached to one thread
- add Run now for saved thread automations using Codex.app-style heartbeat payloads
- render automation prompt messages visibly in selected threads without raw heartbeat XML

## Verification
- pnpm run build:frontend
- created two TestChat automations with 1-minute and 2-minute schedules and confirmed both executed
- browser check on TestChat thread confirmed automation labels visible and raw heartbeat XML hidden