### PR TITLE
Handle fresh install rate limit reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@
 ## PR Review Bot Workflow (MANDATORY)
 
 - Treat Qodo and other review-bot comments as advisory findings, not authoritative fix instructions.
+- When the user asks to update a PR and request review, first push the current branch, update the PR summary/verification notes when they changed, then post a plain PR comment containing exactly `/review`.
+- Do not use a draft review, pending review, or batch review technique to trigger Qodo; Qodo review requests should be ordinary PR comments.
+- After posting `/review`, wait for or re-check bot comments/status when the user asks to wait, continue, or check comments.
 - Before applying a suggested review-bot fix, inspect the relevant code path and decide whether the reported behavior is technically correct.
 - Reproduce the issue with a focused test when feasible; if direct reproduction is impractical, document the exact reasoning and code evidence used to accept or reject the finding.
 - Prefer adding or updating a regression test for every accepted review-bot bug before or alongside the fix.

--- a/public/sw.js
+++ b/public/sw.js
@@ -83,8 +83,9 @@ async function networkFirstStatic(request) {
     const response = await fetch(request)
     if (response.ok) {
       cache.put(request, response.clone())
+      return response
     }
-    return response
+    return (await cache.match(request)) || response
   } catch {
     return (await cache.match(request)) || Response.error()
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'codexweb-shell-v1'
+const CACHE_NAME = 'codexweb-shell-v2'
 const APP_SHELL_PATHS = ['/', '/manifest.webmanifest']
 const STATIC_DESTINATIONS = new Set(['document', 'script', 'style', 'image', 'font'])
 const BYPASS_PREFIXES = ['/codex-api/', '/codex-local-image', '/codex-local-file', '/codex-local-browse/', '/codex-local-edit/']
@@ -36,6 +36,11 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
+  if (request.destination === 'script' || request.destination === 'style') {
+    event.respondWith(networkFirstStatic(request))
+    return
+  }
+
   if (STATIC_DESTINATIONS.has(request.destination) || url.pathname === '/manifest.webmanifest') {
     event.respondWith(staleWhileRevalidate(request))
   }
@@ -70,4 +75,17 @@ async function staleWhileRevalidate(request) {
 
   const response = await networkPromise
   return response || Response.error()
+}
+
+async function networkFirstStatic(request) {
+  const cache = await caches.open(CACHE_NAME)
+  try {
+    const response = await fetch(request)
+    if (response.ok) {
+      cache.put(request, response.clone())
+    }
+    return response
+  } catch {
+    return (await cache.match(request)) || Response.error()
+  }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -3899,7 +3899,7 @@ async function onProviderChange(provider: string): Promise<void> {
     } else if (provider === 'opencode-zen') {
       selectedProvider.value = 'opencode-zen'
       await setCustomProvider('', opencodeZenKey.value.trim(), {
-        wireApi: 'chat',
+        wireApi: 'responses',
         provider: 'opencode-zen',
       })
       freeModeEnabled.value = true
@@ -3973,7 +3973,7 @@ async function saveOpencodeZen(): Promise<void> {
   try {
     providerError.value = ''
     await setCustomProvider('', key, {
-      wireApi: 'chat',
+      wireApi: 'responses',
       provider: 'opencode-zen',
     })
     freeModeEnabled.value = true

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1886,7 +1886,7 @@ export async function setCustomProvider(
   return await response.json() as { ok: boolean }
 }
 
-export async function getAvailableModelIds(options: { includeProviderModels?: boolean } = {}): Promise<string[]> {
+export async function getAvailableModelIds(options: { includeProviderModels?: boolean; requireProviderModels?: boolean } = {}): Promise<string[]> {
   const payload = await callRpc<ModelListResponse>('model/list', {})
   const ids: string[] = []
   for (const row of payload.data) {
@@ -1899,6 +1899,7 @@ export async function getAvailableModelIds(options: { includeProviderModels?: bo
     return ids
   }
 
+  let sawProviderModels = false
   try {
     const response = await fetch('/codex-api/provider-models', {
       signal: AbortSignal.timeout(PROVIDER_MODELS_FETCH_TIMEOUT_MS),
@@ -1911,6 +1912,7 @@ export async function getAvailableModelIds(options: { includeProviderModels?: bo
     }
 
     if (response.ok && Array.isArray(providerPayload?.data)) {
+      sawProviderModels = true
       if (providerPayload.exclusive) {
         return providerPayload.data.filter((c): c is string => typeof c === 'string' && c.trim().length > 0)
       }
@@ -1923,6 +1925,10 @@ export async function getAvailableModelIds(options: { includeProviderModels?: bo
     }
   } catch {
     // Keep Codex usable when the provider-models endpoint is unavailable.
+  }
+
+  if (options.requireProviderModels && !sawProviderModels) {
+    return []
   }
 
   return ids

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -537,6 +537,7 @@ async function startServer(options: {
   const server = createServer(app)
   attachWebSocket(server)
   const port = await listenWithFallback(server, requestedPort)
+  process.env.CODEXUI_SERVER_PORT = String(port)
   let tunnelChild: ReturnType<typeof spawn> | null = null
   let tunnelUrl: string | null = null
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -435,7 +435,7 @@ describe('Codex CLI availability', () => {
 })
 
 describe('provider model selection', () => {
-  it('rejects a persisted Codex model when OpenCode Zen is the active provider', async () => {
+  it('ignores stored selected-model localStorage when OpenCode Zen is the active provider', async () => {
     installTestWindow({
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
         '__new-thread__': 'gpt-5.5',
@@ -472,6 +472,8 @@ describe('provider model selection', () => {
     ])
     expect(state.selectedModelId.value).toBe('big-pickle')
     expect(state.readModelIdForThread('').trim()).toBe('big-pickle')
+    expect(window.localStorage.getItem('codex-web-local.selected-model-by-context.v1')).toBe(null)
+    expect(window.localStorage.getItem('codex-web-local.selected-model-id.v1')).toBe(null)
   })
 })
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -435,12 +435,12 @@ describe('Codex CLI availability', () => {
 })
 
 describe('provider model selection', () => {
-  it('ignores stored selected-model localStorage when OpenCode Zen is the active provider', async () => {
+  it('ignores global selected-model localStorage when OpenCode Zen is the active provider', async () => {
     installTestWindow({
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({
         '__new-thread__': 'gpt-5.5',
-        '__provider__:opencode-zen': 'gpt-5.5',
       }),
+      'codex-web-local.selected-model-id.v1': 'gpt-5.5',
     })
     gatewayMocks.getThreadGroupsPage.mockResolvedValue({ groups: [], nextCursor: null })
     gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
@@ -472,8 +472,47 @@ describe('provider model selection', () => {
     ])
     expect(state.selectedModelId.value).toBe('big-pickle')
     expect(state.readModelIdForThread('').trim()).toBe('big-pickle')
-    expect(window.localStorage.getItem('codex-web-local.selected-model-by-context.v1')).toBe(null)
+    expect(JSON.parse(window.localStorage.getItem('codex-web-local.selected-model-by-context.v1') ?? '{}')).toEqual({
+      '__new-thread-provider__::opencode-zen': 'big-pickle',
+    })
     expect(window.localStorage.getItem('codex-web-local.selected-model-id.v1')).toBe(null)
+  })
+
+  it('restores a valid provider-scoped OpenCode Zen selected model from localStorage', async () => {
+    installTestWindow({
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread-provider__::opencode-zen': 'ring-2.6-1t-free',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({ groups: [], nextCursor: null })
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.getAccountRateLimits.mockResolvedValue(null)
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'medium',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue([
+      'big-pickle',
+      'deepseek-v4-flash-free',
+      'ring-2.6-1t-free',
+    ])
+
+    const state = useDesktopState()
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.availableModelIds.value).toEqual([
+      'big-pickle',
+      'deepseek-v4-flash-free',
+      'ring-2.6-1t-free',
+    ])
+    expect(state.selectedModelId.value).toBe('ring-2.6-1t-free')
+    expect(state.readModelIdForThread('').trim()).toBe('ring-2.6-1t-free')
+    expect(JSON.parse(window.localStorage.getItem('codex-web-local.selected-model-by-context.v1') ?? '{}')).toEqual({
+      '__new-thread-provider__::opencode-zen': 'ring-2.6-1t-free',
+    })
   })
 })
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -434,6 +434,47 @@ describe('Codex CLI availability', () => {
   })
 })
 
+describe('provider model selection', () => {
+  it('rejects a persisted Codex model when OpenCode Zen is the active provider', async () => {
+    installTestWindow({
+      'codex-web-local.selected-model-by-context.v1': JSON.stringify({
+        '__new-thread__': 'gpt-5.5',
+        '__provider__:opencode-zen': 'gpt-5.5',
+      }),
+    })
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({ groups: [], nextCursor: null })
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.getAccountRateLimits.mockResolvedValue(null)
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'big-pickle',
+      providerId: 'opencode-zen',
+      reasoningEffort: 'medium',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue([
+      'big-pickle',
+      'deepseek-v4-flash-free',
+      'ring-2.6-1t-free',
+    ])
+
+    const state = useDesktopState()
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(gatewayMocks.getAvailableModelIds).toHaveBeenCalledWith({
+      includeProviderModels: true,
+      requireProviderModels: true,
+    })
+    expect(state.availableModelIds.value).toEqual([
+      'big-pickle',
+      'deepseek-v4-flash-free',
+      'ring-2.6-1t-free',
+    ])
+    expect(state.selectedModelId.value).toBe('big-pickle')
+    expect(state.readModelIdForThread('').trim()).toBe('big-pickle')
+  })
+})
+
 describe('findAdjacentThreadId', () => {
   it('selects the next thread after the archived thread', () => {
     const threads = [

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -223,34 +223,8 @@ function toThreadContextId(threadId: string): string {
 }
 
 function loadSelectedModelMap(): Record<string, string> {
-  if (typeof window === 'undefined') return createStringKeyedRecord<string>()
-
-  try {
-    const raw = window.localStorage.getItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
-    if (raw) {
-      const parsed = JSON.parse(raw) as unknown
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return createStringKeyedRecord<string>()
-
-      const next = createStringKeyedRecord<string>()
-      for (const [contextId, value] of Object.entries(parsed as Record<string, unknown>)) {
-        if (typeof contextId !== 'string' || contextId.length === 0) continue
-        const normalizedModelId = normalizeStoredModelId(value)
-        if (normalizedModelId) {
-          next[contextId] = normalizedModelId
-        }
-      }
-      return next
-    }
-  } catch {
-    // Fall back to the legacy global preference below.
-  }
-
-  const legacyModelId = normalizeStoredModelId(window.localStorage.getItem(LEGACY_SELECTED_MODEL_STORAGE_KEY))
-  const next = createStringKeyedRecord<string>()
-  if (legacyModelId) {
-    next[NEW_THREAD_COLLABORATION_MODE_CONTEXT] = legacyModelId
-  }
-  return next
+  clearSelectedModelStorage()
+  return createStringKeyedRecord<string>()
 }
 
 function readSelectedModel(
@@ -264,16 +238,17 @@ function readSelectedModel(
 }
 
 function saveSelectedModelMap(state: Record<string, string>): void {
+  void state
+  clearSelectedModelStorage()
+}
+
+function clearSelectedModelStorage(): void {
   if (typeof window === 'undefined') return
   try {
-    if (Object.keys(state).length === 0) {
-      window.localStorage.removeItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
-    } else {
-      window.localStorage.setItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY, JSON.stringify(state))
-    }
+    window.localStorage.removeItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
     window.localStorage.removeItem(LEGACY_SELECTED_MODEL_STORAGE_KEY)
   } catch {
-    // Keep in-memory selection working even if localStorage writes fail.
+    // Keep in-memory selection working even if localStorage cleanup fails.
   }
 }
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1864,10 +1864,12 @@ export function useDesktopState() {
       const currentConfig = await getCurrentModelConfig()
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
+      const isProviderBacked = normalizedProviderId !== 'codex'
       activeProviderId.value = normalizedProviderId
       const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const modelIds = await getAvailableModelIds({
-        includeProviderModels: options?.includeProviderModels !== false || normalizedProviderId !== 'codex',
+        includeProviderModels: options?.includeProviderModels !== false || isProviderBacked,
+        requireProviderModels: isProviderBacked,
       })
       const providerModelContextId = toProviderModelContextId(normalizedProviderId)
       const providerScopedModelId = providerModelContextId
@@ -1875,7 +1877,8 @@ export function useDesktopState() {
         : ''
       const nextModelIds = [...modelIds]
       if (!options?.providerChanged) {
-        for (const modelId of [normalizedSelectedModelId, normalizedConfiguredModelId]) {
+        const extraModelIds = isProviderBacked ? [normalizedConfiguredModelId] : [normalizedSelectedModelId, normalizedConfiguredModelId]
+        for (const modelId of extraModelIds) {
           if (modelId && !nextModelIds.includes(modelId)) {
             nextModelIds.push(modelId)
           }
@@ -1901,9 +1904,9 @@ export function useDesktopState() {
           setSelectedModelId('')
         }
       } else if (
-        normalizedProviderId !== 'codex'
+        isProviderBacked
         && normalizedConfiguredModelId
-        && nextModelIds.includes(normalizedConfiguredModelId)
+        && modelIds.includes(normalizedConfiguredModelId)
         && normalizedSelectedModelId !== normalizedConfiguredModelId
       ) {
         setSelectedModelId(normalizedConfiguredModelId)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -223,8 +223,34 @@ function toThreadContextId(threadId: string): string {
 }
 
 function loadSelectedModelMap(): Record<string, string> {
-  clearSelectedModelStorage()
-  return createStringKeyedRecord<string>()
+  if (typeof window === 'undefined') return createStringKeyedRecord<string>()
+
+  try {
+    const raw = window.localStorage.getItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as unknown
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return createStringKeyedRecord<string>()
+
+      const next = createStringKeyedRecord<string>()
+      for (const [contextId, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof contextId !== 'string' || contextId.length === 0) continue
+        const normalizedModelId = normalizeStoredModelId(value)
+        if (normalizedModelId) {
+          next[contextId] = normalizedModelId
+        }
+      }
+      return next
+    }
+  } catch {
+    // Fall back to the legacy global preference below.
+  }
+
+  const legacyModelId = normalizeStoredModelId(window.localStorage.getItem(LEGACY_SELECTED_MODEL_STORAGE_KEY))
+  const next = createStringKeyedRecord<string>()
+  if (legacyModelId) {
+    next[NEW_THREAD_COLLABORATION_MODE_CONTEXT] = legacyModelId
+  }
+  return next
 }
 
 function readSelectedModel(
@@ -238,17 +264,16 @@ function readSelectedModel(
 }
 
 function saveSelectedModelMap(state: Record<string, string>): void {
-  void state
-  clearSelectedModelStorage()
-}
-
-function clearSelectedModelStorage(): void {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.removeItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
+    if (Object.keys(state).length === 0) {
+      window.localStorage.removeItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY)
+    } else {
+      window.localStorage.setItem(SELECTED_MODEL_BY_CONTEXT_STORAGE_KEY, JSON.stringify(state))
+    }
     window.localStorage.removeItem(LEGACY_SELECTED_MODEL_STORAGE_KEY)
   } catch {
-    // Keep in-memory selection working even if localStorage cleanup fails.
+    // Keep in-memory selection working even if localStorage writes fail.
   }
 }
 
@@ -1548,11 +1573,13 @@ export function useDesktopState() {
   function readModelIdForThread(threadId: string): string {
     const contextId = toThreadContextId(threadId)
     if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
-      const providerContextId = toProviderModelContextId(activeProviderId.value)
-      const providerModelId = providerContextId
-        ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
-        : ''
-      if (providerModelId) return providerModelId
+      const normalizedProviderId = normalizeProviderContextId(activeProviderId.value)
+      if (normalizedProviderId !== 'codex') {
+        const providerContextId = toProviderModelContextId(normalizedProviderId)
+        return providerContextId
+          ? normalizeStoredModelId(selectedModelIdByContext.value[providerContextId])
+          : ''
+      }
     }
     return readSelectedModel(selectedModelIdByContext.value, threadId).trim()
   }
@@ -1587,30 +1614,31 @@ export function useDesktopState() {
   function setSelectedModelIdForThread(threadId: string, modelId: string): void {
     const normalizedModelId = modelId.trim()
     const contextId = toThreadContextId(threadId)
+    const normalizedProviderId = normalizeProviderContextId(activeProviderId.value)
+    const providerContextId =
+      contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT && normalizedProviderId !== 'codex'
+        ? toProviderModelContextId(normalizedProviderId)
+        : ''
+    const selectedContextId = providerContextId || contextId
     if (normalizedModelId) {
       const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
-      nextModelMap[contextId] = normalizedModelId
+      nextModelMap[selectedContextId] = normalizedModelId
+      if (providerContextId) {
+        delete nextModelMap[contextId]
+      }
       selectedModelIdByContext.value = nextModelMap
     } else {
-      selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, contextId)
+      let nextModelMap = omitStringKeyedRecordKey(selectedModelIdByContext.value, selectedContextId)
+      if (providerContextId) {
+        nextModelMap = omitStringKeyedRecordKey(nextModelMap, contextId)
+      }
+      selectedModelIdByContext.value = nextModelMap
     }
     if (threadId.trim() === selectedThreadId.value) {
       selectedModelId.value = readModelIdForThread(selectedThreadId.value)
       ensureAvailableModelIds(selectedModelId.value)
     } else {
       ensureAvailableModelIds(normalizedModelId)
-    }
-    if (contextId === NEW_THREAD_COLLABORATION_MODE_CONTEXT) {
-      const providerContextId = toProviderModelContextId(activeProviderId.value)
-      if (providerContextId) {
-        if (normalizedModelId) {
-          const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)
-          nextModelMap[providerContextId] = normalizedModelId
-          selectedModelIdByContext.value = nextModelMap
-        } else {
-          selectedModelIdByContext.value = omitStringKeyedRecordKey(selectedModelIdByContext.value, providerContextId)
-        }
-      }
     }
     saveSelectedModelMap(selectedModelIdByContext.value)
   }
@@ -1864,7 +1892,7 @@ export function useDesktopState() {
       const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
       if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
         if (options?.providerChanged && nextModelIds.length > 0) {
-          if (providerScopedModelId && nextModelIds.includes(providerScopedModelId)) {
+          if (providerScopedModelId && modelIds.includes(providerScopedModelId)) {
             setSelectedModelId(providerScopedModelId)
           } else if (normalizedConfiguredModelId && nextModelIds.includes(normalizedConfiguredModelId)) {
             setSelectedModelId(normalizedConfiguredModelId)
@@ -1878,13 +1906,8 @@ export function useDesktopState() {
         } else {
           setSelectedModelId('')
         }
-      } else if (
-        isProviderBacked
-        && normalizedConfiguredModelId
-        && modelIds.includes(normalizedConfiguredModelId)
-        && normalizedSelectedModelId !== normalizedConfiguredModelId
-      ) {
-        setSelectedModelId(normalizedConfiguredModelId)
+      } else if (selectedModelId.value.trim() !== normalizedSelectedModelId) {
+        setSelectedModelId(normalizedSelectedModelId)
       }
       if (providerModelContextId && selectedModelId.value.trim().length > 0) {
         const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1862,13 +1862,13 @@ export function useDesktopState() {
   async function refreshModelPreferences(options?: { providerChanged?: boolean; includeProviderModels?: boolean }): Promise<void> {
     try {
       const currentConfig = await getCurrentModelConfig()
-      const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
+      activeProviderId.value = normalizedProviderId
+      const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const modelIds = await getAvailableModelIds({
         includeProviderModels: options?.includeProviderModels !== false || normalizedProviderId !== 'codex',
       })
-      activeProviderId.value = normalizedProviderId
       const providerModelContextId = toProviderModelContextId(normalizedProviderId)
       const providerScopedModelId = providerModelContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerModelContextId])
@@ -1900,6 +1900,13 @@ export function useDesktopState() {
         } else {
           setSelectedModelId('')
         }
+      } else if (
+        normalizedProviderId !== 'codex'
+        && normalizedConfiguredModelId
+        && nextModelIds.includes(normalizedConfiguredModelId)
+        && normalizedSelectedModelId !== normalizedConfiguredModelId
+      ) {
+        setSelectedModelId(normalizedConfiguredModelId)
       }
       if (providerModelContextId && selectedModelId.value.trim().length > 0) {
         const nextModelMap = cloneStringKeyedRecord(selectedModelIdByContext.value)

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1861,14 +1861,13 @@ export function useDesktopState() {
 
   async function refreshModelPreferences(options?: { providerChanged?: boolean; includeProviderModels?: boolean }): Promise<void> {
     try {
-      const [modelIds, currentConfig] = await Promise.all([
-        getAvailableModelIds({ includeProviderModels: options?.includeProviderModels !== false }),
-        getCurrentModelConfig(),
-      ])
-
+      const currentConfig = await getCurrentModelConfig()
       const normalizedSelectedModelId = readModelIdForThread(selectedThreadId.value)
       const normalizedConfiguredModelId = currentConfig.model.trim()
       const normalizedProviderId = normalizeProviderContextId(currentConfig.providerId)
+      const modelIds = await getAvailableModelIds({
+        includeProviderModels: options?.includeProviderModels !== false || normalizedProviderId !== 'codex',
+      })
       activeProviderId.value = normalizedProviderId
       const providerModelContextId = toProviderModelContextId(normalizedProviderId)
       const providerScopedModelId = providerModelContextId

--- a/src/server/codexAppServerBridge.archive.test.ts
+++ b/src/server/codexAppServerBridge.archive.test.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, describe, expect, it } from 'vitest'
-import { callRpcWithArchiveRecovery, hasCodexRefreshToken, isUnauthenticatedRateLimitError } from './codexAppServerBridge'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { callRpcWithArchiveRecovery, hasUsableCodexAuth, isUnauthenticatedRateLimitError } from './codexAppServerBridge'
 
 const originalCodexHome = process.env.CODEX_HOME
 
@@ -100,26 +100,45 @@ describe('isUnauthenticatedRateLimitError', () => {
   })
 })
 
-describe('hasCodexRefreshToken', () => {
-  it('returns false when auth.json is missing or does not contain a refresh token', async () => {
+describe('hasUsableCodexAuth', () => {
+  it('returns false when auth.json is missing or does not contain usable tokens', async () => {
     const codexHome = await mkdtemp(join(tmpdir(), 'codex-home-no-token-'))
     process.env.CODEX_HOME = codexHome
     try {
-      await expect(hasCodexRefreshToken()).resolves.toBe(false)
+      await expect(hasUsableCodexAuth()).resolves.toBe(false)
       await writeFile(join(codexHome, 'auth.json'), JSON.stringify({ tokens: {} }))
-      await expect(hasCodexRefreshToken()).resolves.toBe(false)
+      await expect(hasUsableCodexAuth()).resolves.toBe(false)
     } finally {
       await rm(codexHome, { recursive: true, force: true })
     }
   })
 
-  it('returns true when auth.json contains a refresh token', async () => {
+  it('returns true when auth.json contains an access token or refresh token', async () => {
     const codexHome = await mkdtemp(join(tmpdir(), 'codex-home-with-token-'))
     process.env.CODEX_HOME = codexHome
     try {
+      await writeFile(join(codexHome, 'auth.json'), JSON.stringify({ tokens: { access_token: 'access-token' } }))
+      await expect(hasUsableCodexAuth()).resolves.toBe(true)
       await writeFile(join(codexHome, 'auth.json'), JSON.stringify({ tokens: { refresh_token: 'refresh-token' } }))
-      await expect(hasCodexRefreshToken()).resolves.toBe(true)
+      await expect(hasUsableCodexAuth()).resolves.toBe(true)
     } finally {
+      await rm(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it('warns when auth.json exists but cannot be parsed', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'codex-home-invalid-auth-'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    process.env.CODEX_HOME = codexHome
+    try {
+      await writeFile(join(codexHome, 'auth.json'), '{')
+      await expect(hasUsableCodexAuth()).resolves.toBe(false)
+      expect(warn).toHaveBeenCalledWith(
+        '[codex-auth] Unable to read Codex auth state',
+        expect.objectContaining({ path: join(codexHome, 'auth.json') }),
+      )
+    } finally {
+      warn.mockRestore()
       await rm(codexHome, { recursive: true, force: true })
     }
   })

--- a/src/server/codexAppServerBridge.archive.test.ts
+++ b/src/server/codexAppServerBridge.archive.test.ts
@@ -2,7 +2,12 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { callRpcWithArchiveRecovery, hasUsableCodexAuth, isUnauthenticatedRateLimitError } from './codexAppServerBridge'
+import {
+  callRpcWithArchiveRecovery,
+  hasUsableCodexAuth,
+  isEmptyThreadReadError,
+  isUnauthenticatedRateLimitError,
+} from './codexAppServerBridge'
 
 const originalCodexHome = process.env.CODEX_HOME
 
@@ -97,6 +102,19 @@ describe('isUnauthenticatedRateLimitError', () => {
   it('does not match unrelated authentication failures', () => {
     expect(isUnauthenticatedRateLimitError(new Error('codex account authentication required to send messages'))).toBe(false)
     expect(isUnauthenticatedRateLimitError(new Error('failed to read rate limits'))).toBe(false)
+  })
+})
+
+describe('isEmptyThreadReadError', () => {
+  it('matches Codex empty rollout read failures during immediate thread startup', () => {
+    expect(isEmptyThreadReadError(new Error(
+      'failed to read thread: thread-store internal error: failed to read thread /tmp/codex-home/sessions/rollout-test.jsonl: rollout at /tmp/codex-home/sessions/rollout-test.jsonl is empty',
+    ))).toBe(true)
+  })
+
+  it('does not match unrelated thread read failures', () => {
+    expect(isEmptyThreadReadError(new Error('failed to read thread: permission denied'))).toBe(false)
+    expect(isEmptyThreadReadError(new Error('rollout is empty'))).toBe(false)
   })
 })
 

--- a/src/server/codexAppServerBridge.archive.test.ts
+++ b/src/server/codexAppServerBridge.archive.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import { callRpcWithArchiveRecovery } from './codexAppServerBridge'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { callRpcWithArchiveRecovery, hasCodexRefreshToken, isUnauthenticatedRateLimitError } from './codexAppServerBridge'
+
+const originalCodexHome = process.env.CODEX_HOME
+
+afterEach(() => {
+  if (originalCodexHome === undefined) {
+    delete process.env.CODEX_HOME
+  } else {
+    process.env.CODEX_HOME = originalCodexHome
+  }
+})
 
 describe('callRpcWithArchiveRecovery', () => {
   it('sets a fallback name and retries archive when Codex has not materialized a rollout', async () => {
@@ -73,5 +86,41 @@ describe('callRpcWithArchiveRecovery', () => {
 
     await expect(callRpcWithArchiveRecovery(appServer, 'thread/archive', { threadId: 'test-thread' })).rejects.toThrow('network failed')
     await expect(callRpcWithArchiveRecovery(appServer, 'thread/read', { threadId: 'test-thread' })).rejects.toThrow('network failed')
+  })
+})
+
+describe('isUnauthenticatedRateLimitError', () => {
+  it('matches unauthenticated rate-limit failures from a fresh Codex home', () => {
+    expect(isUnauthenticatedRateLimitError(new Error('codex account authentication required to read rate limits'))).toBe(true)
+  })
+
+  it('does not match unrelated authentication failures', () => {
+    expect(isUnauthenticatedRateLimitError(new Error('codex account authentication required to send messages'))).toBe(false)
+    expect(isUnauthenticatedRateLimitError(new Error('failed to read rate limits'))).toBe(false)
+  })
+})
+
+describe('hasCodexRefreshToken', () => {
+  it('returns false when auth.json is missing or does not contain a refresh token', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'codex-home-no-token-'))
+    process.env.CODEX_HOME = codexHome
+    try {
+      await expect(hasCodexRefreshToken()).resolves.toBe(false)
+      await writeFile(join(codexHome, 'auth.json'), JSON.stringify({ tokens: {} }))
+      await expect(hasCodexRefreshToken()).resolves.toBe(false)
+    } finally {
+      await rm(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it('returns true when auth.json contains a refresh token', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'codex-home-with-token-'))
+    process.env.CODEX_HOME = codexHome
+    try {
+      await writeFile(join(codexHome, 'auth.json'), JSON.stringify({ tokens: { refresh_token: 'refresh-token' } }))
+      await expect(hasCodexRefreshToken()).resolves.toBe(true)
+    } finally {
+      await rm(codexHome, { recursive: true, force: true })
+    }
   })
 })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -5928,8 +5928,10 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               ? state.apiKey.substring(0, 12) + '...' + state.apiKey.substring(state.apiKey.length - 4)
               : null
             let models = getCachedFreeModels()
+            let currentModel = state.enabled ? state.model : null
             let wireApi = state.wireApi ?? null
             if (state.provider === OPENCODE_ZEN_PROVIDER_ID) {
+              currentModel = state.enabled ? (state.model?.trim() || OPENCODE_ZEN_DEFAULT_MODEL) : null
               try {
                 const zenModels = sortOpenCodeZenModelIds(await fetchOpenCodeZenModelIds(state.apiKey))
                 if (zenModels.length > 0) {
@@ -5958,7 +5960,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               enabled: state.enabled,
               keyCount: getFreeKeyCount(),
               models,
-              currentModel: state.enabled ? state.model : null,
+              currentModel,
               customKey: Boolean(state.customKey),
               maskedKey,
               provider: state.provider ?? 'openrouter',
@@ -6054,7 +6056,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
               ? (current.model || FREE_MODE_DEFAULT_MODEL)
               : providerType === 'custom'
                 ? await fetchCustomEndpointDefaultModel(baseUrl, resolvedKey)
-                : ''
+                : OPENCODE_ZEN_DEFAULT_MODEL
             const state: FreeModeState = {
               enabled: true,
               apiKey: resolvedKey,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -223,6 +223,7 @@ const PROVIDER_MODELS_FETCH_TIMEOUT_MS = 5_000
 const THREAD_RESPONSE_TURN_LIMIT = 10
 const THREAD_TURN_PAGE_READ_CACHE_TTL_MS = 30_000
 const THREAD_METHODS_WITH_TURNS = new Set(['thread/read', 'thread/resume', 'thread/fork', 'thread/rollback'])
+const THREAD_METHODS_WITH_THREAD_SNAPSHOT = new Set([...THREAD_METHODS_WITH_TURNS, 'thread/start'])
 const THREAD_SEARCH_FULL_TEXT_THREAD_LIMIT = 100
 const PROJECTLESS_THREAD_DIRECTORY_MAX_ATTEMPTS = 100
 const PROJECTLESS_THREAD_SLUG_MAX_LENGTH = 80
@@ -922,6 +923,11 @@ function getErrorMessage(payload: unknown, fallback: string): string {
 export function isUnauthenticatedRateLimitError(error: unknown): boolean {
   const message = getErrorMessage(error, '').toLowerCase()
   return message.includes('authentication required') && message.includes('rate limits')
+}
+
+export function isEmptyThreadReadError(error: unknown): boolean {
+  const message = getErrorMessage(error, '').toLowerCase()
+  return message.includes('failed to read thread') && message.includes('rollout') && message.includes('is empty')
 }
 
 const warnedCodexAuthReadFailures = new Set<string>()
@@ -6156,36 +6162,50 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         }
         rpcMethod = body?.method && typeof body.method === 'string' ? body.method : null
 
-        if (!body || typeof body.method !== 'string' || body.method.length === 0) {
-          setJson(res, 400, { error: 'Invalid body: expected { method, params? }' })
-          return
-        }
+	        if (!body || typeof body.method !== 'string' || body.method.length === 0) {
+	          setJson(res, 400, { error: 'Invalid body: expected { method, params? }' })
+	          return
+	        }
 
-        if (body.method === 'account/rateLimits/read' && !(await hasUsableCodexAuth())) {
-          setJson(res, 200, { result: null })
-          return
-        }
+	        if (body.method === 'generate-thread-title') {
+	          setJson(res, 200, { result: { title: '' } })
+	          return
+	        }
+
+	        if (body.method === 'account/rateLimits/read' && !(await hasUsableCodexAuth())) {
+	          setJson(res, 200, { result: null })
+	          return
+	        }
 
         let rpcResult: unknown
         try {
           rpcResult = await callRpcWithArchiveRecovery(appServer, body.method, body.params ?? null)
         } catch (error) {
-          if (body.method === 'account/rateLimits/read' && isUnauthenticatedRateLimitError(error)) {
-            setJson(res, 200, { result: null })
-            return
-          }
-          throw error
-        }
+	          if (body.method === 'account/rateLimits/read' && isUnauthenticatedRateLimitError(error)) {
+	            setJson(res, 200, { result: null })
+	            return
+	          }
+	          if (body.method === 'thread/read' && isEmptyThreadReadError(error)) {
+	            const params = asRecord(body.params)
+	            const threadId = typeof params?.threadId === 'string' ? params.threadId.trim() : ''
+	            const snapshot = threadId ? appServer.getLastThreadReadSnapshot(threadId) : null
+	            if (snapshot) {
+	              setJson(res, 200, { result: snapshot })
+	              return
+	            }
+	          }
+	          throw error
+	        }
         const trimmedResult = trimThreadTurnsInRpcResult(body.method, rpcResult)
         const sanitizedResult = await sanitizeThreadTurnsInlinePayloads(body.method, trimmedResult)
         const result = THREAD_METHODS_WITH_TURNS.has(body.method)
           ? await mergeSessionSkillInputsIntoThreadResult(sanitizedResult)
           : sanitizedResult
 
-        if (THREAD_METHODS_WITH_TURNS.has(body.method)) {
-          const rpcRecord = asRecord(result)
-          const rpcThread = asRecord(rpcRecord?.thread)
-          const rpcThreadId = typeof rpcThread?.id === 'string' ? rpcThread.id : ''
+	        if (THREAD_METHODS_WITH_THREAD_SNAPSHOT.has(body.method)) {
+	          const rpcRecord = asRecord(result)
+	          const rpcThread = asRecord(rpcRecord?.thread)
+	          const rpcThreadId = typeof rpcThread?.id === 'string' ? rpcThread.id : ''
           if (rpcThreadId) {
             appServer.storeThreadReadSnapshot(rpcThreadId, result)
           }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -919,6 +919,21 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback
 }
 
+export function isUnauthenticatedRateLimitError(error: unknown): boolean {
+  const message = getErrorMessage(error, '').toLowerCase()
+  return message.includes('authentication required') && message.includes('rate limits')
+}
+
+export async function hasCodexRefreshToken(): Promise<boolean> {
+  try {
+    const raw = await readFile(getCodexAuthPath(), 'utf8')
+    const auth = JSON.parse(raw) as CodexAuth
+    return (auth.tokens?.refresh_token?.trim() ?? '').length > 0
+  } catch {
+    return false
+  }
+}
+
 function setJson(res: ServerResponse, statusCode: number, payload: unknown): void {
   res.statusCode = statusCode
   res.setHeader('Content-Type', 'application/json; charset=utf-8')
@@ -6120,7 +6135,21 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
 
-        const rpcResult = await callRpcWithArchiveRecovery(appServer, body.method, body.params ?? null)
+        if (body.method === 'account/rateLimits/read' && !(await hasCodexRefreshToken())) {
+          setJson(res, 200, { result: null })
+          return
+        }
+
+        let rpcResult: unknown
+        try {
+          rpcResult = await callRpcWithArchiveRecovery(appServer, body.method, body.params ?? null)
+        } catch (error) {
+          if (body.method === 'account/rateLimits/read' && isUnauthenticatedRateLimitError(error)) {
+            setJson(res, 200, { result: null })
+            return
+          }
+          throw error
+        }
         const trimmedResult = trimThreadTurnsInRpcResult(body.method, rpcResult)
         const sanitizedResult = await sanitizeThreadTurnsInlinePayloads(body.method, trimmedResult)
         const result = THREAD_METHODS_WITH_TURNS.has(body.method)

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -24,6 +24,8 @@ import {
   getFreeModels,
   refreshFreeModelsInBackground,
   FREE_MODE_STATE_FILE,
+  OPENCODE_ZEN_DEFAULT_MODEL,
+  OPENCODE_ZEN_PROVIDER_ID,
   createDefaultOpenCodeZenFreeModeState,
   getFreeModeConfigArgs,
   getFreeModeEnvVars,
@@ -1154,6 +1156,25 @@ async function fetchCustomEndpointDefaultModel(baseUrl: string, apiKey: string):
   } catch {
     return ''
   }
+}
+
+async function fetchOpenCodeZenModelIds(apiKey: string | null | undefined): Promise<string[]> {
+  const headers: Record<string, string> = {}
+  if (apiKey && apiKey !== 'dummy') {
+    headers.Authorization = `Bearer ${apiKey}`
+  }
+  const response = await fetch('https://opencode.ai/zen/v1/models', {
+    headers,
+    signal: AbortSignal.timeout(PROVIDER_MODELS_FETCH_TIMEOUT_MS),
+  })
+  if (!response.ok) return []
+  return normalizeProviderModelsData(await response.json() as unknown)
+}
+
+function sortOpenCodeZenModelIds(modelIds: string[]): string[] {
+  const freeIds = modelIds.filter((id) => id.endsWith('-free') || id === OPENCODE_ZEN_DEFAULT_MODEL)
+  const paidIds = modelIds.filter((id) => !id.endsWith('-free') && id !== OPENCODE_ZEN_DEFAULT_MODEL)
+  return [...freeIds, ...paidIds]
 }
 
 async function readProviderBackedModelIds(appServer: AppServerProcess): Promise<ProviderModelsResponse> {
@@ -5906,17 +5927,43 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
             const maskedKey = state.apiKey && state.customKey
               ? state.apiKey.substring(0, 12) + '...' + state.apiKey.substring(state.apiKey.length - 4)
               : null
-            refreshFreeModelsInBackground()
+            let models = getCachedFreeModels()
+            let wireApi = state.wireApi ?? null
+            if (state.provider === OPENCODE_ZEN_PROVIDER_ID) {
+              try {
+                const zenModels = sortOpenCodeZenModelIds(await fetchOpenCodeZenModelIds(state.apiKey))
+                if (zenModels.length > 0) {
+                  models = zenModels
+                } else {
+                  models = [
+                    OPENCODE_ZEN_DEFAULT_MODEL,
+                    'minimax-m2.5-free',
+                    'nemotron-3-super-free',
+                    'trinity-large-preview-free',
+                  ]
+                }
+              } catch {
+                models = [
+                  OPENCODE_ZEN_DEFAULT_MODEL,
+                  'minimax-m2.5-free',
+                  'nemotron-3-super-free',
+                  'trinity-large-preview-free',
+                ]
+              }
+              wireApi = 'responses'
+            } else {
+              refreshFreeModelsInBackground()
+            }
             setJson(res, 200, {
               enabled: state.enabled,
               keyCount: getFreeKeyCount(),
-              models: getCachedFreeModels(),
+              models,
               currentModel: state.enabled ? state.model : null,
               customKey: Boolean(state.customKey),
               maskedKey,
               provider: state.provider ?? 'openrouter',
               customBaseUrl: state.customBaseUrl ?? null,
-              wireApi: state.wireApi ?? null,
+              wireApi,
             })
           } catch (error) {
             setJson(res, 500, { error: getErrorMessage(error, 'Failed to read free mode status') })
@@ -6601,18 +6648,9 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           if (fmState?.enabled) {
             if (fmState.provider === 'opencode-zen') {
               try {
-                const modelsUrl = 'https://opencode.ai/zen/v1/models'
-                const headers: Record<string, string> = {}
-                if (fmState.apiKey && fmState.apiKey !== 'dummy') {
-                  headers['Authorization'] = `Bearer ${fmState.apiKey}`
-                }
-                const resp = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(8000) })
-                if (resp.ok) {
-                  const json = await resp.json() as { data?: Array<{ id: string }> }
-                  const allIds = (json.data ?? []).map(m => m.id).filter(Boolean)
-                  const freeIds = allIds.filter(id => id.endsWith('-free') || id === 'big-pickle')
-                  const paidIds = allIds.filter(id => !id.endsWith('-free') && id !== 'big-pickle')
-                  setJson(res, 200, { data: [...freeIds, ...paidIds], exclusive: true, source: 'opencode-zen' })
+                const modelIds = sortOpenCodeZenModelIds(await fetchOpenCodeZenModelIds(fmState.apiKey))
+                if (modelIds.length > 0) {
+                  setJson(res, 200, { data: modelIds, exclusive: true, source: 'opencode-zen' })
                   return
                 }
               } catch {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -924,12 +924,38 @@ export function isUnauthenticatedRateLimitError(error: unknown): boolean {
   return message.includes('authentication required') && message.includes('rate limits')
 }
 
-export async function hasCodexRefreshToken(): Promise<boolean> {
+const warnedCodexAuthReadFailures = new Set<string>()
+
+function getErrorCode(error: unknown): string | null {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : null
+}
+
+function getCodexAuthReadErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim().length > 0
+    ? error.message
+    : String(error)
+}
+
+function warnCodexAuthReadFailure(authPath: string, error: unknown): void {
+  const message = getCodexAuthReadErrorMessage(error)
+  const warningKey = `${authPath}:${message}`
+  if (warnedCodexAuthReadFailures.has(warningKey)) return
+  warnedCodexAuthReadFailures.add(warningKey)
+  console.warn('[codex-auth] Unable to read Codex auth state', { path: authPath, error: message })
+}
+
+export async function hasUsableCodexAuth(): Promise<boolean> {
+  const authPath = getCodexAuthPath()
   try {
-    const raw = await readFile(getCodexAuthPath(), 'utf8')
+    const raw = await readFile(authPath, 'utf8')
     const auth = JSON.parse(raw) as CodexAuth
-    return (auth.tokens?.refresh_token?.trim() ?? '').length > 0
-  } catch {
+    return Boolean(auth.tokens?.access_token?.trim() || auth.tokens?.refresh_token?.trim())
+  } catch (error) {
+    if (getErrorCode(error) !== 'ENOENT') {
+      warnCodexAuthReadFailure(authPath, error)
+    }
     return false
   }
 }
@@ -6135,7 +6161,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
 
-        if (body.method === 'account/rateLimits/read' && !(await hasCodexRefreshToken())) {
+        if (body.method === 'account/rateLimits/read' && !(await hasUsableCodexAuth())) {
           setJson(res, 200, { result: null })
           return
         }

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -29,6 +29,7 @@ describe('unauthenticated free mode defaults', () => {
     expect(args).toContain(`model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`)
     expect(args).toContain(`model="${OPENCODE_ZEN_DEFAULT_MODEL}"`)
     expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="http://127.0.0.1:4173/codex-api/zen-proxy/v1"`)
+    expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.wire_api="responses"`)
     expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`)
   })
 

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -16,7 +16,7 @@ describe('unauthenticated free mode defaults', () => {
     expect(state.enabled).toBe(true)
     expect(state.provider).toBe('opencode-zen')
     expect(state.model).toBe(OPENCODE_ZEN_DEFAULT_MODEL)
-    expect(state.wireApi).toBe('chat')
+    expect(state.wireApi).toBe('responses')
     expect(state.apiKey).toBeNull()
     expect(state.providerKeys).toEqual({})
   })

--- a/src/server/freeMode.test.ts
+++ b/src/server/freeMode.test.ts
@@ -33,6 +33,15 @@ describe('unauthenticated free mode defaults', () => {
     expect(args).toContain(`model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`)
   })
 
+  it('uses the OpenCode Zen default model when persisted Zen state has an empty model', () => {
+    const args = getFreeModeConfigArgs({
+      ...createDefaultOpenCodeZenFreeModeState(),
+      model: '',
+    }, 4173)
+
+    expect(args).toContain(`model="${OPENCODE_ZEN_DEFAULT_MODEL}"`)
+  })
+
   it('keeps OpenRouter config available for manual free mode', () => {
     const args = getFreeModeConfigArgs({
       enabled: true,

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -220,6 +220,7 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
   if (!state.enabled) return []
 
   if (state.provider === 'opencode-zen') {
+    const model = state.model?.trim() || OPENCODE_ZEN_DEFAULT_MODEL
     const baseUrl = serverPort
       ? `http://127.0.0.1:${serverPort}/codex-api/zen-proxy/v1`
       : OPENCODE_ZEN_BASE_URL
@@ -227,11 +228,8 @@ export function getFreeModeConfigArgs(state: FreeModeState, serverPort?: number)
     const authArgs: string[] = serverPort
       ? ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.experimental_bearer_token="zen-proxy-token"`]
       : ['-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.env_key="OPENCODE_ZEN_API_KEY"`]
-    const modelArgs: string[] = state.model?.trim()
-      ? ['-c', `model="${state.model.trim()}"`]
-      : []
     return [
-      ...modelArgs,
+      '-c', `model="${model}"`,
       '-c', `model_provider="${OPENCODE_ZEN_PROVIDER_ID}"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.name="OpenCode Zen"`,
       '-c', `model_providers.${OPENCODE_ZEN_PROVIDER_ID}.base_url="${baseUrl}"`,

--- a/src/server/freeMode.ts
+++ b/src/server/freeMode.ts
@@ -190,7 +190,7 @@ export function createDefaultOpenCodeZenFreeModeState(): FreeModeState {
     model: OPENCODE_ZEN_DEFAULT_MODEL,
     customKey: false,
     provider: 'opencode-zen',
-    wireApi: 'chat',
+    wireApi: 'responses',
     providerKeys: {},
   }
 }

--- a/tests.md
+++ b/tests.md
@@ -5194,10 +5194,14 @@ Fresh unauthenticated install mobile home screen rate-limit handling.
 4. Confirm the composer renders and the quota UI is simply absent when the fresh `CODEX_HOME` has no authenticated Codex account.
 5. Switch to dark theme and reload the same mobile viewport.
 6. Repeat steps 2 through 4 in dark theme.
+7. Add an `auth.json` containing only `tokens.access_token` and confirm `account/rateLimits/read` is not short-circuited as unauthenticated.
+8. Replace `auth.json` with malformed JSON and confirm the server logs a `[codex-auth] Unable to read Codex auth state` warning while the home screen still renders.
 
 #### Expected Results
 - The fresh mobile home screen renders without a blank page.
 - `account/rateLimits/read` returns an empty result instead of a `502` when no Codex account is authenticated.
+- An access-token-only auth file is treated as authenticated enough to ask Codex for rate limits.
+- Malformed auth files are visible in server logs instead of being silently treated as a normal fresh install.
 - The UI remains usable in light theme and dark theme.
 - No login or account import is required just to load the home screen.
 

--- a/tests.md
+++ b/tests.md
@@ -5267,7 +5267,7 @@ OpenCode Zen free-mode status and model discovery consistency.
 - OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
 - Provider model discovery and status agree on the model list source.
 - Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
-- Selected model ids are not persisted to localStorage; legacy selected-model keys are removed and stale browser storage cannot choose a provider-incompatible model.
+- Selected model ids persist to localStorage by thread/provider context; legacy/global selected-model keys cannot choose a model for OpenCode Zen, while a valid provider-scoped OpenCode Zen saved choice is restored.
 - Service-worker script/style cache invalidation does not keep Chrome on an older model-selector bundle after a new local build is served.
 - Model selector content remains usable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -5243,6 +5243,35 @@ Android `codexui-android` startup passes the bound server port to app-server fre
 
 ---
 
+### OpenCode Zen status returns current provider models
+
+#### Feature/Change Name
+OpenCode Zen free-mode status and model discovery consistency.
+
+#### Prerequisites/Setup
+1. Dev server or published CLI server running with no Codex auth so free mode defaults to OpenCode Zen.
+2. Browser can open the home route in light theme and dark theme.
+
+#### Steps
+1. In light theme, open the home route.
+2. Call `GET /codex-api/free-mode/status`.
+3. Call `GET /codex-api/provider-models`.
+4. Confirm both responses report OpenCode Zen data, including `big-pickle` and current Zen model ids such as `deepseek-v4-flash-free` when upstream returns it.
+5. Confirm `/codex-api/free-mode/status` reports `wireApi` as `responses`.
+6. Open the model selector and confirm the Zen models are available.
+7. Switch to dark theme and repeat steps 1 through 6.
+
+#### Expected Results
+- Free-mode status does not expose stale OpenRouter cached model ids when `provider` is `opencode-zen`.
+- OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
+- Provider model discovery and status agree on the model list source.
+- Model selector content remains usable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- None.
+
+---
+
 ### Thread conversation loads earlier turns on demand
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -5174,6 +5174,38 @@ The sidebar Chats section lists the first 10 projectless chats, offers Show more
 
 ---
 
+### Fresh Docker mobile install does not show rate-limit request failures
+
+#### Feature/Change Name
+Fresh unauthenticated install mobile home screen rate-limit handling.
+
+#### Prerequisites/Setup
+1. Docker is available.
+2. A clean container has this project installed under `/workspace`.
+3. `@openai/codex` is installed in the container.
+4. Container dev server is running with a fresh Codex home:
+   `CODEX_HOME=/tmp/codex-home CODEXUI_CODEX_COMMAND=$(command -v codex) pnpm run dev --host 0.0.0.0 --port 4173`
+5. The container port is mapped to the host, for example `127.0.0.1:4174 -> 4173`.
+
+#### Steps
+1. Open `http://127.0.0.1:4174/` in a mobile viewport such as iPhone 13 `390x664`.
+2. In light theme, wait for the Start new thread home screen to render.
+3. Capture network responses and confirm no `/codex-api/rpc` response fails with `502` for `account/rateLimits/read`.
+4. Confirm the composer renders and the quota UI is simply absent when the fresh `CODEX_HOME` has no authenticated Codex account.
+5. Switch to dark theme and reload the same mobile viewport.
+6. Repeat steps 2 through 4 in dark theme.
+
+#### Expected Results
+- The fresh mobile home screen renders without a blank page.
+- `account/rateLimits/read` returns an empty result instead of a `502` when no Codex account is authenticated.
+- The UI remains usable in light theme and dark theme.
+- No login or account import is required just to load the home screen.
+
+#### Rollback/Cleanup
+- Stop and remove the temporary Docker container, for example `docker rm -f <container-name>`.
+
+---
+
 ### Thread conversation loads earlier turns on demand
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -5259,13 +5259,15 @@ OpenCode Zen free-mode status and model discovery consistency.
 4. Confirm both responses report OpenCode Zen data, including `big-pickle` and current Zen model ids such as `deepseek-v4-flash-free` when upstream returns it.
 5. Confirm `/codex-api/free-mode/status` reports `wireApi` as `responses`.
 6. Open the model selector immediately after initial page load and confirm the Zen models are available without first switching providers or refreshing settings.
-7. Switch to dark theme and repeat steps 1 through 6.
+7. In Chrome with a previously loaded app version, reload the page and confirm the service worker fetches the new script/style bundle instead of keeping stale cached selector behavior.
+8. Switch to dark theme and repeat steps 1 through 7.
 
 #### Expected Results
 - Free-mode status does not expose stale OpenRouter cached model ids when `provider` is `opencode-zen`.
 - OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
 - Provider model discovery and status agree on the model list source.
 - Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
+- Service-worker script/style cache invalidation does not keep Chrome on an older model-selector bundle after a new local build is served.
 - Model selector content remains usable in light theme and dark theme.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -5260,7 +5260,8 @@ OpenCode Zen free-mode status and model discovery consistency.
 5. Confirm `/codex-api/free-mode/status` reports `wireApi` as `responses`.
 6. Open the model selector immediately after initial page load and confirm the Zen models are available without first switching providers or refreshing settings.
 7. In Chrome with a previously loaded app version, reload the page and confirm the service worker fetches the new script/style bundle instead of keeping stale cached selector behavior.
-8. Switch to dark theme and repeat steps 1 through 7.
+8. With a script/style bundle already cached by the service worker, temporarily make the same script/style request return HTTP 404 or 500 and reload.
+9. Switch to dark theme and repeat steps 1 through 8.
 
 #### Expected Results
 - Free-mode status does not expose stale OpenRouter cached model ids when `provider` is `opencode-zen`.
@@ -5269,6 +5270,7 @@ OpenCode Zen free-mode status and model discovery consistency.
 - Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
 - Selected model ids persist to localStorage by thread/provider context; legacy/global selected-model keys cannot choose a model for OpenCode Zen, while a valid provider-scoped OpenCode Zen saved choice is restored.
 - Service-worker script/style cache invalidation does not keep Chrome on an older model-selector bundle after a new local build is served.
+- Service-worker script/style fetches still use a cached bundle if the network request resolves with a non-OK HTTP status.
 - Model selector content remains usable in light theme and dark theme.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -5228,12 +5228,15 @@ Android `codexui-android` startup passes the bound server port to app-server fre
 4. Call `POST /codex-api/rpc` with `{"method":"model/list","params":{}}`.
 5. Confirm `/codex-api/provider-models` still returns OpenCode Zen model ids.
 6. Verify the model selector is enabled in light theme and dark theme.
+7. Send `hi` from the home composer and wait for the first assistant reply.
+8. Confirm browser/network logs do not show a `502` for `generate-thread-title` or an empty-rollout `thread/read` during startup.
 
 #### Expected Results
 - `config/read` returns `200` and includes `model_providers.opencode-zen.base_url` pointing at `http://127.0.0.1:17923/codex-api/zen-proxy/v1`.
 - `config/read` includes `model_providers.opencode-zen.wire_api` as `responses`, not `chat`.
 - `model/list` returns `200` with model data instead of `502 codex app-server exited unexpectedly`.
 - The model selector is usable in both light theme and dark theme.
+- A first home-composer message creates a thread and receives a response without visible startup RPC errors.
 
 #### Rollback/Cleanup
 - Stop the temporary Android proot process with `pkill -f codexui-android` if needed.

--- a/tests.md
+++ b/tests.md
@@ -5267,6 +5267,7 @@ OpenCode Zen free-mode status and model discovery consistency.
 - OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
 - Provider model discovery and status agree on the model list source.
 - Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
+- Persisted selected-model localStorage from another provider is ignored unless the model is present in the active provider list.
 - Service-worker script/style cache invalidation does not keep Chrome on an older model-selector bundle after a new local build is served.
 - Model selector content remains usable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -5267,7 +5267,7 @@ OpenCode Zen free-mode status and model discovery consistency.
 - OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
 - Provider model discovery and status agree on the model list source.
 - Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
-- Persisted selected-model localStorage from another provider is ignored unless the model is present in the active provider list.
+- Selected model ids are not persisted to localStorage; legacy selected-model keys are removed and stale browser storage cannot choose a provider-incompatible model.
 - Service-worker script/style cache invalidation does not keep Chrome on an older model-selector bundle after a new local build is served.
 - Model selector content remains usable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -5210,6 +5210,36 @@ Fresh unauthenticated install mobile home screen rate-limit handling.
 
 ---
 
+### Android published CLI loads Codex app-server models through local proxy
+
+#### Feature/Change Name
+Android `codexui-android` startup passes the bound server port to app-server free-mode config.
+
+#### Prerequisites/Setup
+1. Android proot access works through `/Users/igor/Git-projects/codex-web-local-android/andClaw-codex/ssh.sh`.
+2. The published `codexui-android` package version under test is available from npm.
+3. ADB forward maps device port `17923` to local port `17923`.
+
+#### Steps
+1. Start the package in Android proot:
+   `pnpm dlx codexui-android@<version> --port 17923 --no-open --no-tunnel --no-login`
+2. Open `http://127.0.0.1:17923/#/` in the browser.
+3. Call `POST /codex-api/rpc` with `{"method":"config/read","params":{}}`.
+4. Call `POST /codex-api/rpc` with `{"method":"model/list","params":{}}`.
+5. Confirm `/codex-api/provider-models` still returns OpenCode Zen model ids.
+6. Verify the model selector is enabled in light theme and dark theme.
+
+#### Expected Results
+- `config/read` returns `200` and includes `model_providers.opencode-zen.base_url` pointing at `http://127.0.0.1:17923/codex-api/zen-proxy/v1`.
+- `config/read` includes `model_providers.opencode-zen.wire_api` as `responses`, not `chat`.
+- `model/list` returns `200` with model data instead of `502 codex app-server exited unexpectedly`.
+- The model selector is usable in both light theme and dark theme.
+
+#### Rollback/Cleanup
+- Stop the temporary Android proot process with `pkill -f codexui-android` if needed.
+
+---
+
 ### Thread conversation loads earlier turns on demand
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -5258,13 +5258,14 @@ OpenCode Zen free-mode status and model discovery consistency.
 3. Call `GET /codex-api/provider-models`.
 4. Confirm both responses report OpenCode Zen data, including `big-pickle` and current Zen model ids such as `deepseek-v4-flash-free` when upstream returns it.
 5. Confirm `/codex-api/free-mode/status` reports `wireApi` as `responses`.
-6. Open the model selector and confirm the Zen models are available.
+6. Open the model selector immediately after initial page load and confirm the Zen models are available without first switching providers or refreshing settings.
 7. Switch to dark theme and repeat steps 1 through 6.
 
 #### Expected Results
 - Free-mode status does not expose stale OpenRouter cached model ids when `provider` is `opencode-zen`.
 - OpenCode Zen uses `responses`, not `chat`, in saved/default UI state.
 - Provider model discovery and status agree on the model list source.
+- Initial startup model loading uses the active provider context and does not leave GPT-only `model/list` entries as the visible selector list for OpenCode Zen.
 - Model selector content remains usable in light theme and dark theme.
 
 #### Rollback/Cleanup


### PR DESCRIPTION
## Summary
- Return an empty rate-limit result for unauthenticated fresh installs before starting app-server.
- Keep the existing fallback for app-server auth errors on rate-limit reads.
- Add regression coverage for unauthenticated rate-limit detection and missing refresh-token auth files.
- Document the fresh Docker/mobile manual verification flow in tests.md.
- Restore selected-model localStorage using thread/provider-scoped keys so OpenCode Zen remembers valid Zen selections without accepting stale global model choices.
- Make service-worker script/style network-first caching fall back to cached bundles when the network resolves with a non-OK response.
- Document the Qodo `/review` PR comment workflow in AGENTS.md.

## Verification
- Docker: pnpm exec vitest run src/server/codexAppServerBridge.archive.test.ts
- Docker: pnpm run build:frontend
- Docker runtime: POST /codex-api/rpc account/rateLimits/read returns 200 {"result":null}
- Docker profiler: no warnings, rateLimitsRead=1, totalApiKB=17.5
- Android physical device via /Users/igor/Git-projects/codex-web-local-android/andClaw-codex/ssh.sh on S8ONXS4TBEFMNVEY: account/rateLimits/read returns 200 {"result":null}
- pnpm test:unit src/composables/useDesktopState.test.ts
- pnpm run build
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser: providerModels=1; existing unrelated threadRead=3 warning remains
- Node VM smoke check: non-OK networkFirstStatic() response falls back to cached script/style response
- pnpm run build:frontend
- Rebase verification: pnpm test:unit src/composables/useDesktopState.test.ts src/server/codexAppServerBridge.archive.test.ts src/server/freeMode.test.ts
- Rebase verification: pnpm run build:frontend
