### PR TITLE
Keep pinned threads visible during pagination

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,7 @@
             :project-git-repo-by-name="projectGitRepoByName"
             v-if="!isSidebarCollapsed"
             :selected-thread-id="selectedThreadId" :is-loading="isLoadingThreads"
+            :is-thread-list-fully-loaded="isThreadListFullyLoaded"
             :search-query="sidebarSearchQuery"
             :search-matched-thread-ids="serverMatchedThreadIds"
             @select="onSelectThread"
@@ -1197,6 +1198,7 @@ const {
   accountRateLimitSnapshots,
   messages,
   isLoadingThreads,
+  isThreadListFullyLoaded,
   isLoadingMessages,
   isSendingMessage,
   isInterruptingTurn,

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -25,6 +25,7 @@ import {
   readActiveTurnIdFromResponse,
   normalizeThreadGroupsV2,
   normalizeThreadMessagesV2,
+  normalizeThreadSummaryV2,
   readThreadInProgressFromResponse,
 } from './normalizers/v2'
 import type {
@@ -38,6 +39,7 @@ import type {
   UiFileChange,
   UiMessage,
   UiProjectGroup,
+  UiThread,
   UiReviewAction,
   UiReviewActionLevel,
   UiReviewFile,
@@ -715,6 +717,14 @@ async function getThreadMessagesV2(threadId: string): Promise<UiMessage[]> {
   return normalizeThreadMessagesV2(payload)
 }
 
+async function getThreadSummaryV2(threadId: string): Promise<UiThread> {
+  const payload = await callRpc<ThreadReadResponse>('thread/read', {
+    threadId,
+    includeTurns: false,
+  })
+  return normalizeThreadSummaryV2(payload)
+}
+
 async function getThreadDetailV2(threadId: string): Promise<{
   messages: UiMessage[]
   inProgress: boolean
@@ -760,6 +770,14 @@ export function getBackgroundThreadListLimit(): number {
 export async function getThreadMessages(threadId: string): Promise<UiMessage[]> {
   try {
     return await getThreadMessagesV2(threadId)
+  } catch (error) {
+    throw normalizeCodexApiError(error, `Failed to load thread ${threadId}`, 'thread/read')
+  }
+}
+
+export async function getThreadSummary(threadId: string): Promise<UiThread> {
+  try {
+    return await getThreadSummaryV2(threadId)
   } catch (error) {
     throw normalizeCodexApiError(error, `Failed to load thread ${threadId}`, 'thread/read')
   }

--- a/src/api/normalizers/v2.ts
+++ b/src/api/normalizers/v2.ts
@@ -587,6 +587,10 @@ function toUiThread(summary: Thread): UiThread {
   }
 }
 
+export function normalizeThreadSummaryV2(payload: ThreadReadResponse): UiThread {
+  return toUiThread(payload.thread)
+}
+
 function groupThreadsByProject(threads: UiThread[]): UiProjectGroup[] {
   const grouped = new Map<string, UiThread[]>()
   for (const thread of threads) {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -807,6 +807,7 @@ import {
   deleteThreadAutomation,
   getPinnedThreadState,
   getThreadAutomationMap,
+  getThreadSummary,
   persistPinnedThreadIds,
   runThreadAutomationNow,
   upsertThreadAutomation,
@@ -823,6 +824,7 @@ import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import { getPathLeafName, getPathParent, isProjectlessChatPath } from '../../pathUtils.js'
 import SidebarMenuRow from './SidebarMenuRow.vue'
+import { reconcilePinnedThreadIds } from './pinnedThreadUtils'
 
 const props = defineProps<{
   groups: UiProjectGroup[]
@@ -830,6 +832,7 @@ const props = defineProps<{
   projectGitRepoByName: Record<string, boolean>
   selectedThreadId: string
   isLoading: boolean
+  isThreadListFullyLoaded: boolean
   searchQuery: string
   searchMatchedThreadIds: string[] | null
 }>()
@@ -909,6 +912,7 @@ const showChatsFirst = ref(loadBooleanStorage(CHATS_FIRST_STORAGE_KEY, false))
 const chatSortMode = ref<ChatSortMode>(loadChatSortMode())
 let hasLoadedPinnedThreadState = false
 const pinnedThreadIds = ref<string[]>([])
+const hydratedPinnedThreadById = ref<Record<string, UiThread>>({})
 const inlineDeleteConfirmThreadId = ref('')
 const optimisticallyArchivedThreadIds = ref<string[]>([])
 const openProjectMenuId = ref('')
@@ -1169,9 +1173,42 @@ watch(
 )
 
 watch(threadById, (threadsById) => {
-  const filtered = pinnedThreadIds.value.filter((threadId) => threadsById.has(threadId))
+  const filtered = reconcilePinnedThreadIds(pinnedThreadIds.value, new Set(threadsById.keys()), {
+    canPruneMissing: props.isThreadListFullyLoaded,
+  })
   if (filtered.length === pinnedThreadIds.value.length) return
   pinnedThreadIds.value = filtered
+})
+
+let pinnedThreadHydrationVersion = 0
+
+async function hydrateMissingPinnedThreads(): Promise<void> {
+  if (props.isLoading) return
+  const missingThreadIds = pinnedThreadIds.value.filter((threadId) => !threadById.value.has(threadId) && !hydratedPinnedThreadById.value[threadId])
+  if (missingThreadIds.length === 0) return
+
+  const version = (pinnedThreadHydrationVersion += 1)
+  const loadedThreads = await Promise.all(
+    missingThreadIds.map(async (threadId) => {
+      try {
+        return await getThreadSummary(threadId)
+      } catch {
+        return null
+      }
+    }),
+  )
+  if (version !== pinnedThreadHydrationVersion) return
+
+  const next = { ...hydratedPinnedThreadById.value }
+  for (const thread of loadedThreads) {
+    if (thread) next[thread.id] = thread
+  }
+  hydratedPinnedThreadById.value = next
+}
+
+watch([pinnedThreadIds, threadById, () => props.isLoading], () => {
+  if (!hasLoadedPinnedThreadState) return
+  void hydrateMissingPinnedThreads()
 })
 
 onMounted(async () => {
@@ -1231,7 +1268,7 @@ const openThreadMenuThread = computed(() => {
 
 const pinnedThreads = computed(() =>
   pinnedThreadIds.value
-    .map((threadId) => threadById.value.get(threadId) ?? null)
+    .map((threadId) => threadById.value.get(threadId) ?? hydratedPinnedThreadById.value[threadId] ?? null)
     .filter((thread): thread is UiThread => thread !== null)
     .filter(threadMatchesSearch),
 )

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1172,11 +1172,16 @@ watch(
   },
 )
 
-watch(threadById, (threadsById) => {
+watch([threadById, () => props.isThreadListFullyLoaded], ([threadsById]) => {
   const filtered = reconcilePinnedThreadIds(pinnedThreadIds.value, new Set(threadsById.keys()), {
     canPruneMissing: props.isThreadListFullyLoaded,
   })
   if (filtered.length === pinnedThreadIds.value.length) return
+  const filteredIdSet = new Set(filtered)
+  const nextHydratedPinnedThreads = Object.fromEntries(
+    Object.entries(hydratedPinnedThreadById.value).filter(([threadId]) => filteredIdSet.has(threadId)),
+  )
+  hydratedPinnedThreadById.value = nextHydratedPinnedThreads
   pinnedThreadIds.value = filtered
 })
 
@@ -1229,6 +1234,7 @@ onMounted(async () => {
     automationByThreadId.value = {}
   }
   hasLoadedPinnedThreadState = true
+  void hydrateMissingPinnedThreads()
 })
 
 const deleteThreadHasAutomation = computed(() => threadHasAutomation(deleteThreadDialogThreadId.value))

--- a/src/components/sidebar/pinnedThreadUtils.test.ts
+++ b/src/components/sidebar/pinnedThreadUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { reconcilePinnedThreadIds } from './pinnedThreadUtils'
+
+describe('reconcilePinnedThreadIds', () => {
+  it('keeps pins whose threads have not loaded while pagination is still incomplete', () => {
+    expect(
+      reconcilePinnedThreadIds(['loaded', 'not-yet-loaded'], new Set(['loaded']), {
+        canPruneMissing: false,
+      }),
+    ).toEqual(['loaded', 'not-yet-loaded'])
+  })
+
+  it('prunes missing pins after the thread list is fully loaded', () => {
+    expect(
+      reconcilePinnedThreadIds(['loaded', 'missing'], new Set(['loaded']), {
+        canPruneMissing: true,
+      }),
+    ).toEqual(['loaded'])
+  })
+})

--- a/src/components/sidebar/pinnedThreadUtils.ts
+++ b/src/components/sidebar/pinnedThreadUtils.ts
@@ -1,0 +1,8 @@
+export function reconcilePinnedThreadIds(
+  pinnedThreadIds: string[],
+  loadedThreadIds: Set<string>,
+  options: { canPruneMissing: boolean },
+): string[] {
+  if (!options.canPruneMissing) return pinnedThreadIds
+  return pinnedThreadIds.filter((threadId) => loadedThreadIds.has(threadId))
+}

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1415,6 +1415,7 @@ export function useDesktopState() {
 
   const isLoadingThreads = ref(false)
   const isLoadingMessages = ref(false)
+  const isThreadListFullyLoaded = ref(false)
   const isSendingMessage = ref(false)
   const isInterruptingTurn = ref(false)
   const isUpdatingSpeedMode = ref(false)
@@ -4084,6 +4085,7 @@ export function useDesktopState() {
       const page = await getThreadGroupsPage(threadListNextCursor, getBackgroundThreadListLimit())
       threadListNextCursor = page.nextCursor
       hasLoadedAllThreadPages = page.nextCursor === null
+      isThreadListFullyLoaded.value = hasLoadedAllThreadPages
       loadedThreadListGroups = mergeThreadGroupPages(loadedThreadListGroups, page.groups)
       applyThreadGroups(loadedThreadListGroups, rootsState)
     } catch {
@@ -4122,6 +4124,7 @@ export function useDesktopState() {
         ? threadListNextCursor
         : page.nextCursor
       hasLoadedAllThreadPages = page.nextCursor === null
+      isThreadListFullyLoaded.value = hasLoadedAllThreadPages
       await hydrateWorkspaceRootsStateIfNeeded(groups, rootsState)
 
       applyThreadGroups(loadedThreadListGroups, rootsState)
@@ -5364,6 +5367,7 @@ export function useDesktopState() {
     accountRateLimitSnapshots,
     messages,
     isLoadingThreads,
+    isThreadListFullyLoaded,
     isLoadingMessages,
     isSendingMessage,
     isInterruptingTurn,

--- a/tests.md
+++ b/tests.md
@@ -271,6 +271,35 @@ This file tracks manual regression and feature verification steps.
 
 ---
 
+### Pinned threads remain visible during background pagination
+
+#### Feature/Change Name
+Pinned threads are no longer removed from the Pinned section while the sidebar is still loading older thread-list pages.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev`)
+2. More than 50 total unarchived threads exist
+3. At least one older thread outside the initial recent page is pinned
+4. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, reload the app.
+2. Immediately open the sidebar Pinned section.
+3. Confirm pinned rows from older history remain in the Pinned section after the initial thread list appears.
+4. Wait for background thread pagination to finish.
+5. Confirm the same pinned rows remain visible and can still be selected.
+6. Switch to dark theme and repeat steps 1-5.
+
+#### Expected Results
+- Saved pinned thread IDs are preserved while only the initial thread-list page is loaded.
+- Missing pinned IDs are pruned only after the full thread list has loaded.
+- Pinned rows remain readable and selectable in both light and dark themes.
+
+#### Rollback/Cleanup
+- Unpin any disposable threads created only for this test.
+
+---
+
 ### Startup avoids duplicate setup probes
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- Preserve saved pinned IDs while the sidebar thread list is still background-loading.
- Hydrate pinned thread summaries with lightweight thread/read calls when saved pins are outside the initial thread/list page.
- Add regression coverage for pinned-ID reconciliation and update tests.md manual verification steps.

## Verification
- pnpm exec vitest run src/components/sidebar/pinnedThreadUtils.test.ts src/api/normalizers/v2.test.ts
- pnpm run build:frontend
- Browser check at http://127.0.0.1:4173/ verified 5 pinned rows in light and dark themes.
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser

## Performance audit
- Report: output/playwright/browser-runtime-profile-home-2026-05-09T22-52-25-265Z.json
- threadListFirstPage=1, threadListCursor=0, no duplicate thread-list requests.
- threadRead=3 is expected in this test state because 3 saved pinned threads were absent from the initial 50-thread page; each is loaded with includeTurns:false at about 0.7-0.8 KB.
