### PR TITLE
Reduce startup status probes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@
 - When implementing any feature or behavior change, always audit performance before marking the task complete.
 - Ground the audit in measurements, profiler output, traces, request counts, bundle/build output, or concrete code-path analysis when live measurement is not feasible.
 - For startup, thread loading, realtime rendering, routing, API, filesystem, git, or module-loading changes, explicitly check for duplicate requests, unnecessary blocking work, unbounded fanout, large payloads, and cache invalidation risks.
+- For browser, startup, and thread-loading performance audits, prefer the built-in profiler helpers: `pnpm run profile:browser` and `pnpm run profile:thread`, which use `scripts/profile-browser-runtime.cjs` and write reports under `output/playwright/`.
 - If live measurement is not feasible, state what was not measured and what should be measured next.
 - Include the performance audit result in the completion report.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@
 
 - Before merging to local `main`, diff-compare all changes on the current branch against `main`.
 
+## Performance Audit Rule (MANDATORY)
+
+- When implementing any feature or behavior change, always audit performance before marking the task complete.
+- Ground the audit in measurements, profiler output, traces, request counts, bundle/build output, or concrete code-path analysis when live measurement is not feasible.
+- For startup, thread loading, realtime rendering, routing, API, filesystem, git, or module-loading changes, explicitly check for duplicate requests, unnecessary blocking work, unbounded fanout, large payloads, and cache invalidation risks.
+- If live measurement is not feasible, state what was not measured and what should be measured next.
+- Include the performance audit result in the completion report.
+
 ## Tests Documentation Rule (MANDATORY)
 
 - After every feature implementation, update `tests.md` in the repository root.

--- a/src/App.vue
+++ b/src/App.vue
@@ -3950,6 +3950,15 @@ watch(
 )
 
 watch(
+  () => [route.name, composerCwd.value] as const,
+  ([routeName, cwd]) => {
+    if (routeName !== 'thread') return
+    void loadGitRepoStatus(cwd)
+  },
+  { immediate: true },
+)
+
+watch(
   () => selectedThreadId.value,
   async (threadId) => {
     if (!hasInitialized.value) return
@@ -3997,8 +4006,9 @@ watch(
 )
 
 watch(
-  () => newThreadCwd.value,
-  (cwd) => {
+  () => [route.name, newThreadCwd.value] as const,
+  ([routeName, cwd]) => {
+    if (routeName !== 'home') return
     void loadGitRepoStatus(cwd)
   },
   { immediate: true },

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -276,6 +276,9 @@ export type WorkspaceRootsState = {
   }>
 }
 
+let workspaceRootsStatePromise: Promise<WorkspaceRootsState> | null = null
+let cachedWorkspaceRootsState: WorkspaceRootsState | null = null
+
 export type StoredQueuedMessage = {
   id: string
   text: string
@@ -2285,6 +2288,23 @@ function normalizeThreadQueueState(value: unknown): ThreadQueueState {
 }
 
 export async function getWorkspaceRootsState(): Promise<WorkspaceRootsState> {
+  if (cachedWorkspaceRootsState) {
+    return cloneWorkspaceRootsState(cachedWorkspaceRootsState)
+  }
+  if (!workspaceRootsStatePromise) {
+    workspaceRootsStatePromise = fetchWorkspaceRootsState()
+      .then((state) => {
+        cachedWorkspaceRootsState = state
+        return state
+      })
+      .finally(() => {
+        workspaceRootsStatePromise = null
+      })
+  }
+  return cloneWorkspaceRootsState(await workspaceRootsStatePromise)
+}
+
+async function fetchWorkspaceRootsState(): Promise<WorkspaceRootsState> {
   const response = await fetch('/codex-api/workspace-roots-state')
   const payload = (await response.json()) as unknown
   if (!response.ok) {
@@ -2295,6 +2315,20 @@ export async function getWorkspaceRootsState(): Promise<WorkspaceRootsState> {
       ? (payload as Record<string, unknown>)
       : {}
   return normalizeWorkspaceRootsState(envelope.data)
+}
+
+function cloneWorkspaceRootsState(state: WorkspaceRootsState): WorkspaceRootsState {
+  return {
+    order: [...state.order],
+    labels: { ...state.labels },
+    active: [...state.active],
+    projectOrder: [...state.projectOrder],
+    remoteProjects: state.remoteProjects?.map((item) => ({ ...item })) ?? [],
+  }
+}
+
+function invalidateWorkspaceRootsStateCache(): void {
+  cachedWorkspaceRootsState = null
 }
 
 export async function getThreadQueueState(): Promise<ThreadQueueState> {
@@ -2674,6 +2708,7 @@ export async function setWorkspaceRootsState(nextState: WorkspaceRootsState): Pr
   if (!response.ok) {
     throw new Error('Failed to save workspace roots state')
   }
+  cachedWorkspaceRootsState = cloneWorkspaceRootsState(nextState)
 }
 
 export async function openProjectRoot(path: string, options?: { createIfMissing?: boolean; label?: string }): Promise<string> {
@@ -2700,6 +2735,7 @@ export async function openProjectRoot(path: string, options?: { createIfMissing?
       ? (record.data as Record<string, unknown>)
       : {}
   const normalizedPath = typeof data.path === 'string' ? normalizePathForUi(data.path) : ''
+  invalidateWorkspaceRootsStateCache()
   return normalizedPath
 }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -20,7 +20,9 @@ import {
   getFreeKeyCount,
   FREE_MODE_PROVIDER_ID,
   FREE_MODE_DEFAULT_MODEL,
+  getCachedFreeModels,
   getFreeModels,
+  refreshFreeModelsInBackground,
   FREE_MODE_STATE_FILE,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
@@ -5324,14 +5326,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         if (req.method === 'GET' && url.pathname === '/codex-api/free-mode/status') {
           try {
             const state = readFreeModeState()
-            const freeModels = await getFreeModels()
             const maskedKey = state.apiKey && state.customKey
               ? state.apiKey.substring(0, 12) + '...' + state.apiKey.substring(state.apiKey.length - 4)
               : null
+            refreshFreeModelsInBackground()
             setJson(res, 200, {
               enabled: state.enabled,
               keyCount: getFreeKeyCount(),
-              models: freeModels,
+              models: getCachedFreeModels(),
               currentModel: state.enabled ? state.model : null,
               customKey: Boolean(state.customKey),
               maskedKey,

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -105,6 +105,7 @@ const FALLBACK_FREE_MODELS = [
 let cachedFreeModels: string[] | null = null
 let cacheTimestamp = 0
 const CACHE_TTL_MS = 10 * 60 * 1000
+let freeModelsRefreshPromise: Promise<string[]> | null = null
 
 async function fetchFreeModelsFromOpenRouter(): Promise<string[]> {
   try {
@@ -129,6 +130,19 @@ export async function getFreeModels(): Promise<string[]> {
     return cachedFreeModels
   }
   return fetchFreeModelsFromOpenRouter()
+}
+
+export function getCachedFreeModels(): string[] {
+  return cachedFreeModels ?? FALLBACK_FREE_MODELS
+}
+
+export function refreshFreeModelsInBackground(): void {
+  if (cachedFreeModels && Date.now() - cacheTimestamp < CACHE_TTL_MS) return
+  if (freeModelsRefreshPromise) return
+  freeModelsRefreshPromise = fetchFreeModelsFromOpenRouter()
+    .finally(() => {
+      freeModelsRefreshPromise = null
+    })
 }
 
 export const FREE_MODE_DEFAULT_MODEL = 'openrouter/free'

--- a/tests.md
+++ b/tests.md
@@ -279,6 +279,40 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Startup avoids duplicate setup probes
+
+#### Feature/Change Name
+Startup loads Git repository status only for the active thread/new-thread cwd or an opened project menu, shares workspace-root state reads, and returns free-mode status without waiting on OpenRouter model discovery.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. Browser runtime profiler available (`pnpm run profile:browser`)
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, run `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser`.
+2. Inspect the generated `output/playwright/browser-runtime-profile-*.json`.
+3. Confirm startup does not call `/codex-api/git/repository-status` once per visible project.
+4. Confirm startup performs at most one `/codex-api/workspace-roots-state` GET before user actions.
+5. Confirm `/codex-api/free-mode/status` completes without waiting for a live `https://openrouter.ai/api/v1/models` request.
+6. Open a thread and confirm at most the selected thread cwd is checked with `/codex-api/git/repository-status`.
+7. Open the project action menu for several projects and confirm Git-backed actions still appear only for Git repositories after each menu-specific status check.
+8. Switch to dark theme and repeat steps 1-7.
+
+#### Expected Results
+- Initial sidebar Git status hydration does not scan every visible project.
+- The `/codex-api/git/repository-status/batch` endpoint is not used.
+- Git status checks are lazy and scoped to the active thread/new-thread cwd or the project menu being opened.
+- App startup and initial thread loading share workspace-root state loading instead of issuing duplicate startup reads.
+- Free-mode status returns cached or fallback model options immediately and refreshes model discovery in the background.
+- Git-backed project menu actions remain correct in light theme and dark theme.
+- Free-mode controls remain readable and functional in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Remove generated `output/playwright/browser-runtime-profile-*` artifacts if they are not needed for comparison evidence.
+
+---
+
 ### Composer mode scoping and Fast mode support
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- scope Git repository status checks to the active thread/new-thread cwd or opened project menu instead of probing every visible project
- return free-mode status from cached/fallback models and refresh OpenRouter models in the background
- share in-flight workspace-root state reads during startup
- add mandatory performance-audit guidance and profiler-helper instructions to AGENTS.md

## Tests
- pnpm run build:frontend
- pnpm run build:cli
- pnpm run test:unit

## Performance audit
- Removed the startup fanout pattern for per-project Git status checks; the branch no longer includes /codex-api/git/repository-status/batch or batch queue symbols.
- Workspace roots now share one in-flight GET and cache a cloned state until mutation.
- Free-mode status no longer awaits OpenRouter model discovery on the status route.