### PR TITLE
Fix composer mode scoping and Fast mode support

### DIFF
--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -637,7 +637,7 @@ const standaloneFileAttachments = computed(() => {
 })
 const isInteractionDisabled = computed(() => props.disabled || !props.activeThreadId)
 const isComposerConfigDisabled = computed(() => props.disabled || !props.activeThreadId)
-const isFastModeSupported = computed(() => props.selectedModel.trim() === 'gpt-5.4')
+const isFastModeSupported = computed(() => /^gpt-5\.(?:4|5)(?:$|-)/.test(props.selectedModel.trim()))
 const showFastModeModelIcon = computed(() =>
   props.selectedSpeedMode === 'fast' && isFastModeSupported.value,
 )

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -418,6 +418,36 @@ describe('thread unread state helpers', () => {
   })
 })
 
+describe('collaboration mode selection', () => {
+  it('does not carry plan mode from new chats into existing threads', () => {
+    installTestWindow({
+      'codex-web-local.collaboration-mode.v1': 'plan',
+    })
+
+    const state = useDesktopState()
+
+    expect(state.selectedCollaborationMode.value).toBe('default')
+
+    state.setSelectedCollaborationMode('plan')
+
+    expect(state.selectedCollaborationMode.value).toBe('plan')
+    expect(window.localStorage.getItem('codex-web-local.collaboration-mode-by-context.v1')).toBe(null)
+
+    state.primeSelectedThread('thread-a')
+
+    expect(state.selectedCollaborationMode.value).toBe('default')
+
+    state.setSelectedCollaborationMode('plan')
+    state.primeSelectedThread('thread-b')
+
+    expect(state.selectedCollaborationMode.value).toBe('default')
+
+    state.primeSelectedThread('thread-a')
+
+    expect(state.selectedCollaborationMode.value).toBe('plan')
+  })
+})
+
 describe('pinned project ordering', () => {
   const groups: UiProjectGroup[] = [
     { projectName: 'alpha', threads: [thread('alpha-chat', '/tmp/alpha')] },

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -203,6 +203,10 @@ function normalizeProviderContextId(providerId: string): string {
   return normalized || 'codex'
 }
 
+function isNewThreadContextId(contextId: string): boolean {
+  return contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT
+}
+
 function toProviderModelContextId(providerId: string): string {
   const normalizedProviderId = normalizeProviderContextId(providerId)
   if (!normalizedProviderId) return ''
@@ -294,12 +298,7 @@ function loadSelectedCollaborationModeMap(): Record<string, CollaborationModeKin
     // Fall back to the legacy global preference below.
   }
 
-  const legacyMode = normalizeCollaborationMode(window.localStorage.getItem(LEGACY_COLLABORATION_MODE_STORAGE_KEY))
-  const next = createStringKeyedRecord<CollaborationModeKind>()
-  if (legacyMode === 'plan') {
-    next[NEW_THREAD_COLLABORATION_MODE_CONTEXT] = 'plan'
-  }
-  return next
+  return createStringKeyedRecord<CollaborationModeKind>()
 }
 
 function readSelectedCollaborationMode(
@@ -316,6 +315,9 @@ function writeSelectedCollaborationModeForContext(
   mode: CollaborationModeKind,
 ): Record<string, CollaborationModeKind> {
   const contextId = toThreadContextId(threadId)
+  if (isNewThreadContextId(contextId)) {
+    return omitStringKeyedRecordKey(state, contextId)
+  }
   if (mode === 'plan') {
     const next = cloneStringKeyedRecord(state)
     next[contextId] = 'plan'
@@ -4734,10 +4736,7 @@ export function useDesktopState() {
     const nextText = text.trim()
     const targetCwd = cwd.trim()
     const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
-    const selectedMode = readSelectedCollaborationMode(
-      selectedCollaborationModeByContext.value,
-      NEW_THREAD_COLLABORATION_MODE_CONTEXT,
-    )
+    const selectedMode = selectedCollaborationMode.value
     if (!nextText && imageUrls.length === 0 && fileAttachments.length === 0) return ''
 
     isSendingMessage.value = true

--- a/tests.md
+++ b/tests.md
@@ -279,6 +279,40 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Composer mode scoping and Fast mode support
+
+#### Feature/Change Name
+Plan mode is scoped to the current chat instead of becoming the default for every chat, and Fast mode is available for supported GPT 5.4 and GPT 5.5 model IDs.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. At least two existing threads are available
+3. Model list includes `gpt-5.4` or a `gpt-5.4-*` variant and `gpt-5.5` or a `gpt-5.5-*` variant
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open thread A, open the composer add menu, and enable Plan mode.
+2. Open thread B and confirm Plan mode is off by default.
+3. Return to thread A and confirm Plan mode remains on for that thread.
+4. Open Start new thread, enable Plan mode, send a first message, and confirm the created thread starts in Plan mode.
+5. Return to Start new thread again and confirm Plan mode is off for the next new chat.
+6. Select `gpt-5.4` or a `gpt-5.4-*` model and confirm the Fast mode switch is visible.
+7. Select `gpt-5.5` or a `gpt-5.5-*` model and confirm the Fast mode switch is visible.
+8. Select an unsupported model family and confirm the Fast mode switch is hidden.
+9. Switch to dark theme and repeat steps 1-8.
+
+#### Expected Results
+- Enabling Plan mode in one existing thread does not enable it in other existing threads.
+- A new-chat Plan mode selection applies to the created chat but does not persist as the default for later new chats.
+- Fast mode is visible for GPT 5.4 and GPT 5.5 model IDs, including dashed variants.
+- Fast mode remains hidden for unsupported model families.
+- Composer controls and menus remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Turn Plan mode off in any test threads if desired.
+
+---
+
 ### Lazy project Git status checks
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- scope Plan mode persistence to real thread IDs so new chats default back to off
- preserve the active new-chat Plan selection for the thread being created
- show Fast mode for GPT 5.4 and GPT 5.5 model IDs, including dashed variants

Fixes #137
Fixes #138

## Tests
- pnpm exec vitest run src/composables/useDesktopState.test.ts
- pnpm run build:frontend