### PR TITLE
Use app dropdowns and fix Android Zen app-server config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,12 @@
 - For shared route surfaces and large feature UIs, prefer putting the decisive dark-theme overrides in the global theme stylesheet (`src/style.css`) instead of relying only on component-scoped `:global(:root.dark)` blocks.
 - Scoped dark overrides are fine for truly local elements, but if a full route still looks like light theme in dark mode, add or strengthen the global selectors for that surface.
 
+## UI Interaction Component Rule
+
+- Never add a normal HTML `<select>` for app UI. Use `ComposerDropdown` by default, or another existing app dropdown component when it is already the established pattern for that surface.
+- Never use browser-native `prompt()` for app UI. Use an existing modal, inline editor, drawer, or app-styled form flow instead.
+- When replacing legacy `<select>` or `prompt()` usage, preserve the existing behavior and state wiring while moving the interaction into the app component system.
+
 ## NPX Testing Rule
 
 - For any `npx` package behavior test, **publish first**, then test the published `@latest` package.

--- a/llm-wiki/raw/fixes/opencode-zen-reasoning-summary-replay.md
+++ b/llm-wiki/raw/fixes/opencode-zen-reasoning-summary-replay.md
@@ -1,0 +1,36 @@
+# OpenCode Zen Reasoning Summary Replay Fix
+
+## Date
+2026-05-10
+
+## Problem
+After an OpenCode Zen `big-pickle` turn produced reasoning metadata, a later Responses-backed turn could fail with:
+
+```json
+{"type":"invalid_request_error","message":"[ArrayParam] [input[4].content] [array_above_max_length] Invalid 'input[4].content': array too long. Expected an array with maximum length 0, but got an array with length 1 instead."}
+```
+
+The local proxy had been translating upstream Chat Completions `reasoning_content` into a Responses `reasoning` output item with `content: [{ "type": "reasoning_text", "text": "..." }]`. When that item was replayed as conversation history into a later Responses request, the provider rejected non-empty `reasoning.content`.
+
+## Fix
+The unified Responses proxy now emits translated reasoning output as:
+
+```json
+{
+  "type": "reasoning",
+  "summary": [{ "type": "summary_text", "text": "..." }],
+  "content": []
+}
+```
+
+`responsesInputToMessages()` reads both `content` and `summary`, so later Chat Completions proxy turns still recover `reasoning_content` from the summary while Responses providers receive schema-valid empty reasoning content.
+
+## Files
+- `src/server/unifiedResponsesProxy.ts`
+- `src/server/unifiedResponsesProxy.test.ts`
+- `tests.md`
+
+## Verification
+- `pnpm vitest run src/server/unifiedResponsesProxy.test.ts`
+- `pnpm run test:unit`
+- `pnpm run build`

--- a/llm-wiki/raw/fixes/provider-scoped-model-selection-zen.md
+++ b/llm-wiki/raw/fixes/provider-scoped-model-selection-zen.md
@@ -1,0 +1,92 @@
+# Provider-Scoped Model Selection and Zen Receive Verification
+
+Date: 2026-05-10
+
+## Problem
+
+Codex Web Local could show a provider selection such as OpenRouter or OpenCode Zen while the composer model was stale, blank, or inherited from another provider/thread. In one observed flow:
+
+- The sidebar Provider dropdown showed OpenRouter.
+- The composer still showed the Zen model `big-pickle`.
+- A later Codex-thread route showed the model placeholder `Model` instead of a usable model.
+- Send-path testing initially verified only the outgoing `turn/start` request and did not wait for an assistant reply.
+
+This made provider/model state hard to trust when changing threads and switching between OpenRouter, OpenCode Zen, and Codex-started threads.
+
+## Root Causes
+
+Provider/model state had several different authorities:
+
+- Backend `thread/resume` can report a model for the resumed thread.
+- Free-mode status reports the active free-mode provider and current provider model.
+- Frontend local state stores provider-scoped model choices by thread and by provider default.
+- The visible composer selection is the model actually sent in the current turn.
+
+The frontend needed the visible provider-scoped composer model to win for sends, but it also needed free-mode status to hydrate provider-scoped state after provider switches and startup. Without that hydration, switching from OpenRouter to OpenCode Zen could leave the composer on the `Model` placeholder until another refresh path corrected it.
+
+Another review finding was accepted: provider switching should not overwrite an existing per-thread/per-provider model selection with the provider's new-thread default. Existing thread/provider choices must be preserved.
+
+`getCurrentModelConfig()` also called `/codex-api/free-mode/status`; that request needed a timeout so a stalled status endpoint could not hang model refresh or startup.
+
+## Fix
+
+Relevant commits:
+
+- `dc7871a8 Send visible provider model from composer`
+- `28f76372 Hydrate provider model from free-mode status`
+- `6ecfed96 Preserve thread model during provider status sync`
+
+Implementation details:
+
+- `ThreadComposer.vue` includes the visible `selectedModel` in the submit payload.
+- `App.vue` passes that model into `sendMessageToSelectedThread()`.
+- `useDesktopState.ts` uses the selected model override for pending details and `turn/start`, so a resumed backend model cannot silently replace the visible provider model at send time.
+- `loadFreeModeStatus()` now derives the active provider, previews the provider model selection, and stores `status.currentModel` into the provider-scoped new-thread context.
+- If a selected thread has no model for the current provider, `loadFreeModeStatus()` seeds that thread/provider model from `status.currentModel`.
+- `onProviderChange()` calls `loadFreeModeStatus()` immediately after provider write, before the broader refresh.
+- `onProviderChange()` only seeds the active existing thread from the provider default when the thread lacks a provider-scoped model already.
+- `getFreeModeStatus()` uses `AbortSignal.timeout(8000)` and throws on non-OK status.
+
+## Verification
+
+Unit/build:
+
+```bash
+pnpm vitest run src/composables/useDesktopState.test.ts src/api/codexGateway.test.ts
+pnpm run build:frontend
+```
+
+Browser fallback testing used Playwright against:
+
+```text
+http://127.0.0.1:5174
+```
+
+Browser Use was attempted first, but the in-app browser could not open localhost/127.0.0.1 in that run because navigation failed with `net::ERR_BLOCKED_BY_CLIENT`.
+
+Successful send-and-receive checks:
+
+| Case | Thread | Provider | Sent model | Received reply? |
+|------|--------|----------|------------|-----------------|
+| OpenRouter existing thread | `019e0aef-f2ca-7d61-8345-efd4aac9ea7b` | OpenRouter | `openrouter/free` | Yes |
+| Zen provider test thread | `019e0d1c-41e0-7670-a55a-664fe46f80a8` | OpenCode Zen | `big-pickle` | Yes |
+| Zen older thread | `019dc7fa-5291-7670-8b9b-d06ae0548d01` | OpenCode Zen | `big-pickle` | Yes |
+
+Each browser test filled the composer, clicked the send button, captured the outgoing `/codex-api/rpc` `turn/start` model, and waited for an assistant message row containing the exact marker.
+
+Screenshot artifacts:
+
+- `output/playwright/openrouter-receive-received.png`
+- `output/playwright/zen-receive-primary-received.png`
+- `output/playwright/zen-receive-older-received.png`
+
+Dark theme check:
+
+- Thread `019dc7fa-5291-7670-a55a-664fe46f80a8`
+- Provider: `OpenCode Zen`
+- Composer model: `big-pickle`
+- Screenshot: `output/playwright/provider-zen-dark-model.png`
+
+## Operational Rule
+
+Provider/model browser tests must wait for a received assistant reply, not only a submitted `turn/start` request. A send-only check proves payload wiring, but it does not prove the selected provider/model can complete a user-visible turn.

--- a/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
+++ b/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
@@ -51,7 +51,7 @@ model_provider = "opencode-zen"
 Codex Web Local can expose OpenCode Zen through its local Responses-compatible proxy. The proxy translates between Codex-style Responses input and Zen's Chat Completions-only API.
 
 For thinking-mode models behind `big-pickle`, the proxy must preserve assistant reasoning in both directions:
-- Upstream Chat `message.reasoning_content` becomes a Responses `reasoning` output item.
+- Upstream Chat `message.reasoning_content` becomes a Responses `reasoning` output item with `summary_text` and `content: []`, so later Responses-backed turns do not replay non-empty reasoning content and trigger `array_above_max_length`.
 - Later Responses `reasoning` input becomes assistant Chat `reasoning_content`.
 - Reasoning that precedes function calls is attached to the assistant tool-call message.
 - Streaming Chat `reasoning_content` deltas are emitted as synthetic Responses reasoning output.
@@ -84,5 +84,6 @@ The browser verification clicked send and waited for an assistant message row co
 ## Related
 - Source: [opencode-zen-big-pickle-codex-cli.md](../../raw/fixes/opencode-zen-big-pickle-codex-cli.md)
 - Source: [opencode-zen-reasoning-content-proxy.md](../../raw/fixes/opencode-zen-reasoning-content-proxy.md)
+- Source: [opencode-zen-reasoning-summary-replay.md](../../raw/fixes/opencode-zen-reasoning-summary-replay.md)
 - Source: [provider-scoped-model-selection-zen.md](../../raw/fixes/provider-scoped-model-selection-zen.md)
 - [merge-to-main-workflow.md](./merge-to-main-workflow.md)

--- a/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
+++ b/llm-wiki/wiki/concepts/opencode-zen-big-pickle.md
@@ -58,7 +58,31 @@ For thinking-mode models behind `big-pickle`, the proxy must preserve assistant 
 
 This behavior was fixed in commit `47d52c8c` after a Docker repro using an empty `CODEX_HOME`, no login, and no Zen API key.
 
+## Provider-Scoped Composer Model Behavior
+
+When Codex Web Local is running in free-mode provider workflows, the visible composer model is the model that must be sent for the next turn. Backend `thread/resume`, free-mode status, provider defaults, and per-thread provider choices can all report model state, but the send path must use the currently visible provider-scoped composer model.
+
+The provider/thread scoping fix landed across commits `dc7871a8`, `28f76372`, and `6ecfed96`:
+
+- The composer submit payload includes the visible selected model.
+- The selected model override is passed through `App.vue` into `sendMessageToSelectedThread()`.
+- `turn/start` uses that selected model override instead of allowing a resumed backend model from another provider to replace it.
+- Free-mode status hydrates the provider-scoped model after startup and provider switches.
+- Provider switching preserves existing per-thread/per-provider model selections and only seeds a thread from the provider default when no thread/provider model exists.
+- Free-mode status fetches are bounded with an 8 second timeout.
+
+The validated provider-switch flow was:
+
+| Thread | Provider | Composer model | Sent model | Received reply |
+|--------|----------|----------------|------------|----------------|
+| `019e0aef-f2ca-7d61-8345-efd4aac9ea7b` | OpenRouter | `openrouter/free` | `openrouter/free` | Yes |
+| `019e0d1c-41e0-7670-a55a-664fe46f80a8` | OpenCode Zen | `big-pickle` | `big-pickle` | Yes |
+| `019dc7fa-5291-7670-8b9b-d06ae0548d01` | OpenCode Zen | `big-pickle` | `big-pickle` | Yes |
+
+The browser verification clicked send and waited for an assistant message row containing the exact marker, not only for the outgoing `/codex-api/rpc` `turn/start` payload.
+
 ## Related
 - Source: [opencode-zen-big-pickle-codex-cli.md](../../raw/fixes/opencode-zen-big-pickle-codex-cli.md)
 - Source: [opencode-zen-reasoning-content-proxy.md](../../raw/fixes/opencode-zen-reasoning-content-proxy.md)
+- Source: [provider-scoped-model-selection-zen.md](../../raw/fixes/provider-scoped-model-selection-zen.md)
 - [merge-to-main-workflow.md](./merge-to-main-workflow.md)

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -24,4 +24,5 @@
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.
 - [../raw/fixes/opencode-zen-reasoning-content-proxy.md](../raw/fixes/opencode-zen-reasoning-content-proxy.md): Codex Web Local Zen proxy reasoning_content round-trip fix and Docker verification.
+- [../raw/fixes/opencode-zen-reasoning-summary-replay.md](../raw/fixes/opencode-zen-reasoning-summary-replay.md): Zen reasoning output summary format that keeps later Responses replay valid.
 - [../raw/fixes/provider-scoped-model-selection-zen.md](../raw/fixes/provider-scoped-model-selection-zen.md): provider-scoped model selection, OpenRouter/Zen thread switching, and send-plus-receive browser verification.

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -24,3 +24,4 @@
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.
 - [../raw/fixes/opencode-zen-reasoning-content-proxy.md](../raw/fixes/opencode-zen-reasoning-content-proxy.md): Codex Web Local Zen proxy reasoning_content round-trip fix and Docker verification.
+- [../raw/fixes/provider-scoped-model-selection-zen.md](../raw/fixes/provider-scoped-model-selection-zen.md): provider-scoped model selection, OpenRouter/Zen thread switching, and send-plus-receive browser verification.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -52,3 +52,9 @@
 - Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
 - Documents: visible composer model authority, free-mode status hydration, per-thread/per-provider preservation, bounded free-mode status fetch, and OpenRouter/Zen send-plus-receive browser verification.
 - Updated `index.md`.
+
+## [2026-05-10] ingest | Zen reasoning summary replay fix
+- Added source: `raw/fixes/opencode-zen-reasoning-summary-replay.md`.
+- Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
+- Documents: non-empty Responses reasoning `content` caused `array_above_max_length`, and translated Zen reasoning now uses `summary_text` with `content: []`.
+- Updated `index.md`.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -46,3 +46,9 @@
 - Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
 - Documents: DeepSeek thinking-mode `reasoning_content` round-trip requirement, Chat-shaped Zen proxy endpoint selection, streaming reasoning preservation, Docker validation, and the `/tmp/app.tar` restart gotcha.
 - Updated `index.md`.
+
+## [2026-05-10] ingest | provider-scoped model selection and Zen receive verification
+- Added source: `raw/fixes/provider-scoped-model-selection-zen.md`.
+- Updated wiki page: `concepts/opencode-zen-big-pickle.md`.
+- Documents: visible composer model authority, free-mode status hydration, per-thread/per-provider preservation, bounded free-mode status fetch, and OpenRouter/Zen send-plus-receive browser verification.
+- Updated `index.md`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1436,7 +1436,9 @@ const latestUserTurnId = computed(() => {
 })
 const liveOverlay = computed(() => selectedLiveOverlay.value)
 const composerThreadContextId = computed(() => (isHomeRoute.value ? '__new-thread__' : selectedThreadId.value))
-const composerSelectedModelId = computed(() => readModelIdForThread(composerThreadContextId.value))
+const composerSelectedModelId = computed(() => (
+  readModelIdForThread(composerThreadContextId.value).trim() || selectedModelId.value.trim()
+))
 const selectedThreadPendingRequest = computed<UiServerRequest | null>(() => {
   const rows = selectedThreadServerRequests.value
   return rows.length > 0 ? rows[rows.length - 1] : null

--- a/src/App.vue
+++ b/src/App.vue
@@ -777,6 +777,7 @@
                   :selected-reasoning-effort="selectedReasoningEffort"
                   :selected-speed-mode="selectedSpeedMode"
                   :is-updating-speed-mode="isUpdatingSpeedMode"
+                  :disabled="freeModeLoading"
                   :skills="installedSkills"
                   :thread-token-usage="selectedThreadTokenUsage"
                   :codex-quota="codexQuota"
@@ -851,6 +852,7 @@
                     :selected-reasoning-effort="selectedReasoningEffort"
                     :selected-speed-mode="selectedSpeedMode"
                     :is-updating-speed-mode="isUpdatingSpeedMode"
+                    :disabled="freeModeLoading"
                     :skills="installedSkills"
                     :thread-token-usage="selectedThreadTokenUsage"
                     :codex-quota="codexQuota"
@@ -1219,6 +1221,7 @@ const {
   steerQueuedMessage,
   setSelectedCollaborationMode,
   readModelIdForThread,
+  previewProviderModelSelection,
   setSelectedModelIdForThread,
 
   setSelectedReasoningEffort,
@@ -3634,10 +3637,12 @@ async function onProviderChange(provider: string): Promise<void> {
   try {
     if (provider === 'codex') {
       selectedProvider.value = 'codex'
+      previewProviderModelSelection(provider)
       const result = await withProviderSwitchTimeout(setFreeMode(false), 'Codex provider switch')
       freeModeEnabled.value = result.enabled
     } else if (provider === 'openrouter') {
       selectedProvider.value = 'openrouter'
+      previewProviderModelSelection(provider)
       const result = await withProviderSwitchTimeout(setFreeMode(true), 'OpenRouter provider switch')
       freeModeEnabled.value = result.enabled
       await withProviderSwitchTimeout(
@@ -3649,6 +3654,7 @@ async function onProviderChange(provider: string): Promise<void> {
       )
     } else if (provider === 'opencode-zen') {
       selectedProvider.value = 'opencode-zen'
+      previewProviderModelSelection(provider)
       await withProviderSwitchTimeout(
         setCustomProvider('', opencodeZenKey.value.trim(), {
           wireApi: 'chat',
@@ -3659,6 +3665,7 @@ async function onProviderChange(provider: string): Promise<void> {
       freeModeEnabled.value = true
     } else if (provider === 'custom') {
       selectedProvider.value = 'custom'
+      previewProviderModelSelection(provider)
       if (customEndpointUrl.value.trim() && customEndpointKey.value.trim()) {
         await withProviderSwitchTimeout(
           setCustomProvider(customEndpointUrl.value.trim(), customEndpointKey.value.trim(), {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1789,7 +1789,7 @@ onMounted(() => {
   void refreshDefaultProjectName()
   void refreshTelegramConfig()
   void refreshTelegramStatus()
-  void loadFreeModeStatus()
+  void loadInitialFreeModeStatus()
   void refreshThreadTerminalStatus()
   void refreshTerminalQuickCommands()
 })
@@ -3820,6 +3820,16 @@ async function loadFreeModeStatus(): Promise<void> {
   } catch {
     // Ignore — free mode status unknown
   }
+}
+
+async function loadInitialFreeModeStatus(): Promise<void> {
+  await loadFreeModeStatus()
+  if (selectedProvider.value === 'codex') return
+  await refreshAll({
+    includeSelectedThreadMessages: false,
+    providerChanged: true,
+    awaitAncillaryRefreshes: true,
+  })
 }
 
 function onDictationLanguageChange(nextValue: string): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3687,6 +3687,7 @@ async function onProviderChange(provider: string): Promise<void> {
         freeModeEnabled.value = true
       }
     }
+    await withProviderSwitchTimeout(loadFreeModeStatus(), 'Provider status refresh')
     providerError.value = ''
     await withProviderSwitchTimeout(
       refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true }),
@@ -3814,19 +3815,28 @@ async function loadFreeModeStatus(): Promise<void> {
     freeModeEnabled.value = status.enabled
     freeModeHasCustomKey.value = status.customKey ?? false
     freeModeCustomKeyMasked.value = status.maskedKey ?? null
+    let nextProvider: 'codex' | 'openrouter' | 'opencode-zen' | 'custom' = 'codex'
     if (status.enabled) {
       if (status.provider === 'opencode-zen') {
-        selectedProvider.value = 'opencode-zen'
+        nextProvider = 'opencode-zen'
       } else if (status.provider === 'custom') {
-        selectedProvider.value = 'custom'
+        nextProvider = 'custom'
         customEndpointUrl.value = status.customBaseUrl ?? ''
         customEndpointWireApi.value = status.wireApi === 'chat' ? 'chat' : 'responses'
       } else {
-        selectedProvider.value = 'openrouter'
+        nextProvider = 'openrouter'
         openRouterWireApi.value = status.wireApi === 'chat' ? 'chat' : 'responses'
       }
-    } else {
-      selectedProvider.value = 'codex'
+    }
+    selectedProvider.value = nextProvider
+    previewProviderModelSelection(nextProvider)
+    const currentModel = status.currentModel?.trim() ?? ''
+    if (currentModel) {
+      setSelectedModelIdForThread('__new-thread__', currentModel)
+      const threadId = selectedThreadId.value.trim()
+      if (threadId && !readModelIdForThread(threadId).trim()) {
+        setSelectedModelIdForThread(threadId, currentModel)
+      }
     }
   } catch {
     // Ignore — free mode status unknown

--- a/src/App.vue
+++ b/src/App.vue
@@ -230,17 +230,15 @@
 
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the API provider for the Codex backend')">
                 <span class="sidebar-settings-label">{{ t('Provider') }}</span>
-                <select
-                  class="sidebar-settings-provider-select"
-                  :value="selectedProvider"
+                <ComposerDropdown
+                  class="sidebar-settings-provider-dropdown"
+                  :model-value="selectedProvider"
+                  :options="providerOptions"
                   :disabled="freeModeLoading"
-                  @change="onProviderChange(($event.target as HTMLSelectElement).value)"
-                >
-                  <option value="codex">Codex</option>
-                  <option value="openrouter">OpenRouter</option>
-                  <option value="opencode-zen">OpenCode Zen</option>
-                  <option value="custom">Custom endpoint</option>
-                </select>
+                  :placeholder="t('Provider')"
+                  open-direction="up"
+                  @update:model-value="onProviderChange"
+                />
               </div>
               <div v-if="providerError" class="sidebar-settings-row sidebar-settings-error">
                 {{ providerError }}
@@ -1343,6 +1341,12 @@ const freeModeCustomKeyMasked = ref<string | null>(null)
 const freeModeCustomKeySaving = ref(false)
 const providerError = ref('')
 const selectedProvider = ref<'codex' | 'openrouter' | 'opencode-zen' | 'custom'>('codex')
+const providerOptions = computed(() => [
+  { value: 'codex', label: 'Codex' },
+  { value: 'openrouter', label: 'OpenRouter' },
+  { value: 'opencode-zen', label: 'OpenCode Zen' },
+  { value: 'custom', label: t('Custom endpoint') },
+])
 const customEndpointUrl = ref('')
 const customEndpointKey = ref('')
 const customEndpointWireApi = ref<'responses' | 'chat'>('responses')
@@ -5098,6 +5102,26 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   @apply border-zinc-400 ring-2 ring-zinc-200;
 }
 
+.sidebar-settings-provider-dropdown {
+  @apply min-w-0 max-w-40;
+}
+
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger) {
+  @apply h-auto rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700;
+}
+
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-value) {
+  @apply max-w-32;
+}
+
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-menu-wrap) {
+  @apply left-auto right-0;
+}
+
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger:focus-visible) {
+  @apply border-zinc-400 ring-2 ring-zinc-200;
+}
+
 .sidebar-settings-segmented {
   @apply inline-flex items-center rounded-md border border-zinc-200 bg-white p-0.5;
 }
@@ -5123,6 +5147,14 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 :root.dark .sidebar-settings-provider-select:focus {
+  @apply border-zinc-500 ring-zinc-700;
+}
+
+:root.dark .sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger) {
+  @apply border-zinc-600 bg-zinc-800 text-zinc-200;
+}
+
+:root.dark .sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger:focus-visible) {
   @apply border-zinc-500 ring-zinc-700;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -3694,8 +3694,9 @@ async function onProviderChange(provider: string): Promise<void> {
       'Provider refresh',
     )
     if (activeThreadIdBeforeProviderChange) {
+      const existingThreadModelId = readModelIdForThread(activeThreadIdBeforeProviderChange).trim()
       const providerModelId = readModelIdForThread('__new-thread__').trim() || selectedModelId.value.trim()
-      if (providerModelId) {
+      if (!existingThreadModelId && providerModelId) {
         setSelectedModelIdForThread(activeThreadIdBeforeProviderChange, providerModelId)
       }
       await restoreThreadRouteAfterProviderChange(activeThreadIdBeforeProviderChange)

--- a/src/App.vue
+++ b/src/App.vue
@@ -207,13 +207,13 @@
               </button>
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the interface language for the app.')">
                 <span class="sidebar-settings-label">{{ t('UI language') }}</span>
-                <select
-                  class="sidebar-settings-provider-select"
-                  :value="uiLanguage"
-                  @change="setUiLanguage(($event.target as HTMLSelectElement).value as 'en' | 'zh-CN')"
-                >
-                  <option v-for="option in uiLanguageOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
-                </select>
+                <ComposerDropdown
+                  class="sidebar-settings-language-dropdown"
+                  :model-value="uiLanguage"
+                  :options="uiLanguageOptions"
+                  open-direction="up"
+                  @update:model-value="setUiLanguage($event as 'en' | 'zh-CN')"
+                />
               </div>
               <button class="sidebar-settings-row" type="button" :title="SETTINGS_HELP.chatWidth" @click="cycleChatWidth">
                 <span class="sidebar-settings-label">{{ t('Chat width') }}</span>
@@ -5094,14 +5094,6 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   @apply shrink-0 w-6 h-6 flex items-center justify-center rounded-full border border-zinc-200 text-xs text-zinc-400 transition-colors hover:text-zinc-600 hover:border-zinc-300 disabled:opacity-40;
 }
 
-.sidebar-settings-provider-select {
-  @apply min-w-0 max-w-40 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700 outline-none transition-colors cursor-pointer;
-}
-
-.sidebar-settings-provider-select:focus {
-  @apply border-zinc-400 ring-2 ring-zinc-200;
-}
-
 .sidebar-settings-provider-dropdown {
   @apply min-w-0 max-w-40;
 }
@@ -5140,14 +5132,6 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .sidebar-settings-provider-link {
   @apply text-xs text-blue-600 hover:text-blue-700 underline shrink-0;
-}
-
-:root.dark .sidebar-settings-provider-select {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200;
-}
-
-:root.dark .sidebar-settings-provider-select:focus {
-  @apply border-zinc-500 ring-zinc-700;
 }
 
 :root.dark .sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3604,6 +3604,24 @@ function finishProviderSwitchRoutePreservation(threadId: string): void {
   }, 250)
 }
 
+function withProviderSwitchTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      reject(new Error(`${label} timed out`))
+    }, 15_000)
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeout)
+        resolve(value)
+      },
+      (error) => {
+        window.clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
+
 async function onProviderChange(provider: string): Promise<void> {
   if (freeModeLoading.value) return
   freeModeLoading.value = true
@@ -3616,41 +3634,56 @@ async function onProviderChange(provider: string): Promise<void> {
   try {
     if (provider === 'codex') {
       selectedProvider.value = 'codex'
-      const result = await setFreeMode(false)
+      const result = await withProviderSwitchTimeout(setFreeMode(false), 'Codex provider switch')
       freeModeEnabled.value = result.enabled
     } else if (provider === 'openrouter') {
       selectedProvider.value = 'openrouter'
-      const result = await setFreeMode(true)
+      const result = await withProviderSwitchTimeout(setFreeMode(true), 'OpenRouter provider switch')
       freeModeEnabled.value = result.enabled
-      await setCustomProvider('', '', {
-        wireApi: openRouterWireApi.value,
-        provider: 'openrouter',
-      })
+      await withProviderSwitchTimeout(
+        setCustomProvider('', '', {
+          wireApi: openRouterWireApi.value,
+          provider: 'openrouter',
+        }),
+        'OpenRouter provider configuration',
+      )
     } else if (provider === 'opencode-zen') {
       selectedProvider.value = 'opencode-zen'
-      await setCustomProvider('', opencodeZenKey.value.trim(), {
-        wireApi: 'chat',
-        provider: 'opencode-zen',
-      })
+      await withProviderSwitchTimeout(
+        setCustomProvider('', opencodeZenKey.value.trim(), {
+          wireApi: 'chat',
+          provider: 'opencode-zen',
+        }),
+        'OpenCode Zen provider configuration',
+      )
       freeModeEnabled.value = true
     } else if (provider === 'custom') {
       selectedProvider.value = 'custom'
       if (customEndpointUrl.value.trim() && customEndpointKey.value.trim()) {
-        await setCustomProvider(customEndpointUrl.value.trim(), customEndpointKey.value.trim(), {
-          wireApi: customEndpointWireApi.value,
-        })
+        await withProviderSwitchTimeout(
+          setCustomProvider(customEndpointUrl.value.trim(), customEndpointKey.value.trim(), {
+            wireApi: customEndpointWireApi.value,
+          }),
+          'Custom provider configuration',
+        )
         freeModeEnabled.value = true
       }
     }
     providerError.value = ''
-    await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
+    await withProviderSwitchTimeout(
+      refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true }),
+      'Provider refresh',
+    )
     if (activeThreadIdBeforeProviderChange) {
       const providerModelId = readModelIdForThread('__new-thread__').trim() || selectedModelId.value.trim()
       if (providerModelId) {
         setSelectedModelIdForThread(activeThreadIdBeforeProviderChange, providerModelId)
       }
       await restoreThreadRouteAfterProviderChange(activeThreadIdBeforeProviderChange)
-      await ensureThreadMessagesLoaded(activeThreadIdBeforeProviderChange, { silent: true }).catch(() => {})
+      await withProviderSwitchTimeout(
+        ensureThreadMessagesLoaded(activeThreadIdBeforeProviderChange, { silent: true }).catch(() => {}),
+        'Provider thread refresh',
+      )
       await nextTick()
       await restoreThreadRouteAfterProviderChange(activeThreadIdBeforeProviderChange)
       finishProviderSwitchRoutePreservation(activeThreadIdBeforeProviderChange)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1251,8 +1251,10 @@ const terminalStoredQuickCommands = ref<TerminalHeaderQuickCommand[]>(loadTermin
 const terminalHeaderDropdownValue = ref('')
 const editingQueuedMessageState = ref<{ threadId: string; queueIndex: number } | null>(null)
 const isRouteSyncInProgress = ref(false)
+const providerSwitchPreservedThreadId = ref('')
 const directoryTryInFlightKey = ref('')
 let hasPendingRouteSync = false
+let providerSwitchRestoreTimer: number | null = null
 const hasInitialized = ref(false)
 const newThreadCwd = ref('')
 const newThreadRuntime = ref<'local' | 'worktree'>('local')
@@ -3577,10 +3579,40 @@ function toggleDictationAutoSend(): void {
   window.localStorage.setItem(DICTATION_AUTO_SEND_KEY, dictationAutoSend.value ? '1' : '0')
 }
 
+async function restoreThreadRouteAfterProviderChange(threadId: string): Promise<void> {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) return
+  primeSelectedThread(normalizedThreadId)
+  if (route.name !== 'thread' || routeThreadId.value !== normalizedThreadId) {
+    await router.replace({ name: 'thread', params: { threadId: normalizedThreadId } })
+  }
+}
+
+function finishProviderSwitchRoutePreservation(threadId: string): void {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) return
+  if (providerSwitchRestoreTimer !== null) {
+    window.clearTimeout(providerSwitchRestoreTimer)
+  }
+  providerSwitchRestoreTimer = window.setTimeout(() => {
+    void restoreThreadRouteAfterProviderChange(normalizedThreadId).finally(() => {
+      if (providerSwitchPreservedThreadId.value === normalizedThreadId) {
+        providerSwitchPreservedThreadId.value = ''
+      }
+      providerSwitchRestoreTimer = null
+    })
+  }, 250)
+}
 
 async function onProviderChange(provider: string): Promise<void> {
   if (freeModeLoading.value) return
   freeModeLoading.value = true
+  const activeThreadIdBeforeProviderChange = (
+    route.name === 'thread' ? routeThreadId.value.trim() : selectedThreadId.value.trim()
+  )
+  if (activeThreadIdBeforeProviderChange) {
+    providerSwitchPreservedThreadId.value = activeThreadIdBeforeProviderChange
+  }
   try {
     if (provider === 'codex') {
       selectedProvider.value = 'codex'
@@ -3612,11 +3644,22 @@ async function onProviderChange(provider: string): Promise<void> {
     }
     providerError.value = ''
     await refreshAll({ includeSelectedThreadMessages: false, providerChanged: true, awaitAncillaryRefreshes: true })
-    if (route.name === 'thread') {
-      void router.push({ name: 'home' })
+    if (activeThreadIdBeforeProviderChange) {
+      const providerModelId = readModelIdForThread('__new-thread__').trim() || selectedModelId.value.trim()
+      if (providerModelId) {
+        setSelectedModelIdForThread(activeThreadIdBeforeProviderChange, providerModelId)
+      }
+      await restoreThreadRouteAfterProviderChange(activeThreadIdBeforeProviderChange)
+      await ensureThreadMessagesLoaded(activeThreadIdBeforeProviderChange, { silent: true }).catch(() => {})
+      await nextTick()
+      await restoreThreadRouteAfterProviderChange(activeThreadIdBeforeProviderChange)
+      finishProviderSwitchRoutePreservation(activeThreadIdBeforeProviderChange)
     }
   } catch (err) {
     providerError.value = err instanceof Error ? err.message : 'Failed to switch provider'
+    if (activeThreadIdBeforeProviderChange && providerSwitchPreservedThreadId.value === activeThreadIdBeforeProviderChange) {
+      providerSwitchPreservedThreadId.value = ''
+    }
   } finally {
     freeModeLoading.value = false
   }
@@ -3885,6 +3928,11 @@ async function syncThreadSelectionWithRoute(): Promise<void> {
       hasPendingRouteSync = false
 
       if (route.name === 'home' || route.name === 'skills') {
+        const preservedThreadId = providerSwitchPreservedThreadId.value.trim()
+        if (route.name === 'home' && preservedThreadId) {
+          await restoreThreadRouteAfterProviderChange(preservedThreadId)
+          continue
+        }
         if (selectedThreadId.value !== '') {
           await selectThread('')
         }
@@ -3897,11 +3945,7 @@ async function syncThreadSelectionWithRoute(): Promise<void> {
 
         if (selectedThreadId.value !== threadId) {
           if (!threadExistsInSidebar(threadId)) {
-            if (selectedThreadId.value) {
-              await router.replace({ name: 'thread', params: { threadId: selectedThreadId.value } })
-            } else {
-              await router.replace({ name: 'home' })
-            }
+            await selectThread(threadId)
             continue
           }
           await selectThread(threadId)
@@ -3954,6 +3998,11 @@ watch(
     if (isHomeRoute.value || isSkillsRoute.value) return
 
     if (!threadId) {
+      const preservedThreadId = providerSwitchPreservedThreadId.value.trim()
+      if (preservedThreadId) {
+        await restoreThreadRouteAfterProviderChange(preservedThreadId)
+        return
+      }
       if (route.name !== 'home') {
         await router.replace({ name: 'home' })
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -2809,7 +2809,7 @@ async function syncAfterMobileResume(): Promise<void> {
   }
 }
 
-function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fileAttachments: Array<{ label: string; path: string; fsPath: string }>; skills: Array<{ name: string; path: string }>; mode: 'steer' | 'queue' }): void {
+function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fileAttachments: Array<{ label: string; path: string; fsPath: string }>; skills: Array<{ name: string; path: string }>; selectedModel: string; mode: 'steer' | 'queue' }): void {
   const text = payload.text
   scheduleMobileConversationJumpToLatest()
   const editingState = editingQueuedMessageState.value
@@ -2824,7 +2824,16 @@ function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fil
     void submitFirstMessageForNewThread(text, payload.imageUrls, payload.skills, payload.fileAttachments)
     return
   }
-  void sendMessageToSelectedThread(text, payload.imageUrls, payload.skills, payload.mode, payload.fileAttachments, queueInsertIndex)
+  void sendMessageToSelectedThread(
+    text,
+    payload.imageUrls,
+    payload.skills,
+    payload.mode,
+    payload.fileAttachments,
+    queueInsertIndex,
+    undefined,
+    payload.selectedModel,
+  )
 }
 
 function onEditQueuedMessage(messageId: string): void {

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { listDirectoryComposioConnectors, startThreadTurn } from './codexGateway'
+import { getCurrentModelConfig, listDirectoryComposioConnectors, startThreadTurn } from './codexGateway'
 
 function mockRpcFetch(): { requests: Array<{ method: string, params: Record<string, unknown> }> } {
   const requests: Array<{ method: string, params: Record<string, unknown> }> = []
@@ -85,5 +85,51 @@ describe('listDirectoryComposioConnectors', () => {
     await listDirectoryComposioConnectors('instagram', '50', 25)
 
     expect(requests).toEqual(['/codex-api/composio/connectors?query=instagram&cursor=50&limit=25'])
+  })
+})
+
+describe('getCurrentModelConfig', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses enabled free-mode provider and model over stale Codex config values', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/codex-api/free-mode/status') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          provider: 'opencode-zen',
+          currentModel: 'big-pickle',
+          wireApi: 'chat',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      const body = typeof init?.body === 'string'
+        ? JSON.parse(init.body) as { method: string }
+        : { method: '' }
+      expect(body.method).toBe('config/read')
+      return new Response(JSON.stringify({
+        result: {
+          config: {
+            model: 'gpt-5.4-mini',
+            model_provider: 'openai',
+            model_reasoning_effort: 'high',
+            service_tier: 'auto',
+          },
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    await expect(getCurrentModelConfig()).resolves.toMatchObject({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+    })
   })
 })

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1799,10 +1799,21 @@ export async function getAvailableModelIds(options: { includeProviderModels?: bo
 
 export async function getCurrentModelConfig(): Promise<CurrentModelConfig> {
   const payload = await callRpc<ConfigReadResponse>('config/read', {})
-  const model = payload.config.model ?? ''
-  const providerId = typeof payload.config.model_provider === 'string' ? payload.config.model_provider : ''
+  let model = payload.config.model ?? ''
+  let providerId = typeof payload.config.model_provider === 'string' ? payload.config.model_provider : ''
   const reasoningEffort = normalizeReasoningEffort(payload.config.model_reasoning_effort)
   const speedMode = normalizeSpeedMode(payload.config.service_tier)
+  if (!model || !providerId) {
+    try {
+      const freeModeStatus = await getFreeModeStatus()
+      if (freeModeStatus.enabled) {
+        if (!model) model = freeModeStatus.currentModel ?? ''
+        if (!providerId) providerId = freeModeStatus.provider ?? ''
+      }
+    } catch {
+      // Keep the app usable when free-mode status is unavailable.
+    }
+  }
   return { model, providerId, reasoningEffort, speedMode }
 }
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -249,6 +249,7 @@ type ProviderModelsResponse = {
 }
 
 const PROVIDER_MODELS_FETCH_TIMEOUT_MS = 5_000
+const FREE_MODE_STATUS_FETCH_TIMEOUT_MS = 8_000
 
 type ResolvedCollaborationModeSettings = {
   model: string
@@ -1715,7 +1716,12 @@ export interface FreeModeStatus {
 }
 
 export async function getFreeModeStatus(): Promise<FreeModeStatus> {
-  const response = await fetch('/codex-api/free-mode/status')
+  const response = await fetch('/codex-api/free-mode/status', {
+    signal: AbortSignal.timeout(FREE_MODE_STATUS_FETCH_TIMEOUT_MS),
+  })
+  if (!response.ok) {
+    throw new Error(`Free-mode status request failed with ${response.status}`)
+  }
   return await response.json() as FreeModeStatus
 }
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1803,16 +1803,14 @@ export async function getCurrentModelConfig(): Promise<CurrentModelConfig> {
   let providerId = typeof payload.config.model_provider === 'string' ? payload.config.model_provider : ''
   const reasoningEffort = normalizeReasoningEffort(payload.config.model_reasoning_effort)
   const speedMode = normalizeSpeedMode(payload.config.service_tier)
-  if (!model || !providerId) {
-    try {
-      const freeModeStatus = await getFreeModeStatus()
-      if (freeModeStatus.enabled) {
-        if (!model) model = freeModeStatus.currentModel ?? ''
-        if (!providerId) providerId = freeModeStatus.provider ?? ''
-      }
-    } catch {
-      // Keep the app usable when free-mode status is unavailable.
+  try {
+    const freeModeStatus = await getFreeModeStatus()
+    if (freeModeStatus.enabled) {
+      model = freeModeStatus.currentModel ?? model
+      providerId = freeModeStatus.provider ?? providerId
     }
+  } catch {
+    // Keep the app usable when free-mode status is unavailable.
   }
   return { model, providerId, reasoningEffort, speedMode }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -537,6 +537,7 @@ async function startServer(options: {
   const server = createServer(app)
   attachWebSocket(server)
   const port = await listenWithFallback(server, requestedPort)
+  process.env.CODEXUI_SERVER_PORT = String(port)
   let tunnelChild: ReturnType<typeof spawn> | null = null
   let tunnelUrl: string | null = null
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -533,11 +533,15 @@ async function startServer(options: {
   const generatedPasswordPath = password && passwordResolution.generated
     ? await persistGeneratedPassword(password)
     : null
-  const { app, dispose, attachWebSocket } = createApp({ password })
+  const { app, dispose, attachWebSocket, startBridgeBackgroundServices } = createApp({
+    password,
+    deferBridgeBackgroundServices: true,
+  })
   const server = createServer(app)
   attachWebSocket(server)
   const port = await listenWithFallback(server, requestedPort)
   process.env.CODEXUI_SERVER_PORT = String(port)
+  startBridgeBackgroundServices()
   let tunnelChild: ReturnType<typeof spawn> | null = null
   let tunnelUrl: string | null = null
 

--- a/src/components/content/ReviewPane.vue
+++ b/src/components/content/ReviewPane.vue
@@ -62,20 +62,12 @@
 
         <div v-if="activeScope === 'baseBranch' && snapshot?.baseBranchOptions.length" class="review-pane-control-cluster">
           <span class="review-pane-control-label">{{ t('Branch') }}</span>
-          <label class="review-pane-branch-select-wrap">
-            <select
-              v-model="selectedBaseBranch"
-              class="review-pane-branch-select"
-            >
-              <option
-                v-for="branch in snapshot.baseBranchOptions"
-                :key="branch"
-                :value="branch"
-              >
-                {{ branch }}
-              </option>
-            </select>
-          </label>
+          <ComposerDropdown
+            class="review-pane-branch-select"
+            :model-value="selectedBaseBranch"
+            :options="snapshot.baseBranchOptions.map((branch) => ({ value: branch, label: branch }))"
+            @update:model-value="selectedBaseBranch = $event"
+          />
         </div>
 
         <div v-if="activeScope === 'workspace'" class="review-pane-control-cluster">
@@ -418,6 +410,7 @@ import type {
   UiReviewHunk,
 } from '../../types/codex'
 import IconTablerX from '../icons/IconTablerX.vue'
+import ComposerDropdown from './ComposerDropdown.vue'
 
 const props = defineProps<{
   threadId: string
@@ -1137,12 +1130,16 @@ onBeforeUnmount(() => {
   @apply shrink-0 text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-400;
 }
 
-.review-pane-branch-select-wrap {
-  @apply inline-flex min-w-[9rem] items-center rounded-full border border-zinc-200 bg-white px-2.5 py-1 shadow-sm;
+.review-pane-branch-select {
+  @apply min-w-[9rem];
 }
 
-.review-pane-branch-select {
-  @apply w-full appearance-none bg-transparent text-[11px] font-medium text-zinc-700 outline-none;
+.review-pane-branch-select :deep(.composer-dropdown-trigger) {
+  @apply h-auto rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-medium text-zinc-700 shadow-sm;
+}
+
+.review-pane-branch-select :deep(.composer-dropdown-value) {
+  @apply max-w-44;
 }
 
 .review-pane-segmented {
@@ -1569,12 +1566,12 @@ onBeforeUnmount(() => {
     @apply text-[9px];
   }
 
-  .review-pane-branch-select-wrap {
-    @apply min-w-0 flex-1 px-2 py-0.75;
+  .review-pane-branch-select {
+    @apply min-w-0 flex-1;
   }
 
-  .review-pane-branch-select {
-    @apply text-[12px];
+  .review-pane-branch-select :deep(.composer-dropdown-trigger) {
+    @apply px-2 py-0.75 text-[12px];
   }
 
   .review-pane-segmented {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -454,6 +454,7 @@ export type SubmitPayload = {
   imageUrls: string[]
   fileAttachments: FileAttachment[]
   skills: Array<{ name: string; path: string }>
+  selectedModel: string
   mode: 'steer' | 'queue'
 }
 
@@ -936,6 +937,7 @@ function onSubmit(mode: 'steer' | 'queue' = 'steer'): void {
     imageUrls: selectedImages.value.map((image) => image.url),
     fileAttachments: [...fileAttachments.value],
     skills: selectedSkills.value.map((s) => ({ name: s.name, path: s.path })),
+    selectedModel: props.selectedModel,
     mode,
   })
   clearPersistedDraftForThread(props.activeThreadId)

--- a/src/components/content/ThreadPendingRequestPanel.vue
+++ b/src/components/content/ThreadPendingRequestPanel.vue
@@ -107,33 +107,24 @@
 
             <label v-else-if="field.kind === 'boolean'" class="thread-pending-request-select-wrap">
               <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-              <select
+              <ComposerDropdown
                 class="thread-pending-request-select"
-                :value="serializeMcpBooleanValue(readMcpElicitationFieldValue(request.id, field))"
-                @change="onMcpElicitationBooleanChange(request.id, field, $event)"
-              >
-                <option v-if="!field.hasExplicitDefault" value="">{{ t('Select true or false') }}</option>
-                <option value="true">{{ t('True') }}</option>
-                <option value="false">{{ t('False') }}</option>
-              </select>
+                :model-value="serializeMcpBooleanValue(readMcpElicitationFieldValue(request.id, field))"
+                :options="mcpBooleanOptions(field)"
+                :placeholder="t('Select true or false')"
+                @update:model-value="onMcpElicitationBooleanValueChange(request.id, field, $event)"
+              />
             </label>
 
             <label v-else-if="field.kind === 'singleEnum'" class="thread-pending-request-select-wrap">
               <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-              <select
+              <ComposerDropdown
                 class="thread-pending-request-select"
-                :value="String(readMcpElicitationFieldValue(request.id, field) ?? '')"
-                @change="onMcpElicitationFieldInput(request.id, field, $event)"
-              >
-                <option v-if="!field.hasExplicitDefault" value="">{{ t('Select an option') }}</option>
-                <option
-                  v-for="option in field.options"
-                  :key="`${request.id}:${field.key}:${option.value}`"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </option>
-              </select>
+                :model-value="String(readMcpElicitationFieldValue(request.id, field) ?? '')"
+                :options="mcpSingleEnumOptions(field)"
+                :placeholder="t('Select an option')"
+                @update:model-value="onMcpElicitationFieldValueChange(request.id, field, $event)"
+              />
             </label>
 
             <div v-else class="thread-pending-request-question-options">
@@ -182,19 +173,12 @@
             <div v-if="question.options.length > 0" class="thread-pending-request-question-options">
               <label class="thread-pending-request-select-wrap">
                 <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-                <select
+                <ComposerDropdown
                   class="thread-pending-request-select"
-                  :value="readQuestionAnswer(request.id, question.id, question.options[0]?.label || '')"
-                  @change="onQuestionAnswerChange(request.id, question.id, $event)"
-                >
-                  <option
-                    v-for="option in question.options"
-                    :key="`${request.id}:${question.id}:${option.label}`"
-                    :value="option.label"
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
+                  :model-value="readQuestionAnswer(request.id, question.id, question.options[0]?.label || '')"
+                  :options="toolQuestionOptions(question.options)"
+                  @update:model-value="onQuestionAnswerValueChange(request.id, question.id, $event)"
+                />
               </label>
 
               <p
@@ -250,6 +234,7 @@
 import { computed, ref, watch } from 'vue'
 import type { UiServerRequest, UiServerRequestReply } from '../../types/codex'
 import { useUiLanguage } from '../../composables/useUiLanguage'
+import ComposerDropdown from './ComposerDropdown.vue'
 
 type ApprovalDecision = 'accept' | 'acceptForSession' | 'decline' | 'cancel'
 
@@ -528,6 +513,10 @@ function readQuestionAnswer(requestId: number, questionId: string, fallback: str
   return fallback
 }
 
+function toolQuestionOptions(options: ParsedToolQuestion['options']): Array<{ value: string; label: string }> {
+  return options.map((option) => ({ value: option.label, label: option.label }))
+}
+
 function readQuestionOtherAnswer(requestId: number, questionId: string): string {
   return toolQuestionOtherAnswers.value[toolQuestionKey(requestId, questionId)] ?? ''
 }
@@ -535,10 +524,14 @@ function readQuestionOtherAnswer(requestId: number, questionId: string): string 
 function onQuestionAnswerChange(requestId: number, questionId: string, event: Event): void {
   const target = event.target
   if (!(target instanceof HTMLSelectElement)) return
+  onQuestionAnswerValueChange(requestId, questionId, target.value)
+}
+
+function onQuestionAnswerValueChange(requestId: number, questionId: string, value: string): void {
   const key = toolQuestionKey(requestId, questionId)
   toolQuestionAnswers.value = {
     ...toolQuestionAnswers.value,
-    [key]: target.value,
+    [key]: value,
   }
 }
 
@@ -728,8 +721,10 @@ function readMcpElicitationMultiValue(requestId: number, field: McpElicitationFi
 function onMcpElicitationFieldInput(requestId: number, field: McpElicitationField, event: Event): void {
   const target = event.target
   if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLSelectElement)) return
+  onMcpElicitationFieldValueChange(requestId, field, target.value)
+}
 
-  const rawValue = target.value
+function onMcpElicitationFieldValueChange(requestId: number, field: McpElicitationField, rawValue: string): void {
   const nextValue =
     field.kind === 'number'
       ? rawValue
@@ -745,16 +740,34 @@ function onMcpElicitationFieldInput(requestId: number, field: McpElicitationFiel
 function onMcpElicitationBooleanChange(requestId: number, field: McpElicitationField, event: Event): void {
   const target = event.target
   if (!(target instanceof HTMLSelectElement)) return
+  onMcpElicitationBooleanValueChange(requestId, field, target.value)
+}
 
+function onMcpElicitationBooleanValueChange(requestId: number, field: McpElicitationField, value: string): void {
   let nextValue: boolean | null = null
-  if (target.value === 'true') nextValue = true
-  else if (target.value === 'false') nextValue = false
+  if (value === 'true') nextValue = true
+  else if (value === 'false') nextValue = false
 
   mcpElicitationAnswers.value = {
     ...mcpElicitationAnswers.value,
     [mcpElicitationAnswerKey(requestId, field.key)]: nextValue,
   }
   mcpElicitationValidationError.value = ''
+}
+
+function mcpBooleanOptions(field: McpElicitationField): Array<{ value: string; label: string }> {
+  return [
+    ...(!field.hasExplicitDefault ? [{ value: '', label: t('Select true or false') }] : []),
+    { value: 'true', label: t('True') },
+    { value: 'false', label: t('False') },
+  ]
+}
+
+function mcpSingleEnumOptions(field: McpElicitationField): Array<{ value: string; label: string }> {
+  return [
+    ...(!field.hasExplicitDefault ? [{ value: '', label: t('Select an option') }] : []),
+    ...field.options,
+  ]
 }
 
 function onMcpElicitationMultiToggle(

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -735,15 +735,12 @@
                 step="1"
                 @input="syncAutomationRruleFromScheduleDraft"
               />
-              <select
-                v-model="automationScheduleDraft.intervalUnit"
+              <ComposerDropdown
                 class="automation-schedule-unit"
-                @change="syncAutomationRruleFromScheduleDraft"
-              >
-                <option value="minutes">minutes</option>
-                <option value="hours">hours</option>
-                <option value="days">days</option>
-              </select>
+                :model-value="automationScheduleDraft.intervalUnit"
+                :options="automationIntervalUnitOptions"
+                @update:model-value="onAutomationIntervalUnitChange"
+              />
             </div>
 
             <input
@@ -759,10 +756,12 @@
 
           <label class="automation-thread-field">
             <span class="automation-thread-label">Status</span>
-            <select v-model="automationDraft.status" class="automation-thread-select">
-              <option value="ACTIVE">{{ t('Active') }}</option>
-              <option value="PAUSED">{{ t('Paused') }}</option>
-            </select>
+            <ComposerDropdown
+              class="automation-thread-select"
+              :model-value="automationDraft.status"
+              :options="automationStatusOptions"
+              @update:model-value="automationDraft.status = $event as UiThreadAutomationStatus"
+            />
           </label>
 
           <p v-if="automationDialogError" class="rename-thread-subtitle automation-thread-error">{{ automationDialogError }}</p>
@@ -823,6 +822,7 @@ import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import { getPathLeafName, getPathParent, isProjectlessChatPath } from '../../pathUtils.js'
 import SidebarMenuRow from './SidebarMenuRow.vue'
+import ComposerDropdown from '../content/ComposerDropdown.vue'
 
 const props = defineProps<{
   groups: UiProjectGroup[]
@@ -951,6 +951,15 @@ const automationScheduleDraft = ref<AutomationScheduleDraft>({
   interval: 1,
   intervalUnit: 'hours',
 })
+const automationIntervalUnitOptions: Array<{ value: AutomationIntervalUnit; label: string }> = [
+  { value: 'minutes', label: 'minutes' },
+  { value: 'hours', label: 'hours' },
+  { value: 'days', label: 'days' },
+]
+const automationStatusOptions = computed<Array<{ value: UiThreadAutomationStatus; label: string }>>(() => [
+  { value: 'ACTIVE', label: t('Active') },
+  { value: 'PAUSED', label: t('Paused') },
+])
 const automationDialogAutomations = computed(() => {
   const threadId = automationDialogThreadId.value
   return threadId ? (automationByThreadId.value[threadId] ?? []) : []
@@ -1461,6 +1470,12 @@ function syncAutomationRruleFromScheduleDraft(): void {
 
 function syncAutomationScheduleDraftFromRrule(): void {
   automationScheduleDraft.value = createScheduleDraftFromRrule(automationDraft.value.rrule)
+}
+
+function onAutomationIntervalUnitChange(value: string): void {
+  if (value !== 'minutes' && value !== 'hours' && value !== 'days') return
+  automationScheduleDraft.value.intervalUnit = value
+  syncAutomationRruleFromScheduleDraft()
 }
 
 function setAutomationScheduleMode(mode: AutomationScheduleMode): void {
@@ -3006,9 +3021,16 @@ onBeforeUnmount(() => {
   @apply text-xs font-medium uppercase tracking-wide text-zinc-500;
 }
 
-.automation-thread-textarea,
-.automation-thread-select {
+.automation-thread-textarea {
   @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-thread-select {
+  @apply w-full;
+}
+
+.automation-thread-select :deep(.composer-dropdown-trigger) {
+  @apply rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500;
 }
 
 .automation-schedule-mode-group {
@@ -3032,9 +3054,12 @@ onBeforeUnmount(() => {
 }
 
 .automation-schedule-time,
-.automation-schedule-number,
-.automation-schedule-unit {
+.automation-schedule-number {
   @apply rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-schedule-unit :deep(.composer-dropdown-trigger) {
+  @apply rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-900 focus:border-zinc-500;
 }
 
 .automation-schedule-number {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -727,6 +727,48 @@ describe('model selection', () => {
       gatewayMocks.startThreadTurn.mock.invocationCallOrder[0],
     )
   })
+
+  it('previews provider-scoped model selection before provider refresh completes', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        'thread-a': 'gpt-5.3-codex-spark',
+        '__thread-provider__::opencode-zen::thread-a': 'big-pickle',
+        '__new-thread-provider__::opencode-zen': 'big-pickle',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle', 'zen-model'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.selectedModelId.value).toBe('big-pickle')
+    expect(state.availableModelIds.value).toEqual(['big-pickle', 'zen-model'])
+
+    state.previewProviderModelSelection('codex')
+
+    expect(state.selectedModelId.value).toBe('gpt-5.3-codex-spark')
+    expect(state.availableModelIds.value).toEqual(['gpt-5.3-codex-spark'])
+  })
 })
 
 describe('findAdjacentThreadId', () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -714,6 +714,71 @@ describe('model selection', () => {
     )
   })
 
+  it('uses a resumed thread model when it belongs to the active provider list', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread-provider__::openrouter': 'openrouter/free',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [
+            thread('thread-a', '/tmp/project'),
+            thread('thread-b', '/tmp/project'),
+          ],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['openrouter/free', 'openrouter/other'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'openrouter/free',
+      providerId: 'openrouter',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'openrouter/other',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      turnIndexByTurnId: {},
+    })
+    gatewayMocks.startThreadTurn.mockResolvedValue('turn-1')
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+    state.primeSelectedThread('thread-b')
+    await state.ensureThreadMessagesLoaded('thread-b')
+
+    expect(state.selectedModelId.value).toBe('openrouter/other')
+    expect(state.readModelIdForThread('thread-b')).toBe('openrouter/other')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__thread-provider__::openrouter::thread-b'),
+    )
+
+    await state.sendMessageToSelectedThread('hi')
+
+    expect(gatewayMocks.startThreadTurn).toHaveBeenCalledWith(
+      'thread-b',
+      'hi',
+      [],
+      'openrouter/other',
+      'high',
+      undefined,
+      [],
+      'default',
+    )
+  })
+
   it('accepts gpt-prefixed model ids saved under a custom provider thread key', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -421,6 +421,114 @@ describe('collaboration mode selection', () => {
   })
 })
 
+describe('model selection', () => {
+  it('stores existing-thread models per provider', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.readModelIdForThread('thread-a')).toBe('gpt-5.5')
+
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle', 'zen-model'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+
+    await state.refreshAll({
+      includeSelectedThreadMessages: false,
+      awaitAncillaryRefreshes: true,
+      providerChanged: true,
+    })
+
+    expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
+
+    state.setSelectedModelIdForThread('thread-a', 'zen-model')
+
+    expect(state.readModelIdForThread('thread-a')).toBe('zen-model')
+
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+
+    await state.refreshAll({
+      includeSelectedThreadMessages: false,
+      awaitAncillaryRefreshes: true,
+      providerChanged: true,
+    })
+
+    expect(state.readModelIdForThread('thread-a')).toBe('gpt-5.5')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__thread-provider__::opencode-zen::thread-a'),
+    )
+  })
+
+  it('does not fall back to a legacy thread model for a non-Codex provider on reload', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        'thread-a': 'gpt-5.5',
+        '__new-thread-provider__::opencode-zen': 'big-pickle',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5', 'big-pickle'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
+  })
+})
+
 describe('findAdjacentThreadId', () => {
   it('selects the next thread after the archived thread', () => {
     const threads = [

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -728,6 +728,61 @@ describe('model selection', () => {
     )
   })
 
+  it('reloads selected thread messages after switching providers even when previously loaded', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'gpt-5.5',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      turnIndexByTurnId: {},
+    })
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: true, awaitAncillaryRefreshes: true })
+    expect(gatewayMocks.resumeThread).toHaveBeenCalledTimes(1)
+
+    gatewayMocks.resumeThread.mockClear()
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle'])
+
+    await state.refreshAll({
+      includeSelectedThreadMessages: false,
+      awaitAncillaryRefreshes: true,
+      providerChanged: true,
+    })
+    await state.ensureThreadMessagesLoaded('thread-a')
+
+    expect(gatewayMocks.resumeThread).toHaveBeenCalledWith('thread-a')
+  })
+
   it('previews provider-scoped model selection before provider refresh completes', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -454,6 +454,53 @@ describe('model selection', () => {
     expect(state.availableModelIds.value).toEqual(['gpt-5.5'])
   })
 
+  it('uses the Codex provider namespace when the backend reports openai', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread-provider__::codex': 'gpt-5.5',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.selectedModelId.value).toBe('gpt-5.5')
+    expect(state.readModelIdForThread('thread-a')).toBe('gpt-5.5')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__thread-provider__::codex::thread-a'),
+    )
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__new-thread-provider__::openai'),
+    )
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__thread-provider__::openai::thread-a'),
+    )
+  })
+
   it('stores existing-thread models per provider', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -528,6 +528,93 @@ describe('model selection', () => {
     expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
   })
 
+  it('uses the provider default when selecting an existing thread without a provider model', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        'thread-a': 'gpt-5.5',
+        'thread-b': 'gpt-5.4',
+        '__new-thread-provider__::opencode-zen': 'big-pickle',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [
+            thread('thread-a', '/tmp/project'),
+            thread('thread-b', '/tmp/project'),
+          ],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle', 'zen-model'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+    state.primeSelectedThread('thread-b')
+
+    expect(state.selectedModelId.value).toBe('big-pickle')
+    expect(state.readModelIdForThread('thread-b')).toBe('big-pickle')
+  })
+
+  it('ignores stale Codex model ids saved under a non-Codex provider thread key', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        'thread-a': 'gpt-5.5',
+        '__new-thread-provider__::opencode-zen': 'big-pickle',
+        '__thread-provider__::opencode-zen::thread-b': 'gpt-5.4',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [
+            thread('thread-a', '/tmp/project'),
+            thread('thread-b', '/tmp/project'),
+          ],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle', 'zen-model', 'gpt-5.4'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+    state.primeSelectedThread('thread-b')
+
+    expect(state.selectedModelId.value).toBe('big-pickle')
+    expect(state.readModelIdForThread('thread-b')).toBe('big-pickle')
+
+    state.setSelectedModelIdForThread('thread-b', 'zen-model')
+
+    expect(state.selectedModelId.value).toBe('zen-model')
+    expect(state.readModelIdForThread('thread-b')).toBe('zen-model')
+  })
+
   it('resumes the selected thread again after switching providers before sending', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -422,6 +422,38 @@ describe('collaboration mode selection', () => {
 })
 
 describe('model selection', () => {
+  it('does not request provider model lists while Codex is the active provider', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(gatewayMocks.getAvailableModelIds).toHaveBeenCalledWith({ includeProviderModels: false })
+    expect(state.availableModelIds.value).toEqual(['gpt-5.5'])
+  })
+
   it('stores existing-thread models per provider', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -560,7 +560,7 @@ describe('model selection', () => {
     expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
   })
 
-  it('keeps existing thread model empty without a provider-scoped thread model', async () => {
+  it('shows the active provider default when selecting a thread without a provider-scoped model', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
@@ -597,8 +597,74 @@ describe('model selection', () => {
     await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
     state.primeSelectedThread('thread-b')
 
-    expect(state.selectedModelId.value).toBe('')
+    expect(state.selectedModelId.value).toBe('big-pickle')
     expect(state.readModelIdForThread('thread-b')).toBe('')
+  })
+
+  it('does not save a resumed thread model under the active provider while switching chats', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread-provider__::openrouter': 'openrouter/free',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [
+            thread('thread-a', '/tmp/project'),
+            thread('thread-b', '/tmp/project'),
+          ],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['openrouter/free'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'openrouter/free',
+      providerId: 'openrouter',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'big-pickle',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      turnIndexByTurnId: {},
+    })
+    gatewayMocks.startThreadTurn.mockResolvedValue('turn-1')
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+    state.primeSelectedThread('thread-b')
+    await state.ensureThreadMessagesLoaded('thread-b')
+
+    expect(state.selectedModelId.value).toBe('openrouter/free')
+    expect(state.readModelIdForThread('thread-b')).toBe('')
+    expect(state.availableModelIds.value).toEqual(['openrouter/free'])
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      'codex-web-local.selected-model-by-context.v1',
+      expect.stringContaining('__thread-provider__::openrouter::thread-b'),
+    )
+
+    await state.sendMessageToSelectedThread('hi')
+
+    expect(gatewayMocks.startThreadTurn).toHaveBeenCalledWith(
+      'thread-b',
+      'hi',
+      [],
+      'openrouter/free',
+      'high',
+      undefined,
+      [],
+      'default',
+    )
   })
 
   it('accepts gpt-prefixed model ids saved under a custom provider thread key', async () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -779,6 +779,51 @@ describe('model selection', () => {
     )
   })
 
+  it('loads provider models before resuming selected thread on startup', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread-provider__::openrouter': 'openrouter/free',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['openrouter/free', 'openrouter/other'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'openrouter/free',
+      providerId: 'openrouter',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.resumeThread.mockImplementation(async () => {
+      expect(state.availableModelIds.value).toEqual(['openrouter/free', 'openrouter/other'])
+      return {
+        model: 'openrouter/other',
+        messages: [],
+        inProgress: false,
+        activeTurnId: '',
+        turnIndexByTurnId: {},
+      }
+    })
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: true })
+
+    expect(state.readModelIdForThread('thread-a')).toBe('openrouter/other')
+    expect(state.selectedModelId.value).toBe('openrouter/other')
+  })
+
   it('accepts gpt-prefixed model ids saved under a custom provider thread key', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -527,6 +527,87 @@ describe('model selection', () => {
 
     expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
   })
+
+  it('resumes the selected thread again after switching providers before sending', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [
+        {
+          projectName: 'project',
+          threads: [thread('thread-a', '/tmp/project')],
+        },
+      ],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: 'openai',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAccountRateLimits.mockResolvedValue([])
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'gpt-5.5',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      turnIndexByTurnId: {},
+    })
+    gatewayMocks.startThreadTurn.mockResolvedValue('turn-1')
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+    await state.ensureThreadMessagesLoaded('thread-a')
+
+    expect(gatewayMocks.resumeThread).toHaveBeenCalledTimes(1)
+
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle'])
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'high',
+      speedMode: 'standard',
+    })
+
+    await state.refreshAll({
+      includeSelectedThreadMessages: false,
+      awaitAncillaryRefreshes: true,
+      providerChanged: true,
+    })
+
+    gatewayMocks.resumeThread.mockClear()
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'big-pickle',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      turnIndexByTurnId: {},
+    })
+    gatewayMocks.startThreadTurn.mockClear()
+
+    await state.sendMessageToSelectedThread('hi')
+
+    expect(gatewayMocks.resumeThread).toHaveBeenCalledWith('thread-a')
+    expect(gatewayMocks.startThreadTurn).toHaveBeenCalledWith(
+      'thread-a',
+      'hi',
+      [],
+      'big-pickle',
+      'high',
+      undefined,
+      [],
+      'default',
+    )
+    expect(gatewayMocks.resumeThread.mock.invocationCallOrder[0]).toBeLessThan(
+      gatewayMocks.startThreadTurn.mock.invocationCallOrder[0],
+    )
+  })
 })
 
 describe('findAdjacentThreadId', () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -560,7 +560,7 @@ describe('model selection', () => {
     expect(state.readModelIdForThread('thread-a')).toBe('big-pickle')
   })
 
-  it('uses the provider default when selecting an existing thread without a provider model', async () => {
+  it('keeps existing thread model empty without a provider-scoped thread model', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
@@ -597,8 +597,8 @@ describe('model selection', () => {
     await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
     state.primeSelectedThread('thread-b')
 
-    expect(state.selectedModelId.value).toBe('big-pickle')
-    expect(state.readModelIdForThread('thread-b')).toBe('big-pickle')
+    expect(state.selectedModelId.value).toBe('')
+    expect(state.readModelIdForThread('thread-b')).toBe('')
   })
 
   it('accepts gpt-prefixed model ids saved under a custom provider thread key', async () => {
@@ -787,7 +787,7 @@ describe('model selection', () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
-        'thread-a': 'gpt-5.3-codex-spark',
+        '__thread-provider__::codex::thread-a': 'gpt-5.3-codex-spark',
         '__thread-provider__::opencode-zen::thread-a': 'big-pickle',
         '__new-thread-provider__::opencode-zen': 'big-pickle',
       }),

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -601,13 +601,13 @@ describe('model selection', () => {
     expect(state.readModelIdForThread('thread-b')).toBe('big-pickle')
   })
 
-  it('ignores stale Codex model ids saved under a non-Codex provider thread key', async () => {
+  it('accepts gpt-prefixed model ids saved under a custom provider thread key', async () => {
     installTestWindow({
       'codex-web-local.selected-thread-id.v1': 'thread-a',
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
         'thread-a': 'gpt-5.5',
-        '__new-thread-provider__::opencode-zen': 'big-pickle',
-        '__thread-provider__::opencode-zen::thread-b': 'gpt-5.4',
+        '__new-thread-provider__::custom-endpoint': 'gpt-custom-default',
+        '__thread-provider__::custom-endpoint::thread-b': 'gpt-custom-thread',
       }),
     })
     gatewayMocks.getThreadGroupsPage.mockResolvedValue({
@@ -622,10 +622,10 @@ describe('model selection', () => {
       ],
       nextCursor: null,
     })
-    gatewayMocks.getAvailableModelIds.mockResolvedValue(['big-pickle', 'zen-model', 'gpt-5.4'])
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-custom-default', 'gpt-custom-thread'])
     gatewayMocks.getCurrentModelConfig.mockResolvedValue({
-      model: 'big-pickle',
-      providerId: 'opencode-zen',
+      model: 'gpt-custom-default',
+      providerId: 'custom-endpoint',
       reasoningEffort: 'high',
       speedMode: 'standard',
     })
@@ -638,13 +638,13 @@ describe('model selection', () => {
     await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
     state.primeSelectedThread('thread-b')
 
-    expect(state.selectedModelId.value).toBe('big-pickle')
-    expect(state.readModelIdForThread('thread-b')).toBe('big-pickle')
+    expect(state.selectedModelId.value).toBe('gpt-custom-thread')
+    expect(state.readModelIdForThread('thread-b')).toBe('gpt-custom-thread')
 
-    state.setSelectedModelIdForThread('thread-b', 'zen-model')
+    state.setSelectedModelIdForThread('thread-b', 'gpt-custom-default')
 
-    expect(state.selectedModelId.value).toBe('zen-model')
-    expect(state.readModelIdForThread('thread-b')).toBe('zen-model')
+    expect(state.selectedModelId.value).toBe('gpt-custom-default')
+    expect(state.readModelIdForThread('thread-b')).toBe('gpt-custom-default')
   })
 
   it('resumes the selected thread again after switching providers before sending', async () => {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1676,6 +1676,12 @@ export function useDesktopState() {
     saveSelectedModelMap(selectedModelIdByContext.value)
   }
 
+  function setResumedThreadModelIdForActiveProvider(threadId: string, modelId: string): void {
+    const normalizedModelId = modelId.trim()
+    if (!normalizedModelId || !availableModelIds.value.includes(normalizedModelId)) return
+    setThreadModelId(threadId, normalizedModelId)
+  }
+
   function setThreadTokenUsage(threadId: string, usage: UiThreadTokenUsage | null): void {
     const normalizedThreadId = threadId.trim()
     if (!normalizedThreadId) return
@@ -4250,6 +4256,7 @@ export function useDesktopState() {
       const detail = resumedThread ?? await getThreadDetail(threadId)
 
       if (resumedThread) {
+        setResumedThreadModelIdForActiveProvider(threadId, resumedThread.model)
         resumedThreadById.value = {
           ...resumedThreadById.value,
           [threadId]: true,
@@ -4823,7 +4830,8 @@ export function useDesktopState() {
 
     try {
       if (resumedThreadById.value[threadId] !== true) {
-        await resumeThread(threadId)
+        const resumedThread = await resumeThread(threadId)
+        setResumedThreadModelIdForActiveProvider(threadId, resumedThread.model)
       }
       const modelId = readModelIdForActiveThreadSelection(threadId)
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1859,10 +1859,10 @@ export function useDesktopState() {
       const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
       if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
         if (options?.providerChanged && nextModelIds.length > 0) {
-          if (providerScopedModelId && nextModelIds.includes(providerScopedModelId)) {
-            setSelectedModelId(providerScopedModelId)
-          } else if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
+          if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
             setSelectedModelId(normalizedConfiguredModelId)
+          } else if (providerScopedModelId && nextModelIds.includes(providerScopedModelId)) {
+            setSelectedModelId(providerScopedModelId)
           } else {
             setSelectedModelId(nextModelIds[0])
           }

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1629,6 +1629,13 @@ export function useDesktopState() {
     shouldAutoScrollOnNextAgentEvent = false
   }
 
+  function previewProviderModelSelection(providerId: string): void {
+    activeProviderId.value = normalizeProviderContextId(providerId)
+    const nextSelectedModelId = readModelIdForThread(selectedThreadId.value).trim()
+    selectedModelId.value = nextSelectedModelId
+    availableModelIds.value = nextSelectedModelId ? [nextSelectedModelId] : []
+  }
+
   function setSelectedModelIdForThread(threadId: string, modelId: string): void {
     const normalizedModelId = modelId.trim()
     const contextId = toThreadContextId(threadId)
@@ -5462,6 +5469,7 @@ export function useDesktopState() {
     steerQueuedMessage,
     setSelectedCollaborationMode,
     readModelIdForThread,
+    previewProviderModelSelection,
     setSelectedModelIdForThread,
     setSelectedModelId,
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -82,6 +82,7 @@ const COLLABORATION_MODE_STORAGE_KEY = 'codex-web-local.collaboration-mode-by-co
 const LEGACY_COLLABORATION_MODE_STORAGE_KEY = 'codex-web-local.collaboration-mode.v1'
 const NEW_THREAD_COLLABORATION_MODE_CONTEXT = '__new-thread__'
 const NEW_THREAD_PROVIDER_MODEL_CONTEXT_PREFIX = '__new-thread-provider__::'
+const THREAD_PROVIDER_MODEL_CONTEXT_PREFIX = '__thread-provider__::'
 const EVENT_SYNC_DEBOUNCE_MS = 220
 const BACKGROUND_THREAD_PAGINATION_DELAY_MS = 10_000
 const RATE_LIMIT_REFRESH_DEBOUNCE_MS = 500
@@ -182,6 +183,15 @@ function pruneThreadContextStateMap<T>(
   let changed = false
   const next = createStringKeyedRecord<T>()
   for (const [contextId, value] of Object.entries(stateMap)) {
+    if (contextId.startsWith(THREAD_PROVIDER_MODEL_CONTEXT_PREFIX)) {
+      const providerThreadId = readThreadIdFromProviderModelContextId(contextId)
+      if (providerThreadId && threadIds.has(providerThreadId)) {
+        next[contextId] = value
+        continue
+      }
+      changed = true
+      continue
+    }
     if (
       contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT
       || contextId.startsWith(NEW_THREAD_PROVIDER_MODEL_CONTEXT_PREFIX)
@@ -200,6 +210,11 @@ function normalizeProviderContextId(providerId: string): string {
   return normalized || 'codex'
 }
 
+function isCodexProviderContextId(providerId: string): boolean {
+  const normalizedProviderId = normalizeProviderContextId(providerId)
+  return normalizedProviderId === 'codex' || normalizedProviderId === 'openai'
+}
+
 function isNewThreadContextId(contextId: string): boolean {
   return contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT
 }
@@ -208,6 +223,22 @@ function toProviderModelContextId(providerId: string): string {
   const normalizedProviderId = normalizeProviderContextId(providerId)
   if (!normalizedProviderId) return ''
   return `${NEW_THREAD_PROVIDER_MODEL_CONTEXT_PREFIX}${normalizedProviderId}`
+}
+
+function toThreadProviderModelContextId(threadId: string, providerId: string): string {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) return ''
+  const normalizedProviderId = normalizeProviderContextId(providerId)
+  if (!normalizedProviderId) return ''
+  return `${THREAD_PROVIDER_MODEL_CONTEXT_PREFIX}${normalizedProviderId}::${normalizedThreadId}`
+}
+
+function readThreadIdFromProviderModelContextId(contextId: string): string {
+  if (!contextId.startsWith(THREAD_PROVIDER_MODEL_CONTEXT_PREFIX)) return ''
+  const remainder = contextId.slice(THREAD_PROVIDER_MODEL_CONTEXT_PREFIX.length)
+  const separatorIndex = remainder.indexOf('::')
+  if (separatorIndex < 0) return ''
+  return remainder.slice(separatorIndex + 2).trim()
 }
 
 function toThreadContextId(threadId: string): string {
@@ -1544,12 +1575,21 @@ export function useDesktopState() {
 
   function readModelIdForThread(threadId: string): string {
     const contextId = toThreadContextId(threadId)
+    const providerContextId = toProviderModelContextId(activeProviderId.value)
     if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
-      const providerContextId = toProviderModelContextId(activeProviderId.value)
       const providerModelId = providerContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
         : ''
       if (providerModelId) return providerModelId
+    } else {
+      const providerThreadContextId = toThreadProviderModelContextId(contextId, activeProviderId.value)
+      const providerThreadModelId = providerThreadContextId
+        ? normalizeStoredModelId(selectedModelIdByContext.value[providerThreadContextId])
+        : ''
+      if (providerThreadModelId) return providerThreadModelId
+      if (!isCodexProviderContextId(activeProviderId.value)) {
+        return ''
+      }
     }
     return readSelectedModel(selectedModelIdByContext.value, threadId).trim()
   }
@@ -1584,12 +1624,17 @@ export function useDesktopState() {
   function setSelectedModelIdForThread(threadId: string, modelId: string): void {
     const normalizedModelId = modelId.trim()
     const contextId = toThreadContextId(threadId)
+    const isNewThreadContext = contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT
+    const providerScopedContextId = isNewThreadContext
+      ? toProviderModelContextId(activeProviderId.value)
+      : toThreadProviderModelContextId(contextId, activeProviderId.value)
+    const primaryContextId = providerScopedContextId || contextId
     if (normalizedModelId) {
       const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
-      nextModelMap[contextId] = normalizedModelId
+      nextModelMap[primaryContextId] = normalizedModelId
       selectedModelIdByContext.value = nextModelMap
     } else {
-      selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, contextId)
+      selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, primaryContextId)
     }
     if (threadId.trim() === selectedThreadId.value) {
       selectedModelId.value = readModelIdForThread(selectedThreadId.value)
@@ -1597,7 +1642,7 @@ export function useDesktopState() {
     } else {
       ensureAvailableModelIds(normalizedModelId)
     }
-    if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
+    if (isNewThreadContext) {
       const providerContextId = toProviderModelContextId(activeProviderId.value)
       if (providerContextId) {
         if (normalizedModelId) {
@@ -1621,12 +1666,14 @@ export function useDesktopState() {
     if (!normalizedThreadId) return
 
     const normalizedModelId = modelId.trim()
+    const providerScopedContextId = toThreadProviderModelContextId(normalizedThreadId, activeProviderId.value)
+    const contextId = providerScopedContextId || normalizedThreadId
     if (normalizedModelId) {
       const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
-      nextModelMap[normalizedThreadId] = normalizedModelId
+      nextModelMap[contextId] = normalizedModelId
       selectedModelIdByContext.value = nextModelMap
     } else {
-      selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, normalizedThreadId)
+      selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, contextId)
     }
     ensureAvailableModelIds(normalizedModelId)
     if (selectedThreadId.value === normalizedThreadId) {
@@ -1838,10 +1885,12 @@ export function useDesktopState() {
         getCurrentModelConfig(),
       ])
 
-      const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
       activeProviderId.value = normalizedProviderId
+      const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
+      selectedModelId.value = normalizedSelectedModelId
+      ensureAvailableModelIds(normalizedSelectedModelId)
       const providerModelContextId = toProviderModelContextId(normalizedProviderId)
       const providerScopedModelId = providerModelContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerModelContextId])
@@ -1884,9 +1933,9 @@ export function useDesktopState() {
           setSelectedModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT, normalizedSelectedModelId)
         }
       }
-      if (providerModelContextId && selectedModelId.value.trim().length > 0) {
+      if (providerModelContextId && !providerScopedModelId && normalizedConfiguredModelId) {
         const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
-        nextModelMap[providerModelContextId] = selectedModelId.value.trim()
+        nextModelMap[providerModelContextId] = normalizedConfiguredModelId
         selectedModelIdByContext.value = nextModelMap
         saveSelectedModelMap(selectedModelIdByContext.value)
       }

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -153,6 +153,10 @@ function normalizeStoredModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function isCodexBuiltinModelId(modelId: string): boolean {
+  return modelId.trim().toLowerCase().startsWith('gpt-')
+}
+
 function createStringKeyedRecord<T>(): Record<string, T> {
   return Object.create(null) as Record<string, T>
 }
@@ -1586,10 +1590,14 @@ export function useDesktopState() {
       const providerThreadModelId = providerThreadContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerThreadContextId])
         : ''
-      if (providerThreadModelId) return providerThreadModelId
       if (!isCodexProviderContextId(activeProviderId.value)) {
-        return ''
+        const providerModelId = providerContextId
+          ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
+          : ''
+        if (providerThreadModelId && !isCodexBuiltinModelId(providerThreadModelId)) return providerThreadModelId
+        return providerModelId
       }
+      if (providerThreadModelId) return providerThreadModelId
     }
     return readSelectedModel(selectedModelIdByContext.value, threadId).trim()
   }

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4391,7 +4391,7 @@ export function useDesktopState() {
       } else {
         scheduleAncillaryStateRefresh({
           providerChanged: options.providerChanged,
-          includeProviderModels: false,
+          includeProviderModels: true,
         })
       }
     } catch (unknownError) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1888,13 +1888,12 @@ export function useDesktopState() {
 
   async function refreshModelPreferences(options?: { providerChanged?: boolean; includeProviderModels?: boolean }): Promise<void> {
     try {
-      const [modelIds, currentConfig] = await Promise.all([
-        getAvailableModelIds({ includeProviderModels: options?.includeProviderModels !== false }),
-        getCurrentModelConfig(),
-      ])
-
+      const currentConfig = await getCurrentModelConfig()
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
+      const includeProviderModels =
+        options?.includeProviderModels !== false && !isCodexProviderContextId(normalizedProviderId)
+      const modelIds = await getAvailableModelIds({ includeProviderModels })
       activeProviderId.value = normalizedProviderId
       if (options?.providerChanged) {
         resumedThreadById.value = {}

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1904,6 +1904,7 @@ export function useDesktopState() {
       activeProviderId.value = normalizedProviderId
       if (options?.providerChanged) {
         resumedThreadById.value = {}
+        loadedMessagesByThreadId.value = {}
       }
       const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       selectedModelId.value = normalizedSelectedModelId

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -209,12 +209,11 @@ function pruneThreadContextStateMap<T>(
 
 function normalizeProviderContextId(providerId: string): string {
   const normalized = providerId.trim().toLowerCase()
-  return normalized || 'codex'
+  return !normalized || normalized === 'openai' ? 'codex' : normalized
 }
 
 function isCodexProviderContextId(providerId: string): boolean {
-  const normalizedProviderId = normalizeProviderContextId(providerId)
-  return normalizedProviderId === 'codex' || normalizedProviderId === 'openai'
+  return normalizeProviderContextId(providerId) === 'codex'
 }
 
 function isNewThreadContextId(contextId: string): boolean {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1858,20 +1858,30 @@ export function useDesktopState() {
 
       const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
       if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
+        let nextSelectedModelId = ''
         if (options?.providerChanged && nextModelIds.length > 0) {
           if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
-            setSelectedModelId(normalizedConfiguredModelId)
+            nextSelectedModelId = normalizedConfiguredModelId
           } else if (providerScopedModelId && nextModelIds.includes(providerScopedModelId)) {
-            setSelectedModelId(providerScopedModelId)
+            nextSelectedModelId = providerScopedModelId
           } else {
-            setSelectedModelId(nextModelIds[0])
+            nextSelectedModelId = nextModelIds[0]
           }
         } else if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
-          setSelectedModelId(currentConfig.model)
+          nextSelectedModelId = currentConfig.model
         } else if (nextModelIds.length > 0) {
-          setSelectedModelId(nextModelIds[0])
+          nextSelectedModelId = nextModelIds[0]
+        }
+
+        setSelectedModelId(nextSelectedModelId)
+        if (options?.providerChanged) {
+          setSelectedModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT, nextSelectedModelId)
+        }
+      } else if (options?.providerChanged) {
+        if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
+          setSelectedModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT, normalizedConfiguredModelId)
         } else {
-          setSelectedModelId('')
+          setSelectedModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT, normalizedSelectedModelId)
         }
       }
       if (providerModelContextId && selectedModelId.value.trim().length > 0) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1562,17 +1562,24 @@ export function useDesktopState() {
   function readModelIdForThread(threadId: string): string {
     const contextId = toThreadContextId(threadId)
     if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
-      const providerContextId = toProviderModelContextId(activeProviderId.value)
-      const providerModelId = providerContextId
-        ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
-        : ''
-      return providerModelId
+      return readProviderModelId()
     }
 
     const providerThreadContextId = toThreadProviderModelContextId(contextId, activeProviderId.value)
     return providerThreadContextId
       ? normalizeStoredModelId(selectedModelIdByContext.value[providerThreadContextId])
       : ''
+  }
+
+  function readProviderModelId(): string {
+    const providerContextId = toProviderModelContextId(activeProviderId.value)
+    return providerContextId
+      ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
+      : ''
+  }
+
+  function readModelIdForActiveThreadSelection(threadId: string): string {
+    return readModelIdForThread(threadId) || readProviderModelId()
   }
 
   function ensureAvailableModelIds(...modelIds: string[]): void {
@@ -1592,7 +1599,7 @@ export function useDesktopState() {
     if (selectedThreadId.value === nextThreadId) return
     selectedThreadId.value = nextThreadId
     saveSelectedThreadId(nextThreadId)
-    selectedModelId.value = readModelIdForThread(nextThreadId)
+    selectedModelId.value = readModelIdForActiveThreadSelection(nextThreadId)
     ensureAvailableModelIds(selectedModelId.value)
     selectedCollaborationMode.value = readSelectedCollaborationMode(
       selectedCollaborationModeByContext.value,
@@ -1604,7 +1611,7 @@ export function useDesktopState() {
 
   function previewProviderModelSelection(providerId: string): void {
     activeProviderId.value = normalizeProviderContextId(providerId)
-    const nextSelectedModelId = readModelIdForThread(selectedThreadId.value).trim()
+    const nextSelectedModelId = readModelIdForActiveThreadSelection(selectedThreadId.value).trim()
     selectedModelId.value = nextSelectedModelId
     availableModelIds.value = nextSelectedModelId ? [nextSelectedModelId] : []
   }
@@ -1625,7 +1632,7 @@ export function useDesktopState() {
       selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, primaryContextId)
     }
     if (threadId.trim() === selectedThreadId.value) {
-      selectedModelId.value = readModelIdForThread(selectedThreadId.value)
+      selectedModelId.value = readModelIdForActiveThreadSelection(selectedThreadId.value)
       ensureAvailableModelIds(selectedModelId.value)
     } else {
       ensureAvailableModelIds(normalizedModelId)
@@ -1665,7 +1672,7 @@ export function useDesktopState() {
     }
     ensureAvailableModelIds(normalizedModelId)
     if (selectedThreadId.value === normalizedThreadId) {
-      selectedModelId.value = readModelIdForThread(selectedThreadId.value)
+      selectedModelId.value = readModelIdForActiveThreadSelection(selectedThreadId.value)
     }
     saveSelectedModelMap(selectedModelIdByContext.value)
   }
@@ -2114,7 +2121,7 @@ export function useDesktopState() {
     })
     if (nextSelectedModelMap !== selectedModelIdByContext.value) {
       selectedModelIdByContext.value = nextSelectedModelMap
-      selectedModelId.value = readModelIdForThread(selectedThreadId.value)
+      selectedModelId.value = readModelIdForActiveThreadSelection(selectedThreadId.value)
       ensureAvailableModelIds(selectedModelId.value)
       saveSelectedModelMap(nextSelectedModelMap)
     }
@@ -4244,7 +4251,6 @@ export function useDesktopState() {
       const detail = resumedThread ?? await getThreadDetail(threadId)
 
       if (resumedThread) {
-        setThreadModelId(threadId, resumedThread.model)
         resumedThreadById.value = {
           ...resumedThreadById.value,
           [threadId]: true,
@@ -4818,10 +4824,9 @@ export function useDesktopState() {
 
     try {
       if (resumedThreadById.value[threadId] !== true) {
-        const resumedThread = await resumeThread(threadId)
-        setThreadModelId(threadId, resumedThread.model)
+        await resumeThread(threadId)
       }
-      const modelId = readModelIdForThread(threadId)
+      const modelId = readModelIdForActiveThreadSelection(threadId)
 
       let startedTurnId = ''
       try {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1888,6 +1888,9 @@ export function useDesktopState() {
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
       activeProviderId.value = normalizedProviderId
+      if (options?.providerChanged) {
+        resumedThreadById.value = {}
+      }
       const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       selectedModelId.value = normalizedSelectedModelId
       ensureAvailableModelIds(normalizedSelectedModelId)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -153,10 +153,6 @@ function normalizeStoredModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function isCodexBuiltinModelId(modelId: string): boolean {
-  return modelId.trim().toLowerCase().startsWith('gpt-')
-}
-
 function createStringKeyedRecord<T>(): Record<string, T> {
   return Object.create(null) as Record<string, T>
 }
@@ -1594,7 +1590,7 @@ export function useDesktopState() {
         const providerModelId = providerContextId
           ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
           : ''
-        if (providerThreadModelId && !isCodexBuiltinModelId(providerThreadModelId)) return providerThreadModelId
+        if (providerThreadModelId) return providerThreadModelId
         return providerModelId
       }
       if (providerThreadModelId) return providerThreadModelId

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4387,6 +4387,10 @@ export function useDesktopState() {
       await loadPersistedQueueStateIfNeeded()
       await loadThreads()
       if (includeSelectedThreadMessages) {
+        await refreshModelPreferences({
+          providerChanged: options.providerChanged,
+          includeProviderModels: options.providerChanged === true || awaitAncillaryRefreshes,
+        })
         await loadMessages(selectedThreadId.value)
       }
       if (awaitAncillaryRefreshes) {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4605,6 +4605,7 @@ export function useDesktopState() {
     fileAttachments: FileAttachment[] = [],
     queueInsertIndex?: number,
     collaborationModeOverride?: CollaborationModeKind,
+    selectedModelOverride?: string,
   ): Promise<void> {
     if (isUpdatingSpeedMode.value) return
 
@@ -4654,6 +4655,7 @@ export function useDesktopState() {
         skills,
         fileAttachments,
         collaborationModeOverride,
+        selectedModelOverride,
       ).catch((unknownError) => {
         const errorMessage = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
         setTurnErrorForThread(threadId, errorMessage)
@@ -4670,7 +4672,7 @@ export function useDesktopState() {
       {
         label: 'Thinking',
         details: buildPendingTurnDetails(
-          readModelIdForThread(threadId),
+          selectedModelOverride?.trim() || selectedModelId.value.trim() || readModelIdForActiveThreadSelection(threadId),
           selectedReasoningEffort.value,
           collaborationModeOverride === 'plan'
             ? 'plan'
@@ -4691,6 +4693,7 @@ export function useDesktopState() {
         skills,
         fileAttachments,
         collaborationModeOverride,
+        selectedModelOverride,
       )
     } catch (unknownError) {
       shouldAutoScrollOnNextAgentEvent = false
@@ -4803,6 +4806,7 @@ export function useDesktopState() {
     skills: Array<{ name: string; path: string }> = [],
     fileAttachments: FileAttachment[] = [],
     collaborationModeOverride?: CollaborationModeKind,
+    selectedModelOverride?: string,
   ): Promise<void> {
     const reasoningEffort = selectedReasoningEffort.value
     const collaborationMode = collaborationModeOverride === 'plan' ? 'plan' : collaborationModeOverride === 'default'
@@ -4837,7 +4841,7 @@ export function useDesktopState() {
         const resumedThread = await resumeThread(threadId)
         setResumedThreadModelIdForActiveProvider(threadId, resumedThread.model)
       }
-      const modelId = readModelIdForActiveThreadSelection(threadId)
+      const modelId = selectedModelOverride?.trim() || selectedModelId.value.trim() || readModelIdForActiveThreadSelection(threadId)
 
       let startedTurnId = ''
       try {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -75,7 +75,6 @@ const THREAD_TOKEN_USAGE_STORAGE_KEY = 'codex-web-local.thread-token-usage.v1'
 const THREAD_TERMINAL_OPEN_STORAGE_KEY = 'codex-web-local.thread-terminal-open.v1'
 const SELECTED_THREAD_STORAGE_KEY = 'codex-web-local.selected-thread-id.v1'
 const SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY = 'codex-web-local.selected-model-by-context.v1'
-const LEGACY_SELECTED_MODEL_STORAGE_KEY = 'codex-web-local.selected-model-id.v1'
 const PROJECT_ORDER_STORAGE_KEY = 'codex-web-local.project-order.v1'
 const PROJECT_DISPLAY_NAME_STORAGE_KEY = 'codex-web-local.project-display-name.v1'
 const COLLABORATION_MODE_STORAGE_KEY = 'codex-web-local.collaboration-mode-by-context.v1'
@@ -179,7 +178,10 @@ function omitStringKeyedRecordKey<T>(record: Record<string, T>, key: string): Re
 function pruneThreadContextStateMap<T>(
   stateMap: Record<string, T>,
   threadIds: Set<string>,
+  options: { preserveLegacyThreadContexts?: boolean; preserveNewThreadContext?: boolean } = {},
 ): Record<string, T> {
+  const preserveLegacyThreadContexts = options.preserveLegacyThreadContexts !== false
+  const preserveNewThreadContext = options.preserveNewThreadContext !== false
   let changed = false
   const next = createStringKeyedRecord<T>()
   for (const [contextId, value] of Object.entries(stateMap)) {
@@ -193,9 +195,9 @@ function pruneThreadContextStateMap<T>(
       continue
     }
     if (
-      contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT
+      (preserveNewThreadContext && contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT)
       || contextId.startsWith(NEW_THREAD_PROVIDER_MODEL_CONTEXT_PREFIX)
-      || threadIds.has(contextId)
+      || (preserveLegacyThreadContexts && threadIds.has(contextId))
     ) {
       next[contextId] = value
       continue
@@ -266,25 +268,10 @@ function loadSelectedModelMap(): Record<string, string> {
       return next
     }
   } catch {
-    // Fall back to the legacy global preference below.
+    // Keep model selection empty when persisted state is invalid.
   }
 
-  const legacyModelId = normalizeStoredModelId(window.localStorage.getItem(LEGACY_SELECTED_MODEL_STORAGE_KEY))
-  const next = createStringKeyedRecord<string>()
-  if (legacyModelId) {
-    next[NEW_THREAD_COLLABORATION_MODE_CONTEXT] = legacyModelId
-  }
-  return next
-}
-
-function readSelectedModel(
-  state: Record<string, string>,
-  threadId: string,
-): string {
-  const contextId = toThreadContextId(threadId)
-  const contextModelId = normalizeStoredModelId(state[contextId])
-  if (contextModelId) return contextModelId
-  return normalizeStoredModelId(state[NEW_THREAD_COLLABORATION_MODE_CONTEXT])
+  return createStringKeyedRecord<string>()
 }
 
 function saveSelectedModelMap(state: Record<string, string>): void {
@@ -295,7 +282,6 @@ function saveSelectedModelMap(state: Record<string, string>): void {
     } else {
       window.localStorage.setItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY, JSON.stringify(state))
     }
-    window.localStorage.removeItem(LEGACY_SELECTED_MODEL_STORAGE_KEY)
   } catch {
     // Keep in-memory selection working even if localStorage writes fail.
   }
@@ -1414,7 +1400,7 @@ export function useDesktopState() {
   const selectedCollaborationMode = ref<CollaborationModeKind>(
     readSelectedCollaborationMode(selectedCollaborationModeByContext.value, selectedThreadId.value),
   )
-  const selectedModelId = ref(readSelectedModel(selectedModelIdByContext.value, selectedThreadId.value))
+  const selectedModelId = ref('')
   const selectedReasoningEffort = ref<ReasoningEffort | ''>('medium')
   const selectedSpeedMode = ref<SpeedMode>('standard')
   const activeProviderId = ref('')
@@ -1575,27 +1561,18 @@ export function useDesktopState() {
 
   function readModelIdForThread(threadId: string): string {
     const contextId = toThreadContextId(threadId)
-    const providerContextId = toProviderModelContextId(activeProviderId.value)
     if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
+      const providerContextId = toProviderModelContextId(activeProviderId.value)
       const providerModelId = providerContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
         : ''
-      if (providerModelId) return providerModelId
-    } else {
-      const providerThreadContextId = toThreadProviderModelContextId(contextId, activeProviderId.value)
-      const providerThreadModelId = providerThreadContextId
-        ? normalizeStoredModelId(selectedModelIdByContext.value[providerThreadContextId])
-        : ''
-      if (!isCodexProviderContextId(activeProviderId.value)) {
-        const providerModelId = providerContextId
-          ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
-          : ''
-        if (providerThreadModelId) return providerThreadModelId
-        return providerModelId
-      }
-      if (providerThreadModelId) return providerThreadModelId
+      return providerModelId
     }
-    return readSelectedModel(selectedModelIdByContext.value, threadId).trim()
+
+    const providerThreadContextId = toThreadProviderModelContextId(contextId, activeProviderId.value)
+    return providerThreadContextId
+      ? normalizeStoredModelId(selectedModelIdByContext.value[providerThreadContextId])
+      : ''
   }
 
   function ensureAvailableModelIds(...modelIds: string[]): void {
@@ -2131,7 +2108,10 @@ export function useDesktopState() {
     if (currentThreadId) {
       activeThreadIds.add(currentThreadId)
     }
-    const nextSelectedModelMap = pruneThreadContextStateMap(selectedModelIdByContext.value, activeThreadIds)
+    const nextSelectedModelMap = pruneThreadContextStateMap(selectedModelIdByContext.value, activeThreadIds, {
+      preserveLegacyThreadContexts: false,
+      preserveNewThreadContext: false,
+    })
     if (nextSelectedModelMap !== selectedModelIdByContext.value) {
       selectedModelIdByContext.value = nextSelectedModelMap
       selectedModelId.value = readModelIdForThread(selectedThreadId.value)

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -5172,7 +5172,12 @@ class MethodCatalog {
 
 type CodexBridgeMiddleware = ((req: IncomingMessage, res: ServerResponse, next: () => void) => Promise<void>) & {
   dispose: () => void
+  startBackgroundServices: () => void
   subscribeNotifications: (listener: (value: { method: string; params: unknown; atIso: string }) => void) => () => void
+}
+
+export type CodexBridgeOptions = {
+  startBackgroundServices?: boolean
 }
 
 type SharedBridgeState = {
@@ -5297,10 +5302,11 @@ async function buildThreadSearchIndex(appServer: AppServerProcess): Promise<Thre
   return { docsById }
 }
 
-export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
+export function createCodexBridgeMiddleware(options: CodexBridgeOptions = {}): CodexBridgeMiddleware {
   const { appServer, terminalManager, methodCatalog, telegramBridge, backendQueueProcessor } = getSharedBridgeState()
   let threadSearchIndex: ThreadSearchIndex | null = null
   let threadSearchIndexPromise: Promise<ThreadSearchIndex> | null = null
+  let backgroundServicesStarted = false
 
   async function getThreadSearchIndex(): Promise<ThreadSearchIndex> {
     if (threadSearchIndex) return threadSearchIndex
@@ -5316,15 +5322,23 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
     }
     return threadSearchIndexPromise
   }
-  void initializeSkillsSyncOnStartup(appServer)
-  void readTelegramBridgeConfig()
-    .then((config) => {
-      if (!config.botToken) return
-      telegramBridge.configureToken(config.botToken)
-      telegramBridge.configureAllowedUserIds(config.allowedUserIds)
-      telegramBridge.start()
-    })
-    .catch(() => {})
+  function startBackgroundServices(): void {
+    if (backgroundServicesStarted) return
+    backgroundServicesStarted = true
+    void initializeSkillsSyncOnStartup(appServer)
+    void readTelegramBridgeConfig()
+      .then((config) => {
+        if (!config.botToken) return
+        telegramBridge.configureToken(config.botToken)
+        telegramBridge.configureAllowedUserIds(config.allowedUserIds)
+        telegramBridge.start()
+      })
+      .catch(() => {})
+  }
+
+  if (options.startBackgroundServices !== false) {
+    startBackgroundServices()
+  }
 
   const middleware = async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
     const requestStartNs = process.hrtime.bigint()
@@ -7087,6 +7101,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
     backendQueueProcessor.dispose()
     appServer.dispose()
   }
+  middleware.startBackgroundServices = startBackgroundServices
   middleware.subscribeNotifications = (
     listener: (value: { method: string; params: unknown; atIso: string }) => void,
   ) => {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -27,6 +27,7 @@ import {
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
+  OPENCODE_ZEN_DEFAULT_MODEL,
   shouldCreateDefaultFreeModeStateForMissingAuth,
   type FreeModeState,
 } from './freeMode.js'
@@ -5424,8 +5425,12 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
 
         function readFreeModeState(): FreeModeState {
-          return ensureDefaultFreeModeStateForMissingAuthSync(statePath)
+          const state = ensureDefaultFreeModeStateForMissingAuthSync(statePath)
             ?? { enabled: false, apiKey: null, model: FREE_MODE_DEFAULT_MODEL }
+          if (state.provider === 'opencode-zen' && !state.model?.trim()) {
+            return { ...state, model: OPENCODE_ZEN_DEFAULT_MODEL }
+          }
+          return state
         }
 
         if (req.method === 'POST' && url.pathname === '/codex-api/free-mode') {
@@ -5593,7 +5598,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               ? (current.model || FREE_MODE_DEFAULT_MODEL)
               : providerType === 'custom'
                 ? await fetchCustomEndpointDefaultModel(baseUrl, resolvedKey)
-                : ''
+                : OPENCODE_ZEN_DEFAULT_MODEL
             const state: FreeModeState = {
               enabled: true,
               apiKey: resolvedKey,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -27,6 +27,7 @@ import {
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
+  getOpenCodeZenFreeModelIds,
   OPENCODE_ZEN_DEFAULT_MODEL,
   shouldCreateDefaultFreeModeStateForMissingAuth,
   type FreeModeState,
@@ -6118,22 +6119,29 @@ export function createCodexBridgeMiddleware(options: CodexBridgeOptions = {}): C
               try {
                 const modelsUrl = 'https://opencode.ai/zen/v1/models'
                 const headers: Record<string, string> = {}
-                if (fmState.apiKey && fmState.apiKey !== 'dummy') {
+                const hasZenApiKey = Boolean(fmState.apiKey && fmState.apiKey !== 'dummy')
+                if (hasZenApiKey) {
                   headers['Authorization'] = `Bearer ${fmState.apiKey}`
                 }
                 const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
                 if (resp.ok) {
                   const json = await resp.json() as { data?: Array<{ id: string }> }
                   const allIds = (json.data ?? []).map(m => m.id).filter(Boolean)
-                  const freeIds = allIds.filter(id => id.endsWith('-free') || id === 'big-pickle')
-                  const paidIds = allIds.filter(id => !id.endsWith('-free') && id !== 'big-pickle')
-                  setJson(res, 200, { data: [...freeIds, ...paidIds], exclusive: true, source: 'opencode-zen' })
+                  setJson(res, 200, {
+                    data: getOpenCodeZenFreeModelIds(allIds),
+                    exclusive: true,
+                    source: 'opencode-zen',
+                  })
                   return
                 }
               } catch {
                 // OpenCode Zen model fetch failed
               }
-              setJson(res, 200, { data: ['big-pickle', 'minimax-m2.5-free', 'nemotron-3-super-free', 'trinity-large-preview-free'], exclusive: true, source: 'opencode-zen' })
+              setJson(res, 200, {
+                data: getOpenCodeZenFreeModelIds([]),
+                exclusive: true,
+                source: 'opencode-zen',
+              })
               return
             }
             if (fmState.provider === 'custom' && fmState.customBaseUrl) {

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -6,6 +6,7 @@ import {
   OPENCODE_ZEN_PROVIDER_ID,
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
+  getOpenCodeZenFreeModelIds,
   shouldCreateDefaultFreeModeStateForMissingAuth,
 } from './freeMode'
 
@@ -58,5 +59,31 @@ describe('unauthenticated free mode defaults', () => {
   it('creates the default only when state is absent and Codex auth is missing', () => {
     expect(shouldCreateDefaultFreeModeStateForMissingAuth(null, false)).toBe(true)
     expect(shouldCreateDefaultFreeModeStateForMissingAuth(null, true)).toBe(false)
+  })
+
+  it('limits OpenCode Zen models to free/default choices without an API key', () => {
+    expect(getOpenCodeZenFreeModelIds([
+      'gpt-5.5',
+      'big-pickle',
+      'minimax-m2.5-free',
+      'gpt-5.4-mini',
+      'hy3-preview-free',
+    ])).toEqual([
+      'big-pickle',
+      'minimax-m2.5-free',
+      'hy3-preview-free',
+    ])
+  })
+
+  it('keeps the built-in OpenCode Zen dropdown on free/default choices even with an API key', () => {
+    expect(getOpenCodeZenFreeModelIds([
+      'gpt-5.5',
+      'big-pickle',
+      'minimax-m2.5-free',
+      'gpt-5.4-mini',
+    ])).toEqual([
+      'big-pickle',
+      'minimax-m2.5-free',
+    ])
   })
 })

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -153,6 +153,13 @@ export const CUSTOM_PROVIDER_ID = 'custom-endpoint'
 export const OPENCODE_ZEN_PROVIDER_ID = 'opencode-zen'
 export const OPENCODE_ZEN_BASE_URL = 'https://opencode.ai/zen/v1'
 export const OPENCODE_ZEN_DEFAULT_MODEL = 'big-pickle'
+export const OPENCODE_ZEN_FALLBACK_FREE_MODELS = [
+  OPENCODE_ZEN_DEFAULT_MODEL,
+  'minimax-m2.5-free',
+  'hy3-preview-free',
+  'nemotron-3-super-free',
+  'trinity-large-preview-free',
+]
 
 export type WireApi = 'responses' | 'chat'
 
@@ -193,6 +200,14 @@ export function createDefaultOpenCodeZenFreeModeState(): FreeModeState {
     wireApi: 'chat',
     providerKeys: {},
   }
+}
+
+export function getOpenCodeZenFreeModelIds(modelIds: string[]): string[] {
+  const uniqueIds = modelIds
+    .map((id) => id.trim())
+    .filter((id, index, ids) => id.length > 0 && ids.indexOf(id) === index)
+  const freeIds = uniqueIds.filter((id) => id.endsWith('-free') || id === OPENCODE_ZEN_DEFAULT_MODEL)
+  return freeIds.length > 0 ? freeIds : OPENCODE_ZEN_FALLBACK_FREE_MODELS
 }
 
 export function shouldCreateDefaultFreeModeStateForMissingAuth(

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -15,12 +15,14 @@ const spaEntryFile = join(distDir, 'index.html')
 
 export type ServerOptions = {
   password?: string
+  deferBridgeBackgroundServices?: boolean
 }
 
 export type ServerInstance = {
   app: Express
   dispose: () => void
   attachWebSocket: (server: HttpServer) => void
+  startBridgeBackgroundServices: () => void
 }
 
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -74,7 +76,9 @@ function readWildcardPathParam(value: unknown): string {
 
 export function createServer(options: ServerOptions = {}): ServerInstance {
   const app = express()
-  const bridge = createCodexBridgeMiddleware()
+  const bridge = createCodexBridgeMiddleware({
+    startBackgroundServices: options.deferBridgeBackgroundServices !== true,
+  })
   const authSession = options.password ? createAuthSession(options.password) : null
 
   // 1. Auth middleware (if password is set)
@@ -252,6 +256,7 @@ export function createServer(options: ServerOptions = {}): ServerInstance {
   return {
     app,
     dispose: () => bridge.dispose(),
+    startBridgeBackgroundServices: () => bridge.startBackgroundServices(),
     attachWebSocket: (server: HttpServer) => {
       const wss = new WebSocketServer({ noServer: true })
 

--- a/src/server/unifiedResponsesProxy.test.ts
+++ b/src/server/unifiedResponsesProxy.test.ts
@@ -50,19 +50,45 @@ describe('unified responses proxy reasoning_content translation', () => {
       {
         type: 'reasoning',
         id: expect.stringMatching(/^rs_/),
-        summary: [],
-        content: [{ type: 'reasoning_text', text: 'thinking trace' }],
+        summary: [{ type: 'summary_text', text: 'thinking trace' }],
+        content: [],
       },
     ])
   })
 
-  it('passes prior reasoning items back as assistant reasoning_content', () => {
+  it('passes prior reasoning item content back as assistant reasoning_content', () => {
     const messages = responsesInputToMessages([
       {
         type: 'reasoning',
         id: 'rs_test',
         summary: [],
         content: [{ type: 'reasoning_text', text: 'thinking trace' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'again' }],
+      },
+    ])
+
+    expect(messages).toEqual([
+      { role: 'assistant', content: 'Hello.', reasoning_content: 'thinking trace' },
+      { role: 'user', content: 'again' },
+    ])
+  })
+
+  it('passes prior reasoning summaries back as assistant reasoning_content', () => {
+    const messages = responsesInputToMessages([
+      {
+        type: 'reasoning',
+        id: 'rs_test',
+        summary: [{ type: 'summary_text', text: 'thinking trace' }],
+        content: [],
       },
       {
         type: 'message',

--- a/src/server/unifiedResponsesProxy.ts
+++ b/src/server/unifiedResponsesProxy.ts
@@ -145,6 +145,15 @@ function extractTextParts(value: unknown): string {
     .join('\n')
 }
 
+function buildReasoningOutputItem(reasoningContent: string): Record<string, unknown> {
+  return {
+    type: 'reasoning',
+    id: `rs_${Date.now()}`,
+    summary: [{ type: 'summary_text', text: reasoningContent }],
+    content: [],
+  }
+}
+
 export function responsesInputToMessages(input: string | ResponsesApiInput[], instructions?: string): ChatMessage[] {
   const messages: ChatMessage[] = []
   let pendingReasoningContent = ''
@@ -304,12 +313,7 @@ export function chatCompletionToResponsesFormat(chatResponse: Record<string, unk
     }
 
     if (message.reasoning_content) {
-      output.push({
-        type: 'reasoning',
-        id: `rs_${Date.now()}`,
-        summary: [],
-        content: [{ type: 'reasoning_text', text: message.reasoning_content }],
-      })
+      output.push(buildReasoningOutputItem(message.reasoning_content))
     }
   }
 
@@ -386,12 +390,7 @@ function forwardStreamingTextResponse(
     const messageItem = { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: fullText }], status: 'completed' }
     const output: Array<Record<string, unknown>> = [messageItem]
     if (fullReasoningText) {
-      output.push({
-        type: 'reasoning',
-        id: `rs_${Date.now()}`,
-        summary: [],
-        content: [{ type: 'reasoning_text', text: fullReasoningText }],
-      })
+      output.push(buildReasoningOutputItem(fullReasoningText))
     }
     res.write(`data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"${escapedFull}"}\n\n`)
     res.write(`data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"${escapedFull}"}}\n\n`)

--- a/src/style.css
+++ b/src/style.css
@@ -291,6 +291,10 @@
   @apply text-zinc-400;
 }
 
+:root.dark .automation-thread-select .composer-dropdown-trigger,
+:root.dark .automation-schedule-unit .composer-dropdown-trigger {
+  @apply border-zinc-600 bg-zinc-800 text-zinc-100 focus:border-zinc-400;
+}
 
 :root.dark .composer-dropdown-menu {
   @apply border-zinc-600 bg-zinc-800;

--- a/src/style.css
+++ b/src/style.css
@@ -296,6 +296,10 @@
   @apply border-zinc-600 bg-zinc-800 text-zinc-100 focus:border-zinc-400;
 }
 
+:root.dark .review-pane-branch-select .composer-dropdown-trigger {
+  @apply border-zinc-700 bg-zinc-900 text-zinc-200 shadow-none;
+}
+
 :root.dark .composer-dropdown-menu {
   @apply border-zinc-600 bg-zinc-800;
 }

--- a/tests.md
+++ b/tests.md
@@ -271,6 +271,35 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Qodo review fixes: automation dropdown dark theme and bridge startup ordering
+
+#### Feature/Change Name
+Automation ComposerDropdown controls use dark-theme overrides, and Codex bridge background services start only after the resolved web server port is recorded.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Light theme and dark theme both available from the appearance switcher
+3. OpenCode Zen provider selected when validating server startup behavior
+
+#### Steps
+1. In light theme, open an automation creation/editing surface that shows schedule/status dropdowns.
+2. Confirm automation dropdown triggers match the surrounding light automation form styling.
+3. Switch to dark theme.
+4. Reopen the same automation surface and confirm dropdown triggers use dark backgrounds, dark borders, and readable text.
+5. Start the CLI server on an available port with OpenCode Zen free mode enabled.
+6. Confirm `/codex-api/free-mode/status` reports `provider: opencode-zen`.
+7. Trigger a background skills refresh or open Skills and confirm the app-server still uses the local proxy port instead of falling back to direct Zen `chat` wiring.
+
+#### Expected Results
+- Automation dropdown triggers are not light boxes inside dark theme.
+- Bridge background startup cannot spawn app-server before `CODEXUI_SERVER_PORT` is set.
+- Zen/custom proxy config receives the resolved web server port before startup-triggered app-server RPC calls.
+
+#### Rollback/Cleanup
+- Switch theme/provider settings back to preferred defaults if changed.
+
+---
+
 ### Existing thread models are provider scoped
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -313,13 +313,14 @@ Switching the API provider from an existing thread keeps the user on that thread
 #### Steps
 1. In light theme, open an existing TestChat thread and note the `/thread/<id>` URL.
 2. Open Settings and switch Provider to `OpenCode Zen`.
-3. Confirm the URL remains on the same `/thread/<id>` route.
-4. Confirm the composer model changes to `big-pickle`.
-5. Send a short message and confirm the response appears in the same thread.
-6. Switch Provider back to `Codex`.
-7. Confirm the URL still remains on the same `/thread/<id>` route.
-8. Confirm the composer model changes to a Codex model and sending still works.
-9. Switch to dark theme and repeat steps 1-8.
+3. Confirm the URL remains on the same `/thread/<id>` route while the provider refresh is in progress.
+4. Confirm the composer controls are disabled during the refresh and do not expose the previous provider's model list.
+5. Confirm the composer model changes to `big-pickle`.
+6. Send a short message and confirm the response appears in the same thread.
+7. Switch Provider back to `Codex`.
+8. Confirm the URL still remains on the same `/thread/<id>` route.
+9. Confirm the composer immediately previews a Codex model instead of keeping `big-pickle`, then sending still works after refresh.
+10. Switch to dark theme and repeat steps 1-9.
 
 #### Expected Results
 - Provider switching does not navigate to the home/new-thread composer.
@@ -327,6 +328,7 @@ Switching the API provider from an existing thread keeps the user on that thread
 - The app resumes the selected thread against the newly selected provider before starting the next turn.
 - Messages sent after provider switching stay in the selected thread.
 - The composer model remains provider scoped for the selected thread.
+- The composer does not keep a stale model label or stale model menu visible while provider switching is still loading.
 
 #### Rollback/Cleanup
 - Switch Provider/model settings back to preferred defaults if needed.

--- a/tests.md
+++ b/tests.md
@@ -4923,6 +4923,34 @@ The CLI records the selected web server port before the Codex app-server bridge 
 
 ---
 
+### Provider switch selects provider default model
+
+#### Feature/Change Name
+Changing the Provider dropdown refreshes the model list and selects the provider configured model before any stale provider-scoped composer model.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Settings panel is available
+3. OpenCode Zen provider can fetch models
+
+#### Steps
+1. In light theme, set Provider to `Codex` and select `GPT-5.5` in the composer model dropdown.
+2. Open Settings and switch Provider to `OpenCode Zen`.
+3. Wait for settings/provider refresh to finish.
+4. Confirm the composer model dropdown changes away from `GPT-5.5` to the configured Zen model, normally `big-pickle`.
+5. Open the model dropdown and confirm Zen provider models are shown.
+6. Switch to dark theme and repeat steps 1-5.
+
+#### Expected Results
+- Provider switch does not keep the stale Codex `GPT-5.5` selection.
+- OpenCode Zen selects the configured/default model first.
+- The composer model dropdown remains readable and usable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider back to the preferred default after testing.
+
+---
+
 ### Worktree creation persists across refresh
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -271,6 +271,37 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Existing thread models are provider scoped
+
+#### Feature/Change Name
+Model selection is saved per existing thread and per active provider, so switching providers does not leak the previous provider's selected model into that thread.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. At least one existing thread is selected
+3. Codex and OpenCode Zen providers are available
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, select an existing thread.
+2. With Provider set to `Codex`, select a Codex model such as `GPT-5.5`.
+3. Open Settings and switch Provider to `OpenCode Zen`.
+4. Confirm the same thread's model dropdown changes to a Zen model such as `big-pickle`.
+5. Select another Zen model if available.
+6. Switch Provider back to `Codex`.
+7. Confirm the same thread's model dropdown restores the Codex model instead of keeping the Zen model.
+8. Switch to dark theme and repeat steps 1-7.
+
+#### Expected Results
+- Existing thread model selections are keyed by thread and provider.
+- New-thread provider-scoped model behavior remains unchanged.
+- Model dropdown labels and menus remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider/model settings back to the preferred defaults.
+
+---
+
 ### Startup avoids duplicate setup probes
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -4894,6 +4894,35 @@ Remaining app-native select controls were moved to `ComposerDropdown`, including
 
 ---
 
+### Android Zen app-server uses local proxy
+
+#### Feature/Change Name
+The CLI records the selected web server port before the Codex app-server bridge starts, so OpenCode Zen is configured through the local Responses proxy instead of direct unsupported `wire_api="chat"` config on newer Codex CLI builds.
+
+#### Prerequisites/Setup
+1. Android/proot environment has Codex CLI `0.129.0` or newer.
+2. Published Android package is installed or runnable with `npx codexui-android@latest`.
+3. Free mode state is set to OpenCode Zen with model `big-pickle`.
+
+#### Steps
+1. Start Android package on a fixed port, for example `npx --yes codexui-android@latest --port 18923 --no-password --no-tunnel`.
+2. Request `GET /codex-api/free-mode/status` and confirm provider is `opencode-zen`.
+3. Request `GET /codex-api/provider-models` and confirm `big-pickle` appears.
+4. Request `POST /codex-api/rpc` with body `{"method":"model/list","params":{}}`.
+5. Request `POST /codex-api/rpc` with body `{"method":"config/read","params":{}}`.
+6. Send `hi` through `/codex-api/zen-proxy/v1/responses` using model `big-pickle`.
+
+#### Expected Results
+- Android startup does not configure Codex app-server with direct `wire_api="chat"`.
+- `model/list` and `config/read` do not return `codex app-server exited unexpectedly`.
+- Zen proxy request returns HTTP 200 with assistant output.
+- Model dropdown can load because both the Codex RPC model list and provider model list are available.
+
+#### Rollback/Cleanup
+- Stop the Android `codexui-android` process for the fixed test port.
+
+---
+
 ### Worktree creation persists across refresh
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -3297,6 +3297,7 @@ When switching providers, the model dropdown should only show models from the ne
 - No OpenRouter models (e.g., `openrouter/free`) appear in the list
 - Selected model auto-switches to the first Codex model
 - If the backend reports the Codex provider as `openai`, the composer still uses the `Codex` provider selection and shows a real Codex model, not the `Model` placeholder
+- Existing threads without a provider-thread model still show the active provider's saved/default model in the composer rather than the `Model` placeholder
 - Switching back to OpenRouter shows only OpenRouter models again
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -3298,6 +3298,8 @@ When switching providers, the model dropdown should only show models from the ne
 - Selected model auto-switches to the first Codex model
 - If the backend reports the Codex provider as `openai`, the composer still uses the `Codex` provider selection and shows a real Codex model, not the `Model` placeholder
 - Existing threads without a provider-thread model still show the active provider's saved/default model in the composer rather than the `Model` placeholder
+- If `thread/resume` reports a model that is present in the active provider's model list, that thread shows and sends with the resumed model instead of the provider default
+- If `thread/resume` reports a model outside the active provider's model list, the composer keeps the active provider default and does not save the invalid model for that provider
 - Switching back to OpenRouter shows only OpenRouter models again
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -4937,12 +4937,12 @@ Changing the Provider dropdown refreshes the model list and selects the provider
 1. In light theme, set Provider to `Codex` and select `GPT-5.5` in the composer model dropdown.
 2. Open Settings and switch Provider to `OpenCode Zen`.
 3. Wait for settings/provider refresh to finish.
-4. Confirm the composer model dropdown changes away from `GPT-5.5` to the configured Zen model, normally `big-pickle`.
+4. Confirm the Start new thread composer model dropdown changes away from `GPT-5.5` to the configured Zen model, normally `big-pickle`.
 5. Open the model dropdown and confirm Zen provider models are shown.
 6. Switch to dark theme and repeat steps 1-5.
 
 #### Expected Results
-- Provider switch does not keep the stale Codex `GPT-5.5` selection.
+- Provider switch does not keep the stale Codex `GPT-5.5` selection in the Start new thread composer.
 - OpenCode Zen selects the configured/default model first.
 - The composer model dropdown remains readable and usable in light and dark themes.
 

--- a/tests.md
+++ b/tests.md
@@ -3296,6 +3296,7 @@ When switching providers, the model dropdown should only show models from the ne
 - Model list shows only Codex models (e.g., `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`)
 - No OpenRouter models (e.g., `openrouter/free`) appear in the list
 - Selected model auto-switches to the first Codex model
+- If the backend reports the Codex provider as `openai`, the composer still uses the `Codex` provider selection and shows a real Codex model, not the `Model` placeholder
 - Switching back to OpenRouter shows only OpenRouter models again
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -271,6 +271,34 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Provider model list loads on normal refresh
+
+#### Feature/Change Name
+The composer model dropdown loads provider-specific models during normal background refresh, not only after explicit provider switches.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Provider set to `OpenCode Zen`
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open an existing thread while `OpenCode Zen` is selected.
+2. Refresh the browser tab and wait for the model control to finish loading.
+3. Confirm the selected model is `big-pickle`.
+4. Open the model dropdown.
+5. Confirm Zen models such as `big-pickle`, `minimax-m2.5-free`, and other `*-free` entries can be found in the dropdown search.
+6. Switch to dark theme and repeat steps 1-5.
+
+#### Expected Results
+- Normal page load fetches provider models for the active provider.
+- The dropdown is not limited to stale Codex RPC model results plus `big-pickle`.
+- Model dropdown remains usable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider/model settings back to preferred defaults if needed.
+
+---
+
 ### Qodo review fixes: automation dropdown dark theme and bridge startup ordering
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -5220,3 +5220,34 @@ The sidebar Chats section lists the first 10 projectless chats, offers Show more
 
 #### Rollback/Cleanup
 - None.
+
+---
+
+### OpenCode Zen reasoning replay keeps Responses input valid
+
+#### Feature/Change Name
+OpenCode Zen reasoning output is replay-safe when a later turn is sent through a Responses API provider.
+
+#### Prerequisites/Setup
+1. Dev server running on a non-5173 port, for example `pnpm run dev --host 127.0.0.1 --port 5174`
+2. OpenCode Zen provider available with model `big-pickle`
+3. Codex provider available
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, switch Provider to `OpenCode Zen`.
+2. Send a prompt that produces a visible assistant reply from `big-pickle`.
+3. Switch Provider to `Codex` in the same thread.
+4. Send `hi` and wait for a visible assistant reply.
+5. Confirm the browser does not show an upstream 400 error containing `input[4].content` or `array_above_max_length`.
+6. Switch to dark theme and repeat steps 1-5 in a fresh thread.
+
+#### Expected Results
+- Zen reasoning output is represented with `summary` and an empty `content` array.
+- A later Responses-backed turn does not fail with `Invalid 'input[4].content': array too long`.
+- Both provider turns render visible assistant replies in the browser.
+- Composer controls and replies remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider back to the preferred default after testing.
+- Archive or delete temporary test threads if desired.

--- a/tests.md
+++ b/tests.md
@@ -294,6 +294,7 @@ The composer model dropdown loads provider-specific models during normal backgro
 - Normal page load fetches provider models for the active provider.
 - The dropdown is not limited to stale Codex RPC model results plus `big-pickle`.
 - The built-in OpenCode Zen provider shows only no-key-compatible/default models, even if a key is saved locally.
+- Startup uses enabled free-mode provider/model status instead of stale Codex `config/read` model values.
 - Model dropdown remains usable in light and dark themes.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -4865,6 +4865,35 @@ Managed worktree threads remain visible under their matching canonical workspace
 
 ---
 
+### App dropdowns use ComposerDropdown
+
+#### Feature/Change Name
+Remaining app-native select controls were moved to `ComposerDropdown`, including UI language, pending request choices, review base branch, and thread automation schedule/status selectors.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. Light theme and dark theme both available from the appearance switcher
+3. At least one Git-backed project is available for the review base-branch control
+
+#### Steps
+1. In light theme, open Settings and open the `UI language` dropdown.
+2. Confirm the dropdown uses app menu styling and switching between `English` and `简体中文` updates the UI language.
+3. Open a pending request or elicitation panel with a choice field and confirm the choice control opens as an app dropdown.
+4. Open Review for a Git-backed thread, switch comparison to `Base branch`, and confirm the branch picker opens as an app dropdown.
+5. Open a thread automation dialog, set schedule mode to `Interval`, open the interval unit dropdown, then open the status dropdown.
+6. Switch to dark theme and repeat steps 1, 4, and 5.
+
+#### Expected Results
+- No normal browser `<select>` controls are visible for these surfaces.
+- The dropdowns preserve their previous values and state updates.
+- Dropdown triggers and menus remain readable in light and dark themes.
+- Review, pending request, and automation controls still submit the selected values correctly.
+
+#### Rollback/Cleanup
+- Switch UI language and provider settings back to the preferred defaults after testing.
+
+---
+
 ### Worktree creation persists across refresh
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -271,6 +271,40 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Provider status hydrates active model after provider switches
+
+#### Feature/Change Name
+Free-mode provider status seeds the provider-scoped composer model so switching from OpenRouter to OpenCode Zen does not leave the model dropdown on the `Model` placeholder.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 5174` or equivalent)
+2. At least one existing thread available for OpenRouter testing
+3. At least two existing threads available for OpenCode Zen testing
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open an existing thread and set Provider to OpenRouter.
+2. Wait for the composer model dropdown to show `openrouter/free`.
+3. Send a unique test message and confirm the `/codex-api/rpc` `turn/start` payload uses `model: "openrouter/free"`.
+4. Open a different existing thread and set Provider to OpenCode Zen.
+5. Wait for the composer model dropdown to show `big-pickle`.
+6. Send a unique test message and confirm the `turn/start` payload uses `model: "big-pickle"`.
+7. Open another existing thread while Provider remains OpenCode Zen.
+8. Confirm the composer model dropdown still shows `big-pickle`, then send a unique test message and confirm the payload uses `model: "big-pickle"`.
+9. Switch to dark theme and repeat steps 1-8.
+
+#### Expected Results
+- Switching from OpenRouter to OpenCode Zen never leaves the composer model dropdown on the `Model` placeholder after provider status loads.
+- OpenRouter sends `openrouter/free` for the tested thread.
+- OpenCode Zen sends `big-pickle` for both tested threads.
+- The model dropdown remains readable and usable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider back to the preferred default after testing.
+- Archive or delete test messages if they were only created for this validation.
+
+---
+
 ### Provider model list loads on normal refresh
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -2927,20 +2927,25 @@ Toggle "Free mode" in settings to use free OpenRouter models without an OpenAI A
 1. Open Settings panel from the sidebar.
 2. Verify the settings panel is scrollable when content overflows.
 3. Verify the Accounts section does NOT have its own scrollbar — it flows naturally within the settings panel scroll.
-4. Locate the **Provider** dropdown (default: "Codex").
+4. Locate the **Provider** dropdown (default: "Codex") and confirm it uses the same ComposerDropdown trigger/menu styling as other app dropdowns.
 5. Change provider to **OpenRouter**.
 6. Verify a "Get API key" link appears next to the OpenRouter API key label, pointing to `https://openrouter.ai/keys`.
 7. Verify the API key input field is shown with placeholder `sk-or-v1-... (optional, uses free keys if empty)`.
 8. Optionally enter an OpenRouter API key and click Set.
-9. Change provider to **Custom endpoint**.
-10. Verify URL and API key input fields appear.
-11. Enter a valid endpoint URL and click Save.
-12. Change provider back to **Codex**.
-13. Verify the config is reset and no provider-specific fields are shown.
+9. Change provider to **OpenCode Zen**.
+10. Verify the OpenCode Zen API key row appears and the provider menu can still be reopened.
+11. Change provider to **Custom endpoint**.
+12. Verify URL and API key input fields appear.
+13. Enter a valid endpoint URL and click Save.
+14. Switch between light theme and dark theme, then reopen the Provider dropdown in each theme.
+15. Change provider back to **Codex**.
+16. Verify the config is reset and no provider-specific fields are shown.
 
 #### Expected Results
-- Provider dropdown shows three options: Codex, OpenRouter, Custom endpoint.
+- Provider dropdown shows four options: Codex, OpenRouter, OpenCode Zen, Custom endpoint.
+- Provider dropdown uses the shared ComposerDropdown menu, aligns inside the settings panel, and remains readable in light and dark themes.
 - Selecting OpenRouter enables free mode with community keys (or custom key if provided).
+- Selecting OpenCode Zen enables the built-in Zen provider with Chat Completions defaults.
 - Selecting Custom endpoint allows setting a custom API base URL and bearer token.
 - Selecting Codex disables external provider mode and uses the default Codex backend.
 - Settings panel scrolls as a whole; accounts section has no independent scrollbar.

--- a/tests.md
+++ b/tests.md
@@ -386,11 +386,15 @@ Model selection is saved per existing thread and per active provider, so switchi
 5. Select a Zen model such as `big-pickle`.
 6. Switch Provider back to `Codex`.
 7. Confirm the same thread's model dropdown restores the Codex model instead of keeping the Zen model.
-8. Switch to dark theme and repeat steps 1-7.
+8. Switch Provider to `OpenRouter`.
+9. Select a Zen-created thread and confirm the composer model remains an OpenRouter model such as `openrouter/free`, not `big-pickle`.
+10. Switch to dark theme and repeat steps 1-9.
 
 #### Expected Results
 - Existing thread model selections are keyed by thread and provider.
 - Existing threads without a saved model for the active provider do not use a legacy thread/default localStorage fallback.
+- Existing threads without a saved model for the active provider show the active provider's current/default model in the composer.
+- Loading a thread whose persisted backend model belongs to another provider does not save that model under the active provider.
 - Provider-scoped model ids are accepted as-is for the active provider.
 - The Codex provider model dropdown shows only Codex models and does not include stale provider models such as `big-pickle`.
 - New-thread provider-scoped model behavior remains unchanged.

--- a/tests.md
+++ b/tests.md
@@ -387,6 +387,7 @@ Model selection is saved per existing thread and per active provider, so switchi
 - Existing thread model selections are keyed by thread and provider.
 - Existing threads without a saved model for the active non-Codex provider use that provider's configured/default model instead of a legacy Codex model.
 - Stale Codex `gpt-*` model ids accidentally saved under a non-Codex provider key are ignored until the user explicitly selects a valid non-Codex model.
+- The Codex provider model dropdown shows only Codex models and does not include stale provider models such as `big-pickle`.
 - New-thread provider-scoped model behavior remains unchanged.
 - Model dropdown labels and menus remain readable in light and dark themes.
 

--- a/tests.md
+++ b/tests.md
@@ -295,6 +295,8 @@ Free-mode provider status seeds the provider-scoped composer model so switching 
 
 #### Expected Results
 - Switching from OpenRouter to OpenCode Zen never leaves the composer model dropdown on the `Model` placeholder after provider status loads.
+- Existing per-thread/provider model selections are not overwritten by the provider's new-thread default when switching providers.
+- A stalled or failing `/codex-api/free-mode/status` request is bounded and falls back without blocking startup/model refresh indefinitely.
 - OpenRouter sends `openrouter/free` for the tested thread.
 - OpenCode Zen sends `big-pickle` for both tested threads.
 - The model dropdown remains readable and usable in light and dark themes.

--- a/tests.md
+++ b/tests.md
@@ -385,6 +385,8 @@ Model selection is saved per existing thread and per active provider, so switchi
 
 #### Expected Results
 - Existing thread model selections are keyed by thread and provider.
+- Existing threads without a saved model for the active non-Codex provider use that provider's configured/default model instead of a legacy Codex model.
+- Stale Codex `gpt-*` model ids accidentally saved under a non-Codex provider key are ignored until the user explicitly selects a valid non-Codex model.
 - New-thread provider-scoped model behavior remains unchanged.
 - Model dropdown labels and menus remain readable in light and dark themes.
 

--- a/tests.md
+++ b/tests.md
@@ -287,11 +287,13 @@ The composer model dropdown loads provider-specific models during normal backgro
 3. Confirm the selected model is `big-pickle`.
 4. Open the model dropdown.
 5. Confirm Zen models such as `big-pickle`, `minimax-m2.5-free`, and other `*-free` entries can be found in the dropdown search.
-6. Switch to dark theme and repeat steps 1-5.
+6. Confirm paid GPT-labelled Zen models are not shown in the built-in OpenCode Zen dropdown.
+7. Switch to dark theme and repeat steps 1-6.
 
 #### Expected Results
 - Normal page load fetches provider models for the active provider.
 - The dropdown is not limited to stale Codex RPC model results plus `big-pickle`.
+- The built-in OpenCode Zen provider shows only no-key-compatible/default models, even if a key is saved locally.
 - Model dropdown remains usable in light and dark themes.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -3299,6 +3299,7 @@ When switching providers, the model dropdown should only show models from the ne
 - If the backend reports the Codex provider as `openai`, the composer still uses the `Codex` provider selection and shows a real Codex model, not the `Model` placeholder
 - Existing threads without a provider-thread model still show the active provider's saved/default model in the composer rather than the `Model` placeholder
 - If `thread/resume` reports a model that is present in the active provider's model list, that thread shows and sends with the resumed model instead of the provider default
+- On direct `/thread/:id` startup, model preferences are loaded before thread resume so the resumed model is validated against the active provider list and is not dropped
 - If `thread/resume` reports a model outside the active provider's model list, the composer keeps the active provider default and does not save the invalid model for that provider
 - Switching back to OpenRouter shows only OpenRouter models again
 

--- a/tests.md
+++ b/tests.md
@@ -5081,6 +5081,35 @@ Changing the Provider dropdown refreshes the model list and selects the provider
 
 ---
 
+### Custom provider keeps gpt-prefixed model selections
+
+#### Feature/Change Name
+Custom endpoints can use provider-scoped `gpt-*` model IDs without being treated as stale Codex built-in selections.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. A custom endpoint is configured whose `/models` response includes a `gpt-*` model ID
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open Settings and set Provider to `Custom endpoint`.
+2. Configure the custom endpoint URL/API key and confirm the composer model dropdown includes the custom `gpt-*` model.
+3. Select that custom `gpt-*` model on an existing thread.
+4. Switch to another thread, then return to the original thread.
+5. Confirm the original thread still shows the selected custom `gpt-*` model instead of falling back to the custom provider default.
+6. Switch to dark theme and repeat steps 2-5.
+
+#### Expected Results
+- Provider-scoped custom endpoint thread model selections are preserved even when the model ID starts with `gpt-`.
+- Legacy non-provider-scoped Codex model selections still do not leak into non-Codex providers.
+- The model dropdown remains readable and usable in light and dark themes.
+
+#### Rollback/Cleanup
+- Switch Provider back to the preferred default after testing.
+- Clear custom endpoint credentials if they were only used for this test.
+
+---
+
 ### Worktree creation persists across refresh
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -299,6 +299,40 @@ The composer model dropdown loads provider-specific models during normal backgro
 
 ---
 
+### Provider switching preserves selected thread
+
+#### Feature/Change Name
+Switching the API provider from an existing thread keeps the user on that thread and updates the thread's provider-scoped model.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. An existing TestChat thread is open
+3. Codex and OpenCode Zen providers are available
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, open an existing TestChat thread and note the `/thread/<id>` URL.
+2. Open Settings and switch Provider to `OpenCode Zen`.
+3. Confirm the URL remains on the same `/thread/<id>` route.
+4. Confirm the composer model changes to `big-pickle`.
+5. Send a short message and confirm the response appears in the same thread.
+6. Switch Provider back to `Codex`.
+7. Confirm the URL still remains on the same `/thread/<id>` route.
+8. Confirm the composer model changes to a Codex model and sending still works.
+9. Switch to dark theme and repeat steps 1-8.
+
+#### Expected Results
+- Provider switching does not navigate to the home/new-thread composer.
+- Direct `/thread/<id>` routes remain open even when the thread is temporarily absent from the current provider-filtered sidebar.
+- The app resumes the selected thread against the newly selected provider before starting the next turn.
+- Messages sent after provider switching stay in the selected thread.
+- The composer model remains provider scoped for the selected thread.
+
+#### Rollback/Cleanup
+- Switch Provider/model settings back to preferred defaults if needed.
+
+---
+
 ### Qodo review fixes: automation dropdown dark theme and bridge startup ordering
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -3301,6 +3301,7 @@ When switching providers, the model dropdown should only show models from the ne
 - If `thread/resume` reports a model that is present in the active provider's model list, that thread shows and sends with the resumed model instead of the provider default
 - On direct `/thread/:id` startup, model preferences are loaded before thread resume so the resumed model is validated against the active provider list and is not dropped
 - If `thread/resume` reports a model outside the active provider's model list, the composer keeps the active provider default and does not save the invalid model for that provider
+- Sending from an existing Codex-started thread while the composer shows OpenRouter sends the visible OpenRouter model in `turn/start`, not the resumed Codex model
 - Switching back to OpenRouter shows only OpenRouter models again
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -382,16 +382,16 @@ Model selection is saved per existing thread and per active provider, so switchi
 1. In light theme, select an existing thread.
 2. With Provider set to `Codex`, select a Codex model such as `GPT-5.5`.
 3. Open Settings and switch Provider to `OpenCode Zen`.
-4. Confirm the same thread's model dropdown changes to a Zen model such as `big-pickle`.
-5. Select another Zen model if available.
+4. Confirm the same thread's model dropdown does not reuse the previous Codex model.
+5. Select a Zen model such as `big-pickle`.
 6. Switch Provider back to `Codex`.
 7. Confirm the same thread's model dropdown restores the Codex model instead of keeping the Zen model.
 8. Switch to dark theme and repeat steps 1-7.
 
 #### Expected Results
 - Existing thread model selections are keyed by thread and provider.
-- Existing threads without a saved model for the active non-Codex provider use that provider's configured/default model instead of a legacy Codex model.
-- Stale Codex `gpt-*` model ids accidentally saved under a non-Codex provider key are ignored until the user explicitly selects a valid non-Codex model.
+- Existing threads without a saved model for the active provider do not use a legacy thread/default localStorage fallback.
+- Provider-scoped model ids are accepted as-is for the active provider.
 - The Codex provider model dropdown shows only Codex models and does not include stale provider models such as `big-pickle`.
 - New-thread provider-scoped model behavior remains unchanged.
 - Model dropdown labels and menus remain readable in light and dark themes.
@@ -5096,12 +5096,12 @@ Custom endpoints can use provider-scoped `gpt-*` model IDs without being treated
 2. Configure the custom endpoint URL/API key and confirm the composer model dropdown includes the custom `gpt-*` model.
 3. Select that custom `gpt-*` model on an existing thread.
 4. Switch to another thread, then return to the original thread.
-5. Confirm the original thread still shows the selected custom `gpt-*` model instead of falling back to the custom provider default.
+5. Confirm the original thread still shows the selected custom `gpt-*` model.
 6. Switch to dark theme and repeat steps 2-5.
 
 #### Expected Results
 - Provider-scoped custom endpoint thread model selections are preserved even when the model ID starts with `gpt-`.
-- Legacy non-provider-scoped Codex model selections still do not leak into non-Codex providers.
+- Legacy non-provider-scoped model selections are not read for any provider.
 - The model dropdown remains readable and usable in light and dark themes.
 
 #### Rollback/Cleanup

--- a/whatToTest.md
+++ b/whatToTest.md
@@ -1,0 +1,58 @@
+# What To Test
+
+## Provider And Model Switching
+
+### Setup
+
+- Start the app with `pnpm run dev --host 0.0.0.0 --port 5173`.
+- Open `http://localhost:5173/#/thread/019e0a40-2aad-78e2-b99d-34c8f6b65e21` or any existing thread.
+- Open Settings in the sidebar.
+
+### OpenCode Zen
+
+1. Change Provider to `OpenCode Zen`.
+2. Confirm the thread URL stays on the same `/thread/<id>`.
+3. Confirm the composer immediately shows `big-pickle`.
+4. While the provider switch is loading, confirm composer config controls are disabled.
+5. Open the model dropdown after loading completes.
+6. Confirm the dropdown contains only:
+   - `big-pickle`
+   - `minimax-m2.5-free`
+   - `hy3-preview-free`
+   - `trinity-large-preview-free`
+   - `nemotron-3-super-free`
+7. Confirm GPT-labelled paid Zen models are not listed.
+
+### Codex
+
+1. Change Provider back to `Codex`.
+2. Confirm the thread URL stays on the same `/thread/<id>`.
+3. Confirm the composer immediately changes from `big-pickle` to a Codex model.
+4. Open the model dropdown after loading completes.
+5. Confirm the dropdown contains only Codex models, for example:
+   - `GPT-5.5`
+   - `GPT-5.4`
+   - `GPT-5.4-mini`
+   - `GPT-5.3-codex`
+   - `GPT-5.3-codex-spark`
+   - `GPT-5.2`
+6. Confirm `big-pickle` and Zen `*-free` models are not listed.
+
+### Thread Switching While Zen Is Active
+
+1. Set Provider to `OpenCode Zen`.
+2. Select several different sidebar threads.
+3. Confirm each thread opens its own `/thread/<id>` URL.
+4. Confirm the composer stays on `big-pickle`.
+5. Confirm no stale Codex model appears after changing threads.
+
+### Send Smoke Test
+
+1. With Provider set to `OpenCode Zen`, send `hi` in a test thread.
+2. Confirm a response appears in the same thread.
+3. Switch Provider to `Codex` and send `hi`.
+4. Confirm a response appears in the same thread.
+
+### Light And Dark Theme
+
+Repeat the provider/model dropdown checks in both light and dark theme.


### PR DESCRIPTION
## Summary
- replace remaining app UI select controls with ComposerDropdown, including UI language and review/automation/pending-request selectors
- document the no raw select / no prompt UI rule in AGENTS.md
- set CODEXUI_SERVER_PORT after binding so Android Zen app-server uses the local Responses proxy instead of unsupported direct chat wire API

## Tests
- pnpm run build
- published codexui-android@0.1.105
- Android 18923: model/list and config/read return HTTP 200
- Android 18923: provider-models returns Zen models including big-pickle
- Android 18923: Zen proxy hi request with big-pickle returns HTTP 200