### PR TITLE
Default unauthenticated mode to Zen and preserve reasoning content

### DIFF
--- a/llm-wiki/raw/fixes/opencode-zen-reasoning-content-proxy.md
+++ b/llm-wiki/raw/fixes/opencode-zen-reasoning-content-proxy.md
@@ -1,0 +1,64 @@
+# OpenCode Zen Reasoning Content Proxy Fix
+
+Date: 2026-05-09
+
+## Problem
+
+When unauthenticated Codex Web Local defaulted to OpenCode Zen `big-pickle`, a multi-turn workflow could fail after the model produced thinking-mode metadata and tool calls:
+
+```json
+{"error":{"message":"Error from provider (DeepSeek): The `reasoning_content` in the thinking mode must be passed back to the API.","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}
+```
+
+The reproducing prompt was:
+
+```text
+Use the skill from https://anyclaw.store/skills/anyclaw-publish/SKILL.md
+
+Then build me a beautiful todo list app and deploy it to Anyclaw.
+```
+
+The failure appeared on the second turn after an initial `hi` turn, when Codex sent prior assistant reasoning and tool-call context back through the local Zen proxy.
+
+## Root Cause
+
+OpenCode Zen's `big-pickle` route maps to a DeepSeek thinking-mode model that requires prior assistant `reasoning_content` to be included in later Chat Completions requests.
+
+The local unified Responses proxy was translating Chat Completions responses into Responses-format output, but it did not fully round-trip `reasoning_content` back into later Chat Completions messages. It also had a Zen path where a Chat-shaped payload could be sent to the Responses endpoint instead of `/v1/chat/completions`.
+
+## Fix
+
+Commit: `47d52c8c Preserve Zen reasoning content across tool calls`
+
+Changed files:
+- `src/server/unifiedResponsesProxy.ts`
+- `src/server/unifiedResponsesProxy.test.ts`
+- `tests.md`
+
+Implementation details:
+- Added `reasoning_content` to internal Chat message translation.
+- Translates upstream Chat Completions `message.reasoning_content` into Responses `reasoning` output items.
+- Translates prior Responses `reasoning` items back into assistant Chat messages as `reasoning_content`.
+- Preserves reasoning before assistant tool-call messages.
+- Sends Chat-shaped Zen proxy requests to the Chat Completions endpoint.
+- Preserves streaming `reasoning_content` deltas in the synthetic Responses stream.
+
+## Verification
+
+Commands:
+
+```bash
+pnpm vitest run src/server/unifiedResponsesProxy.test.ts
+pnpm run build
+```
+
+Docker validation:
+- Test server URL: `http://localhost:15900`
+- Empty `CODEX_HOME`, no Codex login, no Zen API key.
+- Free mode status reported `provider: "opencode-zen"`, `currentModel: "big-pickle"`, `wireApi: "chat"`.
+- A synthetic multi-turn Responses payload with prior reasoning, assistant text, tool calls, and tool outputs returned HTTP 200 for both `stream:false` and `stream:true`.
+- The exact app-level prompt reached the second turn without `reasoning_content`, `invalid_request_error`, or provider-error markers in thread state or fresh Docker logs.
+
+## Operational Note
+
+The Docker test container command re-extracts `/tmp/app.tar` into `/app` on restart. Copying only `dist-cli/index.js` into `/app` is overwritten on restart; update `/tmp/app.tar` before restarting when testing rebuilt bundles in that container.

--- a/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
+++ b/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
@@ -43,7 +43,22 @@ model_provider = "opencode-zen"
 - Big Pickle only supports `/v1/chat/completions`, NOT `/v1/responses`
 - `opencode run` hangs without piped stdin in headless environments
 - Codex CLI deprecation warning for `wire_api = "chat"` is safe to ignore on v0.93.0
+- In Codex Web Local's Zen proxy, DeepSeek thinking-mode responses must round-trip `reasoning_content` into later Chat Completions messages. Missing this field can produce `The reasoning_content in the thinking mode must be passed back to the API`.
+- Chat-shaped Zen proxy payloads must be posted to `/v1/chat/completions`, even when the incoming local request uses the Responses-shaped `/responses` route.
+
+## Codex Web Local Proxy Behavior
+
+Codex Web Local can expose OpenCode Zen through its local Responses-compatible proxy. The proxy translates between Codex-style Responses input and Zen's Chat Completions-only API.
+
+For thinking-mode models behind `big-pickle`, the proxy must preserve assistant reasoning in both directions:
+- Upstream Chat `message.reasoning_content` becomes a Responses `reasoning` output item.
+- Later Responses `reasoning` input becomes assistant Chat `reasoning_content`.
+- Reasoning that precedes function calls is attached to the assistant tool-call message.
+- Streaming Chat `reasoning_content` deltas are emitted as synthetic Responses reasoning output.
+
+This behavior was fixed in commit `47d52c8c` after a Docker repro using an empty `CODEX_HOME`, no login, and no Zen API key.
 
 ## Related
 - Source: [opencode-zen-big-pickle-codex-cli.md](../../raw/fixes/opencode-zen-big-pickle-codex-cli.md)
+- Source: [opencode-zen-reasoning-content-proxy.md](../../raw/fixes/opencode-zen-reasoning-content-proxy.md)
 - [merge-to-main-workflow.md](./merge-to-main-workflow.md)

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -21,3 +21,4 @@
 - [../raw/features/skills-route-ui-and-first-launch-card.md](../raw/features/skills-route-ui-and-first-launch-card.md): source facts for the Skills route rename, first-launch Plugins card, dark-theme fix, and dev-server workflow adjustment.
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.
+- [../raw/fixes/opencode-zen-reasoning-content-proxy.md](../raw/fixes/opencode-zen-reasoning-content-proxy.md): Codex Web Local Zen proxy reasoning_content round-trip fix and Docker verification.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## [2026-05-09] ingest | OpenCode Zen reasoning_content proxy fix
+- Added source: `raw/fixes/opencode-zen-reasoning-content-proxy.md`.
+- Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
+- Documents: DeepSeek thinking-mode `reasoning_content` round-trip requirement, Chat-shaped Zen proxy endpoint selection, streaming reasoning preservation, Docker validation, and the `/tmp/app.tar` restart gotcha.
+- Updated `index.md`.
+
 ## [2026-05-02] ingest | Directory Hub Composio and Skills search
 - Added source: `raw/features/directory-hub-composio-skills-search.md`.
 - Created wiki page: `concepts/directory-hub-composio-skills.md`.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,11 +1,5 @@
 # Log
 
-## [2026-05-09] ingest | OpenCode Zen reasoning_content proxy fix
-- Added source: `raw/fixes/opencode-zen-reasoning-content-proxy.md`.
-- Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
-- Documents: DeepSeek thinking-mode `reasoning_content` round-trip requirement, Chat-shaped Zen proxy endpoint selection, streaming reasoning preservation, Docker validation, and the `/tmp/app.tar` restart gotcha.
-- Updated `index.md`.
-
 ## [2026-05-02] ingest | Directory Hub Composio and Skills search
 - Added source: `raw/features/directory-hub-composio-skills-search.md`.
 - Created wiki page: `concepts/directory-hub-composio-skills.md`.
@@ -40,3 +34,9 @@
 - Added source: `raw/projects/codex-web-local.md`.
 - Created wiki pages: `overview.md`, `entities/codex-web-local.md`, `concepts/merge-to-main-workflow.md`.
 - Updated `index.md` with initial catalog entries.
+
+## [2026-05-09] ingest | OpenCode Zen reasoning_content proxy fix
+- Added source: `raw/fixes/opencode-zen-reasoning-content-proxy.md`.
+- Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
+- Documents: DeepSeek thinking-mode `reasoning_content` round-trip requirement, Chat-shaped Zen proxy endpoint selection, streaming reasoning preservation, Docker validation, and the `/tmp/app.tar` restart gotcha.
+- Updated `index.md`.

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -25,6 +25,7 @@ import {
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
+  shouldCreateDefaultFreeModeStateForMissingAuth,
   type FreeModeState,
 } from './freeMode.js'
 import { handleOpenRouterProxyRequest } from './openRouterProxy.js'
@@ -3119,14 +3120,23 @@ function readFreeModeStateSync(statePath: string): FreeModeState | null {
 
 function ensureDefaultFreeModeStateForMissingAuthSync(statePath: string): FreeModeState | null {
   const current = readFreeModeStateSync(statePath)
-  if (current?.enabled) return current
-  if (hasUsableCodexAuthSync()) return current
+  if (!shouldCreateDefaultFreeModeStateForMissingAuth(current, hasUsableCodexAuthSync())) {
+    return current
+  }
 
   const fallback = createDefaultOpenCodeZenFreeModeState()
 
   mkdirSync(dirname(statePath), { recursive: true })
   writeFileSync(statePath, JSON.stringify(fallback), { encoding: 'utf8', mode: 0o600 })
   return fallback
+}
+
+function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) return false
+  const normalized = remoteAddress.startsWith('::ffff:')
+    ? remoteAddress.slice('::ffff:'.length)
+    : remoteAddress
+  return normalized === '127.0.0.1' || normalized === '::1'
 }
 
 function getCodexGlobalStatePath(): string {
@@ -5244,6 +5254,10 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       const url = new URL(req.url, 'http://localhost')
 
       if (url.pathname === '/codex-api/zen-proxy/v1/responses' && req.method === 'POST') {
+        if (!isLoopbackRemoteAddress(req.socket.remoteAddress)) {
+          setJson(res, 403, { error: 'Zen proxy is only available from localhost' })
+          return
+        }
         const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
         let bearerToken = ''
         let wireApi: 'responses' | 'chat' = 'chat'

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { mkdtemp, readFile, readdir, rename, rm, mkdir, stat, cp, lstat, readlink, symlink } from 'node:fs/promises'
-import { createReadStream, existsSync, readFileSync } from 'node:fs'
+import { createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { request as httpRequest } from 'node:http'
 import { request as httpsRequest } from 'node:https'
@@ -22,6 +22,7 @@ import {
   FREE_MODE_DEFAULT_MODEL,
   getFreeModels,
   FREE_MODE_STATE_FILE,
+  createDefaultOpenRouterFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
   type FreeModeState,
@@ -3098,6 +3099,37 @@ async function readCodexAuth(): Promise<{ accessToken: string; accountId?: strin
   }
 }
 
+function hasUsableCodexAuthSync(): boolean {
+  try {
+    const raw = readFileSync(getCodexAuthPath(), 'utf8')
+    const auth = JSON.parse(raw) as CodexAuth
+    return Boolean(auth.tokens?.access_token?.trim())
+  } catch {
+    return false
+  }
+}
+
+function readFreeModeStateSync(statePath: string): FreeModeState | null {
+  try {
+    return JSON.parse(readFileSync(statePath, 'utf8')) as FreeModeState
+  } catch {
+    return null
+  }
+}
+
+function ensureDefaultFreeModeStateForMissingAuthSync(statePath: string): FreeModeState | null {
+  const current = readFreeModeStateSync(statePath)
+  if (current?.enabled) return current
+  if (hasUsableCodexAuthSync()) return current
+
+  const fallback = createDefaultOpenRouterFreeModeState()
+  if (!fallback) return current
+
+  mkdirSync(dirname(statePath), { recursive: true })
+  writeFileSync(statePath, JSON.stringify(fallback), { encoding: 'utf8', mode: 0o600 })
+  return fallback
+}
+
 function getCodexGlobalStatePath(): string {
   return join(getCodexHomeDir(), '.codex-global-state.json')
 }
@@ -4170,10 +4202,11 @@ class AppServerProcess {
     const serverPort = parseInt(process.env.CODEXUI_SERVER_PORT ?? '', 10) || undefined
     const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
     try {
-      const raw = readFileSync(statePath, 'utf8')
-      const state = JSON.parse(raw) as FreeModeState
-      args.push(...getFreeModeConfigArgs(state, serverPort))
-      extraEnv = getFreeModeEnvVars(state)
+      const state = ensureDefaultFreeModeStateForMissingAuthSync(statePath)
+      if (state) {
+        args.push(...getFreeModeConfigArgs(state, serverPort))
+        extraEnv = getFreeModeEnvVars(state)
+      }
     } catch {
       // No free-mode state or invalid — use defaults
     }
@@ -5229,9 +5262,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         let bearerToken = ''
         let wireApi: 'responses' | 'chat' = 'responses'
         try {
-          const state = JSON.parse(readFileSync(statePath, 'utf8')) as FreeModeState
-          bearerToken = state.apiKey ?? ''
-          wireApi = state.wireApi === 'chat' ? 'chat' : 'responses'
+          const state = ensureDefaultFreeModeStateForMissingAuthSync(statePath)
+          bearerToken = state?.apiKey ?? ''
+          wireApi = state?.wireApi === 'chat' ? 'chat' : 'responses'
         } catch { /* use empty */ }
         handleOpenRouterProxyRequest(req, res, bearerToken, wireApi)
         return
@@ -5256,11 +5289,8 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
 
         function readFreeModeState(): FreeModeState {
-          try {
-            return JSON.parse(readFileSync(statePath, 'utf8')) as FreeModeState
-          } catch {
-            return { enabled: false, apiKey: null, model: FREE_MODE_DEFAULT_MODEL }
-          }
+          return ensureDefaultFreeModeStateForMissingAuthSync(statePath)
+            ?? { enabled: false, apiKey: null, model: FREE_MODE_DEFAULT_MODEL }
         }
 
         if (req.method === 'POST' && url.pathname === '/codex-api/free-mode') {
@@ -5928,8 +5958,8 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'GET' && url.pathname === '/codex-api/provider-models') {
         try {
-          const fmState = JSON.parse(readFileSync(join(getCodexHomeDir(), FREE_MODE_STATE_FILE), 'utf8')) as FreeModeState
-          if (fmState.enabled) {
+          const fmState = ensureDefaultFreeModeStateForMissingAuthSync(join(getCodexHomeDir(), FREE_MODE_STATE_FILE))
+          if (fmState?.enabled) {
             if (fmState.provider === 'opencode-zen') {
               try {
                 const modelsUrl = 'https://opencode.ai/zen/v1/models'

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -22,7 +22,7 @@ import {
   FREE_MODE_DEFAULT_MODEL,
   getFreeModels,
   FREE_MODE_STATE_FILE,
-  createDefaultOpenRouterFreeModeState,
+  createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
   type FreeModeState,
@@ -3122,8 +3122,7 @@ function ensureDefaultFreeModeStateForMissingAuthSync(statePath: string): FreeMo
   if (current?.enabled) return current
   if (hasUsableCodexAuthSync()) return current
 
-  const fallback = createDefaultOpenRouterFreeModeState()
-  if (!fallback) return current
+  const fallback = createDefaultOpenCodeZenFreeModeState()
 
   mkdirSync(dirname(statePath), { recursive: true })
   writeFileSync(statePath, JSON.stringify(fallback), { encoding: 'utf8', mode: 0o600 })

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FREE_MODE_DEFAULT_MODEL,
+  FREE_MODE_PROVIDER_ID,
+  createDefaultOpenRouterFreeModeState,
+  getFreeModeConfigArgs,
+} from './freeMode'
+
+describe('OpenRouter free mode defaults', () => {
+  it('creates an enabled OpenRouter state for unauthenticated startup', () => {
+    const state = createDefaultOpenRouterFreeModeState()
+
+    expect(state).not.toBeNull()
+    expect(state?.enabled).toBe(true)
+    expect(state?.provider).toBe('openrouter')
+    expect(state?.model).toBe(FREE_MODE_DEFAULT_MODEL)
+    expect(state?.wireApi).toBe('responses')
+    expect(state?.apiKey).toBeTruthy()
+    expect(state?.providerKeys?.openrouter).toBe(state?.apiKey)
+  })
+
+  it('routes app-server through the local OpenRouter proxy when a server port is available', () => {
+    const state = createDefaultOpenRouterFreeModeState()
+
+    expect(state).not.toBeNull()
+    const args = getFreeModeConfigArgs(state!, 4173)
+
+    expect(args).toContain(`model_provider="${FREE_MODE_PROVIDER_ID}"`)
+    expect(args).toContain(`model="${FREE_MODE_DEFAULT_MODEL}"`)
+    expect(args).toContain(`model_providers.${FREE_MODE_PROVIDER_ID}.base_url="http://127.0.0.1:4173/codex-api/openrouter-proxy/v1"`)
+    expect(args).toContain(`model_providers.${FREE_MODE_PROVIDER_ID}.experimental_bearer_token="openrouter-proxy-token"`)
+  })
+})

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -6,6 +6,7 @@ import {
   OPENCODE_ZEN_PROVIDER_ID,
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
+  shouldCreateDefaultFreeModeStateForMissingAuth,
 } from './freeMode'
 
 describe('unauthenticated free mode defaults', () => {
@@ -42,5 +43,20 @@ describe('unauthenticated free mode defaults', () => {
 
     expect(args).toContain(`model_provider="${FREE_MODE_PROVIDER_ID}"`)
     expect(args).toContain(`model="${FREE_MODE_DEFAULT_MODEL}"`)
+  })
+
+  it('does not replace an intentionally disabled free mode state', () => {
+    expect(shouldCreateDefaultFreeModeStateForMissingAuth({
+      enabled: false,
+      apiKey: null,
+      model: FREE_MODE_DEFAULT_MODEL,
+      provider: 'opencode-zen',
+      wireApi: 'chat',
+    }, false)).toBe(false)
+  })
+
+  it('creates the default only when state is absent and Codex auth is missing', () => {
+    expect(shouldCreateDefaultFreeModeStateForMissingAuth(null, false)).toBe(true)
+    expect(shouldCreateDefaultFreeModeStateForMissingAuth(null, true)).toBe(false)
   })
 })

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -2,32 +2,45 @@ import { describe, expect, it } from 'vitest'
 import {
   FREE_MODE_DEFAULT_MODEL,
   FREE_MODE_PROVIDER_ID,
-  createDefaultOpenRouterFreeModeState,
+  OPENCODE_ZEN_DEFAULT_MODEL,
+  OPENCODE_ZEN_PROVIDER_ID,
+  createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
 } from './freeMode'
 
-describe('OpenRouter free mode defaults', () => {
-  it('creates an enabled OpenRouter state for unauthenticated startup', () => {
-    const state = createDefaultOpenRouterFreeModeState()
+describe('unauthenticated free mode defaults', () => {
+  it('creates an enabled OpenCode Zen state for unauthenticated startup', () => {
+    const state = createDefaultOpenCodeZenFreeModeState()
 
-    expect(state).not.toBeNull()
-    expect(state?.enabled).toBe(true)
-    expect(state?.provider).toBe('openrouter')
-    expect(state?.model).toBe(FREE_MODE_DEFAULT_MODEL)
-    expect(state?.wireApi).toBe('responses')
-    expect(state?.apiKey).toBeTruthy()
-    expect(state?.providerKeys?.openrouter).toBe(state?.apiKey)
+    expect(state.enabled).toBe(true)
+    expect(state.provider).toBe('opencode-zen')
+    expect(state.model).toBe(OPENCODE_ZEN_DEFAULT_MODEL)
+    expect(state.wireApi).toBe('chat')
+    expect(state.apiKey).toBeNull()
+    expect(state.providerKeys).toEqual({})
   })
 
-  it('routes app-server through the local OpenRouter proxy when a server port is available', () => {
-    const state = createDefaultOpenRouterFreeModeState()
+  it('routes app-server through the local OpenCode Zen proxy when a server port is available', () => {
+    const state = createDefaultOpenCodeZenFreeModeState()
 
-    expect(state).not.toBeNull()
-    const args = getFreeModeConfigArgs(state!, 4173)
+    const args = getFreeModeConfigArgs(state, 4173)
+
+    expect(args).toContain(`model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`)
+    expect(args).toContain(`model="${OPENCODE_ZEN_DEFAULT_MODEL}"`)
+    expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="http://127.0.0.1:4173/codex-api/zen-proxy/v1"`)
+    expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`)
+  })
+
+  it('keeps OpenRouter config available for manual free mode', () => {
+    const args = getFreeModeConfigArgs({
+      enabled: true,
+      apiKey: 'sk-or-test',
+      model: FREE_MODE_DEFAULT_MODEL,
+      provider: 'openrouter',
+      wireApi: 'responses',
+    }, 4173)
 
     expect(args).toContain(`model_provider="${FREE_MODE_PROVIDER_ID}"`)
     expect(args).toContain(`model="${FREE_MODE_DEFAULT_MODEL}"`)
-    expect(args).toContain(`model_providers.${FREE_MODE_PROVIDER_ID}.base_url="http://127.0.0.1:4173/codex-api/openrouter-proxy/v1"`)
-    expect(args).toContain(`model_providers.${FREE_MODE_PROVIDER_ID}.experimental_bearer_token="openrouter-proxy-token"`)
   })
 })

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -138,6 +138,7 @@ export const FREE_MODE_STATE_FILE = 'webui-free-mode.json'
 export const CUSTOM_PROVIDER_ID = 'custom-endpoint'
 export const OPENCODE_ZEN_PROVIDER_ID = 'opencode-zen'
 export const OPENCODE_ZEN_BASE_URL = 'https://opencode.ai/zen/v1'
+export const OPENCODE_ZEN_DEFAULT_MODEL = 'big-pickle'
 
 export type WireApi = 'responses' | 'chat'
 
@@ -168,6 +169,18 @@ export function createDefaultOpenRouterFreeModeState(): FreeModeState | null {
   }
 }
 
+export function createDefaultOpenCodeZenFreeModeState(): FreeModeState {
+  return {
+    enabled: true,
+    apiKey: null,
+    model: OPENCODE_ZEN_DEFAULT_MODEL,
+    customKey: false,
+    provider: 'opencode-zen',
+    wireApi: 'chat',
+    providerKeys: {},
+  }
+}
+
 export function getFreeModeEnvVars(state: FreeModeState): Record<string, string> {
   if (!state.enabled) return {}
 
@@ -193,7 +206,11 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
     const authArgs: string[] = serverPort
       ? ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`]
       : ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.env_key="OPENCODE_ZEN_API_KEY"`]
+    const modelArgs: string[] = state.model?.trim()
+      ? ['-c', `model="${state.model.trim()}"`]
+      : []
     return [
+      ...modelArgs,
       '-c', `model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.name="OpenCode Zen"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${baseUrl}"`,

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -181,6 +181,13 @@ export function createDefaultOpenCodeZenFreeModeState(): FreeModeState {
   }
 }
 
+export function shouldCreateDefaultFreeModeStateForMissingAuth(
+  current: FreeModeState | null,
+  hasUsableCodexAuth: boolean,
+): boolean {
+  return current == null && !hasUsableCodexAuth
+}
+
 export function getFreeModeEnvVars(state: FreeModeState): Record<string, string> {
   if (!state.enabled) return {}
 

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -152,6 +152,22 @@ export interface FreeModeState {
   providerKeys?: Record<string, string>
 }
 
+export function createDefaultOpenRouterFreeModeState(): FreeModeState | null {
+  const apiKey = getRandomFreeKey()
+  if (!apiKey) return null
+  return {
+    enabled: true,
+    apiKey,
+    model: FREE_MODE_DEFAULT_MODEL,
+    customKey: false,
+    provider: 'openrouter',
+    wireApi: 'responses',
+    providerKeys: {
+      openrouter: apiKey,
+    },
+  }
+}
+
 export function getFreeModeEnvVars(state: FreeModeState): Record<string, string> {
   if (!state.enabled) return {}
 

--- a/src/server/unifiedResponsesProxy.test.ts
+++ b/src/server/unifiedResponsesProxy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  chatCompletionToResponsesFormat,
+  responsesInputToMessages,
+} from './unifiedResponsesProxy'
+
+describe('unified responses proxy reasoning_content translation', () => {
+  it('preserves DeepSeek reasoning_content in translated Responses output', () => {
+    const response = chatCompletionToResponsesFormat({
+      id: 'chatcmpl-test',
+      created: 123,
+      choices: [{
+        message: {
+          role: 'assistant',
+          reasoning_content: 'thinking trace',
+          content: 'Hello.',
+        },
+      }],
+    }, 'big-pickle')
+
+    expect(response.output).toEqual([
+      {
+        type: 'reasoning',
+        id: expect.stringMatching(/^rs_/),
+        summary: [],
+        content: [{ type: 'reasoning_text', text: 'thinking trace' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello.' }],
+        status: 'completed',
+      },
+    ])
+  })
+
+  it('passes prior reasoning items back as assistant reasoning_content', () => {
+    const messages = responsesInputToMessages([
+      {
+        type: 'reasoning',
+        id: 'rs_test',
+        summary: [],
+        content: [{ type: 'reasoning_text', text: 'thinking trace' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'again' }],
+      },
+    ])
+
+    expect(messages).toEqual([
+      { role: 'assistant', content: 'Hello.', reasoning_content: 'thinking trace' },
+      { role: 'user', content: 'again' },
+    ])
+  })
+
+  it('passes reasoning_content back on assistant tool-call messages', () => {
+    const messages = responsesInputToMessages([
+      {
+        type: 'reasoning',
+        id: 'rs_test',
+        summary: [],
+        content: [{ type: 'reasoning_text', text: 'thinking before tool' }],
+      },
+      {
+        type: 'function_call',
+        call_id: 'call_test',
+        name: 'exec_command',
+        arguments: '{"cmd":"pwd"}',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call_test',
+        output: 'ok',
+      },
+    ])
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'thinking before tool',
+        tool_calls: [{
+          id: 'call_test',
+          type: 'function',
+          function: { name: 'exec_command', arguments: '{"cmd":"pwd"}' },
+        }],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_test',
+        content: 'ok',
+      },
+    ])
+  })
+})

--- a/src/server/unifiedResponsesProxy.test.ts
+++ b/src/server/unifiedResponsesProxy.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from 'vitest'
+import { createServer } from 'node:http'
 import {
   chatCompletionToResponsesFormat,
+  handleUnifiedResponsesProxyRequest,
   responsesInputToMessages,
 } from './unifiedResponsesProxy'
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address && typeof address === 'object') {
+        resolve(address.port)
+      } else {
+        reject(new Error('test server did not bind to a TCP port'))
+      }
+    })
+  })
+}
+
+function close(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
 
 describe('unified responses proxy reasoning_content translation', () => {
   it('preserves DeepSeek reasoning_content in translated Responses output', () => {
@@ -20,16 +42,16 @@ describe('unified responses proxy reasoning_content translation', () => {
 
     expect(response.output).toEqual([
       {
-        type: 'reasoning',
-        id: expect.stringMatching(/^rs_/),
-        summary: [],
-        content: [{ type: 'reasoning_text', text: 'thinking trace' }],
-      },
-      {
         type: 'message',
         role: 'assistant',
         content: [{ type: 'output_text', text: 'Hello.' }],
         status: 'completed',
+      },
+      {
+        type: 'reasoning',
+        id: expect.stringMatching(/^rs_/),
+        summary: [],
+        content: [{ type: 'reasoning_text', text: 'thinking trace' }],
       },
     ])
   })
@@ -98,5 +120,56 @@ describe('unified responses proxy reasoning_content translation', () => {
         content: 'ok',
       },
     ])
+  })
+
+  it('forces non-stream upstream requests when chat-formatted tool requests cannot be streamed', async () => {
+    let upstreamRequest: Record<string, unknown> | null = null
+    const upstream = createServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (chunk: Buffer) => chunks.push(chunk))
+      req.on('end', () => {
+        upstreamRequest = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test',
+          created: 123,
+          choices: [{ message: { role: 'assistant', content: 'ok' } }],
+        }))
+      })
+    })
+    const upstreamPort = await listen(upstream)
+
+    const proxy = createServer((req, res) => {
+      handleUnifiedResponsesProxyRequest(req, res, {
+        bearerToken: '',
+        requireBearerToken: false,
+        wireApi: 'responses',
+        responsesEndpoint: `http://127.0.0.1:${upstreamPort}/v1/responses`,
+        chatCompletionsEndpoint: `http://127.0.0.1:${upstreamPort}/v1/chat/completions`,
+        missingKeyMessage: 'missing',
+        allowToolFallbackToResponses: false,
+        responsesPayloadFormat: 'chat',
+      })
+    })
+    const proxyPort = await listen(proxy)
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'big-pickle',
+          stream: true,
+          input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+          tools: [{ type: 'function', name: 'exec_command', parameters: { type: 'object' } }],
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      expect((upstreamRequest as Record<string, unknown> | null)?.stream).toBe(false)
+    } finally {
+      await close(proxy)
+      await close(upstream)
+    }
   })
 })

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -53,6 +53,7 @@ type ChatCompletionsRequest = {
 
 export type UnifiedProxyOptions = {
   bearerToken: string
+  requireBearerToken?: boolean
   wireApi: 'responses' | 'chat'
   responsesEndpoint: string
   chatCompletionsEndpoint: string
@@ -386,7 +387,7 @@ export function handleUnifiedResponsesProxyRequest(
 ): void {
   void (async () => {
     try {
-      if (!options.bearerToken) {
+      if (options.requireBearerToken !== false && !options.bearerToken) {
         res.writeHead(401, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ error: { message: options.missingKeyMessage } }))
         return
@@ -439,7 +440,7 @@ export function handleUnifiedResponsesProxyRequest(
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(payload),
-          'Authorization': `Bearer ${options.bearerToken}`,
+          ...(options.bearerToken ? { 'Authorization': `Bearer ${options.bearerToken}` } : {}),
         },
       }, (upstreamRes) => {
         const status = upstreamRes.statusCode ?? 502

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -278,15 +278,6 @@ export function chatCompletionToResponsesFormat(chatResponse: Record<string, unk
     const message = choice.message
     if (!message) continue
 
-    if (message.reasoning_content) {
-      output.push({
-        type: 'reasoning',
-        id: `rs_${Date.now()}`,
-        summary: [],
-        content: [{ type: 'reasoning_text', text: message.reasoning_content }],
-      })
-    }
-
     if (Array.isArray(message.tool_calls)) {
       for (const toolCall of message.tool_calls) {
         if (!toolCall || toolCall.type !== 'function') continue
@@ -309,6 +300,15 @@ export function chatCompletionToResponsesFormat(chatResponse: Record<string, unk
         role: 'assistant',
         content: [{ type: 'output_text', text: message.content }],
         status: 'completed',
+      })
+    }
+
+    if (message.reasoning_content) {
+      output.push({
+        type: 'reasoning',
+        id: `rs_${Date.now()}`,
+        summary: [],
+        content: [{ type: 'reasoning_text', text: message.reasoning_content }],
       })
     }
   }
@@ -499,7 +499,7 @@ export function handleUnifiedResponsesProxyRequest(
         const chatReq: ChatCompletionsRequest = {
           model: parsedBody.model,
           messages: responsesInputToMessages(parsedBody.input, parsedBody.instructions),
-          stream: useChatCompletions ? effectiveStreaming : isStreaming,
+          stream: effectiveStreaming,
         }
         if (parsedBody.temperature != null) chatReq.temperature = parsedBody.temperature
         if (parsedBody.top_p != null) chatReq.top_p = parsedBody.top_p

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -3,9 +3,11 @@ import { request as httpRequest } from 'node:http'
 import { request as httpsRequest } from 'node:https'
 
 type ResponsesApiInput = {
+  id?: string
   type: string
   role?: string
   content?: string | Array<{ type?: string; text?: string }>
+  summary?: Array<{ type?: string; text?: string }>
   text?: string
   name?: string
   arguments?: string
@@ -29,6 +31,7 @@ type ResponsesApiRequest = {
 type ChatMessage = {
   role: string
   content?: string
+  reasoning_content?: string
   tool_call_id?: string
   tool_calls?: Array<{
     id: string
@@ -81,36 +84,70 @@ function safeStringifyUnknown(value: unknown): string {
   }
 }
 
-function appendAssistantText(messages: ChatMessage[], text: string): void {
+function appendAssistantText(messages: ChatMessage[], text: string, reasoningContent?: string): void {
   const trimmedText = text.trim()
-  if (!trimmedText) return
+  const trimmedReasoningContent = reasoningContent?.trim() ?? ''
+  if (!trimmedText && !trimmedReasoningContent) return
 
   const lastMessage = messages[messages.length - 1]
   if (lastMessage?.role === 'assistant' && Array.isArray(lastMessage.tool_calls)) {
     lastMessage.content = lastMessage.content
       ? `${lastMessage.content}\n${trimmedText}`
       : trimmedText
+    if (trimmedReasoningContent) {
+      lastMessage.reasoning_content = lastMessage.reasoning_content
+        ? `${lastMessage.reasoning_content}\n${trimmedReasoningContent}`
+        : trimmedReasoningContent
+    }
     return
   }
 
-  messages.push({ role: 'assistant', content: trimmedText })
+  messages.push({
+    role: 'assistant',
+    content: trimmedText,
+    ...(trimmedReasoningContent ? { reasoning_content: trimmedReasoningContent } : {}),
+  })
 }
 
 function appendAssistantToolCall(
   messages: ChatMessage[],
   toolCall: NonNullable<ChatMessage['tool_calls']>[number],
+  reasoningContent?: string,
 ): void {
+  const trimmedReasoningContent = reasoningContent?.trim() ?? ''
   const lastMessage = messages[messages.length - 1]
   if (lastMessage?.role === 'assistant' && !lastMessage.tool_call_id) {
     lastMessage.tool_calls = [...(lastMessage.tool_calls ?? []), toolCall]
+    if (trimmedReasoningContent) {
+      lastMessage.reasoning_content = lastMessage.reasoning_content
+        ? `${lastMessage.reasoning_content}\n${trimmedReasoningContent}`
+        : trimmedReasoningContent
+    }
     return
   }
 
-  messages.push({ role: 'assistant', tool_calls: [toolCall] })
+  messages.push({
+    role: 'assistant',
+    content: '',
+    tool_calls: [toolCall],
+    ...(trimmedReasoningContent ? { reasoning_content: trimmedReasoningContent } : {}),
+  })
 }
 
-function responsesInputToMessages(input: string | ResponsesApiInput[], instructions?: string): ChatMessage[] {
+function extractTextParts(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) return ''
+  return value
+    .map((part) => (part && typeof part === 'object' && typeof (part as { text?: unknown }).text === 'string'
+      ? (part as { text: string }).text
+      : ''))
+    .filter((part) => part.length > 0)
+    .join('\n')
+}
+
+export function responsesInputToMessages(input: string | ResponsesApiInput[], instructions?: string): ChatMessage[] {
   const messages: ChatMessage[] = []
+  let pendingReasoningContent = ''
   if (instructions) {
     messages.push({ role: 'system', content: instructions })
   }
@@ -121,6 +158,25 @@ function responsesInputToMessages(input: string | ResponsesApiInput[], instructi
 
   for (const item of input) {
     if (!item || typeof item !== 'object') continue
+
+    if (item.type === 'reasoning') {
+      const content = extractTextParts(item.content)
+      const summary = extractTextParts(item.summary)
+      const text = content || summary
+      if (text) {
+        const lastMessage = messages[messages.length - 1]
+        if (lastMessage?.role === 'assistant') {
+          lastMessage.reasoning_content = lastMessage.reasoning_content
+            ? `${lastMessage.reasoning_content}\n${text}`
+            : text
+        } else {
+          pendingReasoningContent = pendingReasoningContent
+            ? `${pendingReasoningContent}\n${text}`
+            : text
+        }
+      }
+      continue
+    }
 
     if (item.type === 'message' && item.role) {
       const content = item.content
@@ -134,7 +190,8 @@ function responsesInputToMessages(input: string | ResponsesApiInput[], instructi
           : (typeof item.text === 'string' ? item.text : '')
       const role = item.role === 'developer' ? 'system' : item.role
       if (role === 'assistant') {
-        appendAssistantText(messages, text)
+        appendAssistantText(messages, text, pendingReasoningContent)
+        pendingReasoningContent = ''
       } else {
         messages.push({ role, content: text })
       }
@@ -158,7 +215,8 @@ function responsesInputToMessages(input: string | ResponsesApiInput[], instructi
           name: item.name,
           arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
         },
-      })
+      }, pendingReasoningContent)
+      pendingReasoningContent = ''
     }
   }
 
@@ -202,10 +260,11 @@ function responsesToolChoiceToChatToolChoice(toolChoice: unknown): ChatCompletio
   return { type: 'function', function: { name } }
 }
 
-function chatCompletionToResponsesFormat(chatResponse: Record<string, unknown>, model: string): Record<string, unknown> {
+export function chatCompletionToResponsesFormat(chatResponse: Record<string, unknown>, model: string): Record<string, unknown> {
   const choices = (chatResponse.choices ?? []) as Array<{
     message?: {
       content?: string
+      reasoning_content?: string
       tool_calls?: Array<{
         id?: string
         type?: string
@@ -218,6 +277,15 @@ function chatCompletionToResponsesFormat(chatResponse: Record<string, unknown>, 
   for (const choice of choices) {
     const message = choice.message
     if (!message) continue
+
+    if (message.reasoning_content) {
+      output.push({
+        type: 'reasoning',
+        id: `rs_${Date.now()}`,
+        summary: [],
+        content: [{ type: 'reasoning_text', text: message.reasoning_content }],
+      })
+    }
 
     if (Array.isArray(message.tool_calls)) {
       for (const toolCall of message.tool_calls) {
@@ -274,6 +342,7 @@ function forwardStreamingTextResponse(
 
   let buffer = ''
   const contentParts: string[] = []
+  const reasoningParts: string[] = []
   let responseId = `resp_${Date.now()}`
 
   res.write(`data: {"type":"response.created","response":{"id":"${responseId}","object":"response","status":"in_progress","model":"${model}","output":[]}}\n\n`)
@@ -292,10 +361,13 @@ function forwardStreamingTextResponse(
       try {
         const parsed = JSON.parse(data) as {
           id?: string
-          choices?: Array<{ delta?: { content?: string } }>
+          choices?: Array<{ delta?: { content?: string; reasoning_content?: string } }>
         }
         if (parsed.id) responseId = `resp_${parsed.id}`
         const delta = parsed.choices?.[0]?.delta
+        if (delta?.reasoning_content) {
+          reasoningParts.push(delta.reasoning_content)
+        }
         if (delta?.content) {
           contentParts.push(delta.content)
           const escaped = JSON.stringify(delta.content).slice(1, -1)
@@ -309,11 +381,28 @@ function forwardStreamingTextResponse(
 
   upstreamRes.on('end', () => {
     const fullText = contentParts.join('')
+    const fullReasoningText = reasoningParts.join('')
     const escapedFull = JSON.stringify(fullText).slice(1, -1)
+    const messageItem = { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: fullText }], status: 'completed' }
+    const output: Array<Record<string, unknown>> = [messageItem]
+    if (fullReasoningText) {
+      output.push({
+        type: 'reasoning',
+        id: `rs_${Date.now()}`,
+        summary: [],
+        content: [{ type: 'reasoning_text', text: fullReasoningText }],
+      })
+    }
     res.write(`data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"${escapedFull}"}\n\n`)
     res.write(`data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"${escapedFull}"}}\n\n`)
     res.write(`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"${escapedFull}"}],"status":"completed"}}\n\n`)
-    res.write(`data: {"type":"response.completed","response":{"id":"${responseId}","object":"response","status":"completed","model":"${model}","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"${escapedFull}"}],"status":"completed"}]}}\n\n`)
+    if (fullReasoningText) {
+      const reasoningIndex = output.length - 1
+      const reasoningItem = output[reasoningIndex]
+      res.write(`data: ${JSON.stringify({ type: 'response.output_item.added', output_index: reasoningIndex, item: reasoningItem })}\n\n`)
+      res.write(`data: ${JSON.stringify({ type: 'response.output_item.done', output_index: reasoningIndex, item: reasoningItem })}\n\n`)
+    }
+    res.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: responseId, object: 'response', status: 'completed', model, output } })}\n\n`)
     res.end()
   })
 
@@ -401,7 +490,7 @@ export function handleUnifiedResponsesProxyRequest(
       const useChatCompletions = options.wireApi === 'chat' && !useResponsesFallback
       const useChatPayload = useChatCompletions || options.responsesPayloadFormat === 'chat'
       const isStreaming = parsedBody.stream === true
-      const effectiveStreaming = useChatCompletions && isStreaming && !(hasTools || hasToolOutputs)
+      const effectiveStreaming = useChatPayload && isStreaming && !(hasTools || hasToolOutputs)
 
       let payload = ''
       let upstreamUrl: URL
@@ -420,7 +509,7 @@ export function handleUnifiedResponsesProxyRequest(
         if (chatTools) chatReq.tools = chatTools
         if (chatToolChoice) chatReq.tool_choice = chatToolChoice
         payload = JSON.stringify(chatReq)
-        upstreamUrl = new URL(useChatCompletions ? options.chatCompletionsEndpoint : options.responsesEndpoint)
+        upstreamUrl = new URL(options.chatCompletionsEndpoint)
       } else {
         const requestBody =
           parsedBody && typeof parsedBody === 'object' && !Array.isArray(parsedBody)
@@ -444,7 +533,7 @@ export function handleUnifiedResponsesProxyRequest(
         },
       }, (upstreamRes) => {
         const status = upstreamRes.statusCode ?? 502
-        if (useChatCompletions && effectiveStreaming && status >= 200 && status < 300) {
+        if (useChatPayload && effectiveStreaming && status >= 200 && status < 300) {
           forwardStreamingTextResponse(upstreamRes, res, parsedBody.model)
           return
         }
@@ -453,7 +542,7 @@ export function handleUnifiedResponsesProxyRequest(
         upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk))
         upstreamRes.on('end', () => {
           const rawResponseBody = Buffer.concat(chunks).toString()
-          if (!useChatCompletions) {
+          if (!useChatPayload) {
             res.writeHead(status, copyProxyHeaders(upstreamRes.headers))
             res.end(rawResponseBody)
             return
@@ -462,6 +551,14 @@ export function handleUnifiedResponsesProxyRequest(
           try {
             const upstreamPayload = JSON.parse(rawResponseBody) as Record<string, unknown>
             if (upstreamPayload.error || status >= 400) {
+              if (process.env.CODEXUI_PROXY_DEBUG === '1') {
+                console.warn('[unified-responses-proxy]', JSON.stringify({
+                  status,
+                  upstreamUrl: upstreamUrl.toString(),
+                  request: JSON.parse(payload) as unknown,
+                  response: upstreamPayload,
+                }))
+              }
               res.writeHead(status, { 'Content-Type': 'application/json' })
               res.end(JSON.stringify(upstreamPayload))
               return

--- a/src/server/zenProxy.ts
+++ b/src/server/zenProxy.ts
@@ -16,6 +16,7 @@ export function handleZenProxyRequest(
     responsesEndpoint: ZEN_RESPONSES_ENDPOINT,
     chatCompletionsEndpoint: ZEN_CHAT_COMPLETIONS_ENDPOINT,
     missingKeyMessage: 'Missing OpenCode Zen API key',
+    requireBearerToken: false,
     allowToolFallbackToResponses: false,
     responsesPayloadFormat: 'chat',
   })

--- a/tests.md
+++ b/tests.md
@@ -279,10 +279,10 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
-### OpenRouter Default For Unauthenticated Codex
+### OpenCode Zen Default For Unauthenticated Codex
 
 #### Feature/Change Name
-Codex app-server startup defaults to OpenRouter free mode when `CODEX_HOME` has no usable Codex login.
+Codex app-server startup defaults to OpenCode Zen `big-pickle` when `CODEX_HOME` has no usable Codex login.
 
 #### Prerequisites/Setup
 1. Build artifacts available with `pnpm run build`.
@@ -292,14 +292,14 @@ Codex app-server startup defaults to OpenRouter free mode when `CODEX_HOME` has 
 #### Steps
 1. Start `codexapp` in Docker with an empty `CODEX_HOME`.
 2. Confirm `$CODEX_HOME/webui-free-mode.json` is created.
-3. Confirm `/codex-api/free-mode/status` reports `enabled: true`, `provider: "openrouter"`, and `currentModel: "openrouter/free"`.
+3. Confirm `/codex-api/free-mode/status` reports `enabled: true`, `provider: "opencode-zen"`, and `currentModel: "big-pickle"`.
 4. Send `hi` through the app-server path.
 5. Repeat a quick visual load of the app in light theme.
 6. Switch to dark theme and confirm the provider/settings UI remains readable.
 
 #### Expected Results
 - The app does not require `codex login` before first use in the empty Docker environment.
-- App-server runs with the `openrouter-free` provider and the local OpenRouter proxy.
+- App-server runs with the `opencode-zen` provider and the local Zen proxy without an API key.
 - A `hi` turn completes with an assistant response.
 - Light-theme and dark-theme provider controls remain readable.
 

--- a/tests.md
+++ b/tests.md
@@ -279,6 +279,35 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### OpenRouter Default For Unauthenticated Codex
+
+#### Feature/Change Name
+Codex app-server startup defaults to OpenRouter free mode when `CODEX_HOME` has no usable Codex login.
+
+#### Prerequisites/Setup
+1. Build artifacts available with `pnpm run build`.
+2. Docker available locally.
+3. A temporary empty `CODEX_HOME` mounted into the container.
+
+#### Steps
+1. Start `codexapp` in Docker with an empty `CODEX_HOME`.
+2. Confirm `$CODEX_HOME/webui-free-mode.json` is created.
+3. Confirm `/codex-api/free-mode/status` reports `enabled: true`, `provider: "openrouter"`, and `currentModel: "openrouter/free"`.
+4. Send `hi` through the app-server path.
+5. Repeat a quick visual load of the app in light theme.
+6. Switch to dark theme and confirm the provider/settings UI remains readable.
+
+#### Expected Results
+- The app does not require `codex login` before first use in the empty Docker environment.
+- App-server runs with the `openrouter-free` provider and the local OpenRouter proxy.
+- A `hi` turn completes with an assistant response.
+- Light-theme and dark-theme provider controls remain readable.
+
+#### Rollback/Cleanup
+- Remove the temporary container and temporary Docker `CODEX_HOME`.
+
+---
+
 ### Composer mode scoping and Fast mode support
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -294,14 +294,21 @@ Codex app-server startup defaults to OpenCode Zen `big-pickle` when `CODEX_HOME`
 2. Confirm `$CODEX_HOME/webui-free-mode.json` is created.
 3. Confirm `/codex-api/free-mode/status` reports `enabled: true`, `provider: "opencode-zen"`, and `currentModel: "big-pickle"`.
 4. Send `hi` through the app-server path.
-5. Repeat a quick visual load of the app in light theme.
-6. Switch to dark theme and confirm the provider/settings UI remains readable.
+5. Send a second prompt that triggers tool calls and prior reasoning reuse.
+6. Confirm a streamed tool request through the Zen proxy does not request upstream SSE when tool outputs are present.
+7. Disable free mode and reload `/codex-api/free-mode/status`.
+8. From a non-loopback client, attempt to call `/codex-api/zen-proxy/v1/responses`.
+9. Repeat a quick visual load of the app in light theme.
+10. Switch to dark theme and confirm the provider/settings UI remains readable.
 
 #### Expected Results
 - The app does not require `codex login` before first use in the empty Docker environment.
 - App-server runs with the `opencode-zen` provider and the local Zen proxy without an API key.
 - A `hi` turn completes with an assistant response.
 - Multi-turn Zen conversations preserve provider `reasoning_content` and do not fail with `The reasoning_content in the thinking mode must be passed back to the API`.
+- Tool-bearing Zen proxy requests with downstream `stream: true` are sent upstream as non-streaming JSON when the proxy cannot forward SSE.
+- A user-disabled free mode state remains disabled on later status reads.
+- The unauthenticated local Zen proxy rejects non-loopback callers.
 - Light-theme and dark-theme provider controls remain readable.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -301,6 +301,7 @@ Codex app-server startup defaults to OpenCode Zen `big-pickle` when `CODEX_HOME`
 - The app does not require `codex login` before first use in the empty Docker environment.
 - App-server runs with the `opencode-zen` provider and the local Zen proxy without an API key.
 - A `hi` turn completes with an assistant response.
+- Multi-turn Zen conversations preserve provider `reasoning_content` and do not fail with `The reasoning_content in the thinking mode must be passed back to the API`.
 - Light-theme and dark-theme provider controls remain readable.
 
 #### Rollback/Cleanup


### PR DESCRIPTION
## Summary
- default unauthenticated/free mode first to OpenRouter, then OpenCode Zen big-pickle
- proxy OpenCode Zen through Chat Completions without requiring login or an API key
- preserve DeepSeek/Zen reasoning_content across Responses-to-Chat translation, including tool-call and streaming paths
- document the Zen reasoning_content fix in the LLM wiki

## Tests
- pnpm vitest run src/server/freeMode.test.ts
- pnpm vitest run src/server/unifiedResponsesProxy.test.ts
- pnpm run build
- docker empty-CODEX_HOME smoke test at http://localhost:15900
- direct Zen curl without API key returned 200
- synthetic multi-turn Zen proxy payload returned 200 for stream:false and stream:true
- app-level prompt reached the second turn without reasoning_content/provider errors in thread state or fresh Docker logs