### PR TITLE
Make public skills pull overwrite local files

### DIFF
--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -891,6 +891,8 @@ async function ensureSkillsWorkingTreeRepo(
     }
     await runGitFetchWithRefLockRetry(localDir)
     if (options.overwriteLocalFiles) {
+      await runCommand('git', ['reset', '--hard'], { cwd: localDir })
+      await runCommand('git', ['clean', '-fd'], { cwd: localDir })
       await runCommand('git', ['checkout', '-B', branch, `origin/${branch}`], { cwd: localDir })
       await runCommand('git', ['reset', '--hard', `origin/${branch}`], { cwd: localDir })
       await runCommand('git', ['clean', '-fd'], { cwd: localDir })
@@ -906,6 +908,7 @@ async function ensureSkillsWorkingTreeRepo(
   await runGitFetchWithRefLockRetry(localDir)
   if (options.overwriteLocalFiles) {
     try { await runCommand('git', ['reset', '--hard'], { cwd: localDir }) } catch {}
+    await runCommand('git', ['clean', '-fd'], { cwd: localDir })
     await runCommand('git', ['checkout', '-B', branch, `origin/${branch}`], { cwd: localDir })
     await runCommand('git', ['reset', '--hard', `origin/${branch}`], { cwd: localDir })
     await runCommand('git', ['clean', '-fd'], { cwd: localDir })
@@ -1207,11 +1210,13 @@ async function syncInstalledSkillsFolderToRepo(
   await pushWithNonFastForwardRetry(repoDir, branch)
 }
 
-async function pullInstalledSkillsFolderFromRepo(token: string, repoOwner: string, repoName: string): Promise<void> {
+async function pullInstalledSkillsFolderFromRepo(token: string, repoOwner: string, repoName: string): Promise<string> {
   const remoteUrl = toGitHubTokenRemote(repoOwner, repoName, token)
-  const branch = PRIVATE_SYNC_BRANCH
-  await ensureSkillsWorkingTreeRepo(remoteUrl, branch, {
-    overwriteLocalFiles: isUpstreamSkillsRepo(repoOwner, repoName),
+  const isUpstream = isUpstreamSkillsRepo(repoOwner, repoName)
+  const branch = isUpstream ? PUBLIC_UPSTREAM_BRANCH_ANDROID : PRIVATE_SYNC_BRANCH
+  return await ensureSkillsWorkingTreeRepo(remoteUrl, branch, {
+    ...(isUpstream ? { localDir: getSharedSkillsInstallDir() } : {}),
+    overwriteLocalFiles: isUpstream,
   })
 }
 
@@ -1545,9 +1550,9 @@ export async function handleSkillsRoutes(
         return true
       }
       if (isUpstreamSkillsRepo(state.repoOwner, state.repoName)) {
-        await pullInstalledSkillsFolderFromRepo(state.githubToken, state.repoOwner, state.repoName)
+        const repoDir = await pullInstalledSkillsFolderFromRepo(state.githubToken, state.repoOwner, state.repoName)
         const localSkills = await scanInstalledSkillsFromDisk()
-        const pulledHead = await runCommandWithOutput('git', ['rev-parse', 'HEAD'], { cwd: getSkillsInstallDir() }).catch(() => '')
+        const pulledHead = await runCommandWithOutput('git', ['rev-parse', 'HEAD'], { cwd: repoDir }).catch(() => '')
         await writeSkillsSyncState({
           ...state,
           lastPullCommitSha: pulledHead.trim(),

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -114,6 +114,10 @@ function getSkillsInstallDir(): string {
   return join(getCodexHomeDir(), 'skills')
 }
 
+function getSharedSkillsInstallDir(): string {
+  return join(getSkillsInstallDir(), 'shared_skills')
+}
+
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000
 const SKILL_SEARCH_METADATA_LIMIT = 20
 const SKILL_SEARCH_METADATA_CONCURRENCY = 4
@@ -867,9 +871,9 @@ function toGitHubTokenRemote(repoOwner: string, repoName: string, token: string)
 async function ensureSkillsWorkingTreeRepo(
   repoUrl: string,
   branch: string,
-  options: { overwriteLocalFiles?: boolean } = {},
+  options: { localDir?: string; overwriteLocalFiles?: boolean } = {},
 ): Promise<string> {
-  const localDir = getSkillsInstallDir()
+  const localDir = options.localDir ?? getSkillsInstallDir()
   await mkdir(localDir, { recursive: true })
   const gitDir = join(localDir, '.git')
   let hasGitDir = false
@@ -1213,8 +1217,10 @@ async function pullInstalledSkillsFolderFromRepo(token: string, repoOwner: strin
 
 async function bootstrapSkillsFromUpstreamIntoLocal(): Promise<void> {
   const repoUrl = `https://github.com/${SYNC_UPSTREAM_SKILLS_OWNER}/${SYNC_UPSTREAM_SKILLS_REPO}.git`
-  const branch = getPreferredPublicUpstreamBranch()
-  await ensureSkillsWorkingTreeRepo(repoUrl, branch, { overwriteLocalFiles: true })
+  await ensureSkillsWorkingTreeRepo(repoUrl, PUBLIC_UPSTREAM_BRANCH_ANDROID, {
+    localDir: getSharedSkillsInstallDir(),
+    overwriteLocalFiles: true,
+  })
 }
 
 async function collectLocalSyncedSkills(appServer: AppServerLike): Promise<SyncedSkill[]> {

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -573,9 +573,8 @@ const startupSyncStatus: StartupSyncStatus = {
   lastError: '',
 }
 
-async function scanInstalledSkillsFromDisk(): Promise<Map<string, InstalledSkillInfo>> {
+async function scanInstalledSkillsFromDir(skillsDir: string): Promise<Map<string, InstalledSkillInfo>> {
   const map = new Map<string, InstalledSkillInfo>()
-  const skillsDir = getSkillsInstallDir()
   try {
     const entries = await readdir(skillsDir, { withFileTypes: true })
     for (const entry of entries) {
@@ -588,6 +587,10 @@ async function scanInstalledSkillsFromDisk(): Promise<Map<string, InstalledSkill
     }
   } catch {}
   return map
+}
+
+async function scanInstalledSkillsFromDisk(): Promise<Map<string, InstalledSkillInfo>> {
+  return await scanInstalledSkillsFromDir(getSkillsInstallDir())
 }
 
 async function collectInstalledSkillsMap(appServer: AppServerLike): Promise<Map<string, InstalledSkillInfo>> {
@@ -877,7 +880,12 @@ async function ensureSkillsWorkingTreeRepo(
   await mkdir(localDir, { recursive: true })
   const gitDir = join(localDir, '.git')
   let hasGitDir = false
-  try { hasGitDir = (await stat(gitDir)).isDirectory() } catch { hasGitDir = false }
+  try {
+    const gitDirStat = await lstat(gitDir)
+    hasGitDir = gitDirStat.isDirectory() || gitDirStat.isFile()
+  } catch {
+    hasGitDir = false
+  }
 
   if (!hasGitDir) {
     await runCommand('git', ['init'], { cwd: localDir })
@@ -1220,9 +1228,9 @@ async function pullInstalledSkillsFolderFromRepo(token: string, repoOwner: strin
   })
 }
 
-async function bootstrapSkillsFromUpstreamIntoLocal(): Promise<void> {
+async function bootstrapSkillsFromUpstreamIntoLocal(): Promise<string> {
   const repoUrl = `https://github.com/${SYNC_UPSTREAM_SKILLS_OWNER}/${SYNC_UPSTREAM_SKILLS_REPO}.git`
-  await ensureSkillsWorkingTreeRepo(repoUrl, PUBLIC_UPSTREAM_BRANCH_ANDROID, {
+  return await ensureSkillsWorkingTreeRepo(repoUrl, PUBLIC_UPSTREAM_BRANCH_ANDROID, {
     localDir: getSharedSkillsInstallDir(),
     overwriteLocalFiles: true,
   })
@@ -1544,14 +1552,15 @@ export async function handleSkillsRoutes(
     try {
       const state = await readSkillsSyncState()
       if (!state.githubToken || !state.repoOwner || !state.repoName) {
-        await bootstrapSkillsFromUpstreamIntoLocal()
+        const repoDir = await bootstrapSkillsFromUpstreamIntoLocal()
+        const localSkills = await scanInstalledSkillsFromDir(repoDir)
         try { await appServer.rpc('skills/list', { forceReload: true }) } catch {}
-        setJson(res, 200, { ok: true, data: { synced: 0, source: 'upstream' } })
+        setJson(res, 200, { ok: true, data: { synced: localSkills.size, source: 'upstream' } })
         return true
       }
       if (isUpstreamSkillsRepo(state.repoOwner, state.repoName)) {
         const repoDir = await pullInstalledSkillsFolderFromRepo(state.githubToken, state.repoOwner, state.repoName)
-        const localSkills = await scanInstalledSkillsFromDisk()
+        const localSkills = await scanInstalledSkillsFromDir(repoDir)
         const pulledHead = await runCommandWithOutput('git', ['rev-parse', 'HEAD'], { cwd: repoDir }).catch(() => '')
         await writeSkillsSyncState({
           ...state,

--- a/src/server/skillsRoutes.ts
+++ b/src/server/skillsRoutes.ts
@@ -864,7 +864,11 @@ function toGitHubTokenRemote(repoOwner: string, repoName: string, token: string)
   return `https://x-access-token:${encodeURIComponent(token)}@github.com/${repoOwner}/${repoName}.git`
 }
 
-async function ensureSkillsWorkingTreeRepo(repoUrl: string, branch: string): Promise<string> {
+async function ensureSkillsWorkingTreeRepo(
+  repoUrl: string,
+  branch: string,
+  options: { overwriteLocalFiles?: boolean } = {},
+): Promise<string> {
   const localDir = getSkillsInstallDir()
   await mkdir(localDir, { recursive: true })
   const gitDir = join(localDir, '.git')
@@ -882,6 +886,12 @@ async function ensureSkillsWorkingTreeRepo(repoUrl: string, branch: string): Pro
       await runCommand('git', ['remote', 'set-url', 'origin', repoUrl], { cwd: localDir })
     }
     await runGitFetchWithRefLockRetry(localDir)
+    if (options.overwriteLocalFiles) {
+      await runCommand('git', ['checkout', '-B', branch, `origin/${branch}`], { cwd: localDir })
+      await runCommand('git', ['reset', '--hard', `origin/${branch}`], { cwd: localDir })
+      await runCommand('git', ['clean', '-fd'], { cwd: localDir })
+      return localDir
+    }
     try {
       await runCommand('git', ['merge', '--allow-unrelated-histories', '--no-edit', `origin/${branch}`], { cwd: localDir })
     } catch {}
@@ -890,6 +900,13 @@ async function ensureSkillsWorkingTreeRepo(repoUrl: string, branch: string): Pro
 
   await runCommand('git', ['remote', 'set-url', 'origin', repoUrl], { cwd: localDir })
   await runGitFetchWithRefLockRetry(localDir)
+  if (options.overwriteLocalFiles) {
+    try { await runCommand('git', ['reset', '--hard'], { cwd: localDir }) } catch {}
+    await runCommand('git', ['checkout', '-B', branch, `origin/${branch}`], { cwd: localDir })
+    await runCommand('git', ['reset', '--hard', `origin/${branch}`], { cwd: localDir })
+    await runCommand('git', ['clean', '-fd'], { cwd: localDir })
+    return localDir
+  }
   const hasLocalChangesBeforeSync = await hasLocalUncommittedChanges(localDir)
   const localMtimesBeforeSync = hasLocalChangesBeforeSync ? await snapshotFileMtimes(localDir) : new Map<string, number>()
   await resolveMergeConflictsByNewerCommit(localDir, branch, localMtimesBeforeSync)
@@ -1189,13 +1206,15 @@ async function syncInstalledSkillsFolderToRepo(
 async function pullInstalledSkillsFolderFromRepo(token: string, repoOwner: string, repoName: string): Promise<void> {
   const remoteUrl = toGitHubTokenRemote(repoOwner, repoName, token)
   const branch = PRIVATE_SYNC_BRANCH
-  await ensureSkillsWorkingTreeRepo(remoteUrl, branch)
+  await ensureSkillsWorkingTreeRepo(remoteUrl, branch, {
+    overwriteLocalFiles: isUpstreamSkillsRepo(repoOwner, repoName),
+  })
 }
 
 async function bootstrapSkillsFromUpstreamIntoLocal(): Promise<void> {
   const repoUrl = `https://github.com/${SYNC_UPSTREAM_SKILLS_OWNER}/${SYNC_UPSTREAM_SKILLS_REPO}.git`
   const branch = getPreferredPublicUpstreamBranch()
-  await ensureSkillsWorkingTreeRepo(repoUrl, branch)
+  await ensureSkillsWorkingTreeRepo(repoUrl, branch, { overwriteLocalFiles: true })
 }
 
 async function collectLocalSyncedSkills(appServer: AppServerLike): Promise<SyncedSkill[]> {
@@ -1517,6 +1536,21 @@ export async function handleSkillsRoutes(
         await bootstrapSkillsFromUpstreamIntoLocal()
         try { await appServer.rpc('skills/list', { forceReload: true }) } catch {}
         setJson(res, 200, { ok: true, data: { synced: 0, source: 'upstream' } })
+        return true
+      }
+      if (isUpstreamSkillsRepo(state.repoOwner, state.repoName)) {
+        await pullInstalledSkillsFolderFromRepo(state.githubToken, state.repoOwner, state.repoName)
+        const localSkills = await scanInstalledSkillsFromDisk()
+        const pulledHead = await runCommandWithOutput('git', ['rev-parse', 'HEAD'], { cwd: getSkillsInstallDir() }).catch(() => '')
+        await writeSkillsSyncState({
+          ...state,
+          lastPullCommitSha: pulledHead.trim(),
+          lastSyncAttemptCount: 1,
+          lastSyncError: '',
+          lastSyncAtIso: new Date().toISOString(),
+        })
+        try { await appServer.rpc('skills/list', { forceReload: true }) } catch {}
+        setJson(res, 200, { ok: true, data: { synced: localSkills.size, source: 'upstream' } })
         return true
       }
       const remote = await readRemoteSkillsManifest(state.githubToken, state.repoOwner, state.repoName)

--- a/tests.md
+++ b/tests.md
@@ -1707,13 +1707,17 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 5. Wait for the pull success toast.
 6. Inspect `~/.codex/skills/shared_skills` and compare it with the public `OpenClawAndroid/skills` `android` branch.
 7. Inspect `~/.codex/skills` and verify unrelated parent-level files were not reset or cleaned by the unauthenticated pull.
-8. In light theme, verify the Skills Hub list reloads and does not show stale local-only skills.
-9. Switch to dark theme and verify the same Skills Hub state remains readable and current.
+8. If `~/.codex/skills/shared_skills/.git` is a git file or worktree/submodule-style pointer, repeat the pull and verify the nested repo is not reinitialized.
+9. Inspect the `/codex-api/skills-sync/pull` response and verify `data.synced` matches the number of direct shared skill folders with `SKILL.md`.
+10. In light theme, verify the Skills Hub list reloads and does not show stale local-only skills.
+11. Switch to dark theme and verify the same Skills Hub state remains readable and current.
 
 #### Expected Results
 - Public unauthenticated pull resets only the nested `shared_skills` repo to the public upstream `android` branch.
 - Local uncommitted edits and local-only untracked skill folders inside `shared_skills` are removed by the pull.
 - Parent-level `~/.codex/skills` files outside `shared_skills` are not reset or cleaned.
+- Existing git-file/worktree/submodule-style shared skills repos are reused, not reinitialized.
+- The pull response reports the shared skills count from `~/.codex/skills/shared_skills`, not the parent skills directory.
 - The installed skills list reloads immediately after the pull in both light and dark theme.
 - Private GitHub sync repos still preserve local edits through the bidirectional sync path.
 

--- a/tests.md
+++ b/tests.md
@@ -1692,6 +1692,32 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 #### Rollback/Cleanup
 - If needed, run another sync pull/push to restore previous skill state in the sync repo.
 
+### Feature: Public shared skills pull overwrites local files
+
+#### Prerequisites
+- App running from this repository with Skills Hub available.
+- GitHub skills sync is either not configured, or it targets the public `OpenClawAndroid/skills` repository.
+- Local skills directory exists at `~/.codex/skills`.
+
+#### Steps
+1. Create a temporary local-only skill folder under `~/.codex/skills`, or edit a tracked file in that directory.
+2. Open `Skills Hub`.
+3. Trigger `Pull` from the `Skills Sync (GitHub)` panel.
+4. Wait for the pull success toast.
+5. Inspect `~/.codex/skills` and compare it with the configured public upstream branch.
+6. In light theme, verify the Skills Hub list reloads and does not show stale local-only skills.
+7. Switch to dark theme and verify the same Skills Hub state remains readable and current.
+
+#### Expected Results
+- Public upstream pull resets the local skills repo to the upstream branch.
+- Local uncommitted edits and local-only untracked skill folders are removed by the pull.
+- The installed skills list reloads immediately after the pull in both light and dark theme.
+- Private GitHub sync repos still preserve local edits through the bidirectional sync path.
+
+#### Rollback/Cleanup
+- Recreate any intentionally removed local-only test skill if it should be kept.
+- Use private sync `Push` only after confirming the public pull result should be mirrored elsewhere.
+
 ### Feature: Force Refresh Skills button in Skills Sync panel
 
 #### Prerequisites

--- a/tests.md
+++ b/tests.md
@@ -1692,30 +1692,33 @@ Model, skill, thinking, and plan controls remain usable while a thread turn is i
 #### Rollback/Cleanup
 - If needed, run another sync pull/push to restore previous skill state in the sync repo.
 
-### Feature: Public shared skills pull overwrites local files
+### Feature: Public shared skills pull overwrites only shared skills
 
 #### Prerequisites
 - App running from this repository with Skills Hub available.
-- GitHub skills sync is either not configured, or it targets the public `OpenClawAndroid/skills` repository.
-- Local skills directory exists at `~/.codex/skills`.
+- GitHub skills sync is not configured/logged in.
+- Local shared skills directory exists at `~/.codex/skills/shared_skills`.
 
 #### Steps
-1. Create a temporary local-only skill folder under `~/.codex/skills`, or edit a tracked file in that directory.
-2. Open `Skills Hub`.
-3. Trigger `Pull` from the `Skills Sync (GitHub)` panel.
-4. Wait for the pull success toast.
-5. Inspect `~/.codex/skills` and compare it with the configured public upstream branch.
-6. In light theme, verify the Skills Hub list reloads and does not show stale local-only skills.
-7. Switch to dark theme and verify the same Skills Hub state remains readable and current.
+1. Create a temporary local-only skill folder under `~/.codex/skills/shared_skills`, or edit a tracked shared skill file in that directory.
+2. Note the parent `~/.codex/skills` status, including any unrelated local edits outside `shared_skills`.
+3. Open `Skills Hub`.
+4. Trigger `Pull` from the `Skills Sync (GitHub)` panel.
+5. Wait for the pull success toast.
+6. Inspect `~/.codex/skills/shared_skills` and compare it with the public `OpenClawAndroid/skills` `android` branch.
+7. Inspect `~/.codex/skills` and verify unrelated parent-level files were not reset or cleaned by the unauthenticated pull.
+8. In light theme, verify the Skills Hub list reloads and does not show stale local-only skills.
+9. Switch to dark theme and verify the same Skills Hub state remains readable and current.
 
 #### Expected Results
-- Public upstream pull resets the local skills repo to the upstream branch.
-- Local uncommitted edits and local-only untracked skill folders are removed by the pull.
+- Public unauthenticated pull resets only the nested `shared_skills` repo to the public upstream `android` branch.
+- Local uncommitted edits and local-only untracked skill folders inside `shared_skills` are removed by the pull.
+- Parent-level `~/.codex/skills` files outside `shared_skills` are not reset or cleaned.
 - The installed skills list reloads immediately after the pull in both light and dark theme.
 - Private GitHub sync repos still preserve local edits through the bidirectional sync path.
 
 #### Rollback/Cleanup
-- Recreate any intentionally removed local-only test skill if it should be kept.
+- Recreate any intentionally removed local-only shared skill if it should be kept.
 - Use private sync `Push` only after confirming the public pull result should be mirrored elsewhere.
 
 ### Feature: Force Refresh Skills button in Skills Sync panel


### PR DESCRIPTION
## Summary
- make public upstream skills pulls reset and clean the local skills tree from remote
- keep private GitHub skills sync on the existing local-edit-preserving flow
- document manual light/dark verification for public shared-skills pull behavior

## Testing
- pnpm run build:frontend

## Performance audit
- Server-side sync path remains bounded to fetch/reset/clean for public upstream pulls and avoids manifest cleanup loops for the public repo. Browser profiling was not run because this change does not affect browser startup, routing, or thread loading.