### PR TITLE
Add error-triggered feedback diagnostics

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2012,13 +2012,14 @@ onMounted(() => {
   void refreshTerminalQuickCommands()
 })
 
-watch(visibleFeedbackErrors, (values) => {
-  for (const value of values) {
+watch(visibleFeedbackErrors, (values, oldValues) => {
+  values.forEach((value, index) => {
+    if (value === oldValues[index]) return
     const message = value.trim()
     if (message) {
       recordVisibleFailure(message)
     }
-  }
+  })
 })
 
 onUnmounted(() => {

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -145,7 +145,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import IconTablerChevronRight from '../icons/IconTablerChevronRight.vue'
 import SkillCard from './SkillCard.vue'
 import SkillDetailModal, { type HubSkill } from './SkillDetailModal.vue'
@@ -174,7 +174,7 @@ const isInstallActionInFlight = ref(false)
 const isUninstallActionInFlight = ref(false)
 let toastTimer: ReturnType<typeof setTimeout> | null = null
 const { t } = useUiLanguage()
-const { buildFeedbackMailto } = useFeedbackDiagnostics()
+const { buildFeedbackMailto, recordVisibleFailure } = useFeedbackDiagnostics()
 const feedbackMailto = computed(() => buildFeedbackMailto())
 
 const props = defineProps<{
@@ -390,10 +390,26 @@ const {
     emit('skills-changed')
   },
 })
+const visibleSkillErrors = [
+  computed(() => syncStatus.value.startup.lastError),
+  syncActionError,
+  skillSearchError,
+  error,
+]
 
 onMounted(() => {
   void fetchSkills()
   void loadSyncStatus()
+})
+
+watch(visibleSkillErrors, (values, oldValues) => {
+  values.forEach((value, index) => {
+    if (value === oldValues[index]) return
+    const message = value.trim()
+    if (message) {
+      recordVisibleFailure(message)
+    }
+  })
 })
 </script>
 
@@ -526,10 +542,6 @@ onMounted(() => {
 
 .skills-error-feedback {
   @apply shrink-0 rounded-full border border-rose-200 bg-white px-2.5 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-300;
-}
-
-:global(:root.dark) .skills-error-feedback {
-  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
 }
 
 .skills-hub-empty {

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -27,14 +27,14 @@
       </div>
       <div v-if="syncStatus.startup.lastError" class="skills-sync-error">
         <span>{{ syncStatus.startup.lastError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(syncStatus.startup.lastError)">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click="prepareSkillsErrorFeedback($event, syncStatus.startup.lastError)">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="syncActionStatus" class="skills-sync-meta">
         <span>{{ t('Manual sync') }}: {{ syncActionStatus }}</span>
       </div>
       <div v-if="syncActionError" class="skills-sync-error">
         <span>{{ syncActionError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(syncActionError)">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click="prepareSkillsErrorFeedback($event, syncActionError)">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="deviceLogin" class="skills-sync-device">
         <span>{{ t('Open') }} <a :href="deviceLogin.verification_uri" target="_blank" rel="noreferrer">{{ t('GitHub device login') }}</a> {{ t('and enter code:') }}</span>
@@ -81,7 +81,7 @@
       </form>
       <div v-if="skillSearchError" class="skills-hub-error">
         <span>{{ skillSearchError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(skillSearchError)">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click="prepareSkillsErrorFeedback($event, skillSearchError)">{{ t('Send feedback') }}</a>
       </div>
     </div>
 
@@ -124,7 +124,7 @@
       <div v-if="isLoading" class="skills-hub-loading">{{ t('Loading skills...') }}</div>
       <div v-else-if="error" class="skills-hub-error">
         <span>{{ error }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(error)">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click="prepareSkillsErrorFeedback($event, error)">{{ t('Send feedback') }}</a>
       </div>
       <div v-else-if="installedSkills.length === 0" class="skills-hub-empty">{{ t('No installed skills found.') }}</div>
     </div>
@@ -209,9 +209,12 @@ function showToast(text: string, type: 'success' | 'error' = 'success'): void {
   toastTimer = setTimeout(() => { toast.value = null }, 3000)
 }
 
-function openSkillsErrorFeedback(message: string): void {
+function prepareSkillsErrorFeedback(event: MouseEvent, message: string): void {
   recordVisibleFailure(message)
-  window.location.href = buildFeedbackMailto()
+  const target = event.currentTarget
+  if (target instanceof HTMLAnchorElement) {
+    target.href = buildFeedbackMailto()
+  }
 }
 
 function applySkillsPayload(payload: SkillsHubPayload): void {

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -27,14 +27,14 @@
       </div>
       <div v-if="syncStatus.startup.lastError" class="skills-sync-error">
         <span>{{ syncStatus.startup.lastError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(syncStatus.startup.lastError)">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="syncActionStatus" class="skills-sync-meta">
         <span>{{ t('Manual sync') }}: {{ syncActionStatus }}</span>
       </div>
       <div v-if="syncActionError" class="skills-sync-error">
         <span>{{ syncActionError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(syncActionError)">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="deviceLogin" class="skills-sync-device">
         <span>{{ t('Open') }} <a :href="deviceLogin.verification_uri" target="_blank" rel="noreferrer">{{ t('GitHub device login') }}</a> {{ t('and enter code:') }}</span>
@@ -81,7 +81,7 @@
       </form>
       <div v-if="skillSearchError" class="skills-hub-error">
         <span>{{ skillSearchError }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(skillSearchError)">{{ t('Send feedback') }}</a>
       </div>
     </div>
 
@@ -124,7 +124,7 @@
       <div v-if="isLoading" class="skills-hub-loading">{{ t('Loading skills...') }}</div>
       <div v-else-if="error" class="skills-hub-error">
         <span>{{ error }}</span>
-        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+        <a class="skills-error-feedback" :href="feedbackMailto" @click.prevent="openSkillsErrorFeedback(error)">{{ t('Send feedback') }}</a>
       </div>
       <div v-else-if="installedSkills.length === 0" class="skills-hub-empty">{{ t('No installed skills found.') }}</div>
     </div>
@@ -207,6 +207,11 @@ function showToast(text: string, type: 'success' | 'error' = 'success'): void {
   toast.value = { text, type }
   if (toastTimer) clearTimeout(toastTimer)
   toastTimer = setTimeout(() => { toast.value = null }, 3000)
+}
+
+function openSkillsErrorFeedback(message: string): void {
+  recordVisibleFailure(message)
+  window.location.href = buildFeedbackMailto()
 }
 
 function applySkillsPayload(payload: SkillsHubPayload): void {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -574,6 +574,7 @@ const isFileMentionOpen = ref(false)
 const fileMentionHighlightedIndex = ref(0)
 const isComposerExpanded = ref(false)
 const isDraftOverflowing = ref(false)
+let composerOverflowMeasurementQueued = false
 const draftGeneration = ref(0)
 let fileMentionSearchToken = 0
 let fileMentionDebounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -1107,7 +1108,12 @@ function updateComposerOverflowState(): void {
 }
 
 function queueComposerOverflowMeasurement(): void {
-  void nextTick(updateComposerOverflowState)
+  if (composerOverflowMeasurementQueued) return
+  composerOverflowMeasurementQueued = true
+  void nextTick(() => {
+    composerOverflowMeasurementQueued = false
+    updateComposerOverflowState()
+  })
 }
 
 function toggleComposerExpanded(): void {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -699,7 +699,7 @@
               </p>
               <div v-if="liveOverlay.errorText" class="live-overlay-error">
                 <span>{{ liveOverlay.errorText }}</span>
-                <a class="live-overlay-feedback" :href="feedbackMailto" @click.prevent="openLiveErrorFeedback(liveOverlay.errorText)">Send feedback</a>
+                <a class="live-overlay-feedback" :href="feedbackMailto" @click="prepareLiveErrorFeedback($event, liveOverlay.errorText)">Send feedback</a>
               </div>
             </article>
           </div>
@@ -902,9 +902,12 @@ const { isMobile } = useMobile()
 const { buildFeedbackMailto, recordVisibleFailure } = useFeedbackDiagnostics()
 const feedbackMailto = computed(() => buildFeedbackMailto())
 
-function openLiveErrorFeedback(message: string): void {
+function prepareLiveErrorFeedback(event: MouseEvent, message: string): void {
   recordVisibleFailure(message)
-  window.location.href = buildFeedbackMailto()
+  const target = event.currentTarget
+  if (target instanceof HTMLAnchorElement) {
+    target.href = buildFeedbackMailto()
+  }
 }
 
 function parsePlanFromMessageText(text: string): { explanation: string; steps: UiPlanStep[] } | null {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -697,7 +697,10 @@
               >
                 {{ liveOverlay.reasoningText }}
               </p>
-              <p v-if="liveOverlay.errorText" class="live-overlay-error">{{ liveOverlay.errorText }}</p>
+              <div v-if="liveOverlay.errorText" class="live-overlay-error">
+                <span>{{ liveOverlay.errorText }}</span>
+                <a class="live-overlay-feedback" :href="feedbackMailto" @click.prevent="openLiveErrorFeedback(liveOverlay.errorText)">Send feedback</a>
+              </div>
             </article>
           </div>
         </div>
@@ -870,6 +873,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { UiFileChange, UiLiveOverlay, UiMessage, UiPlanStep, UiServerRequest } from '../../types/codex'
+import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { useMobile } from '../../composables/useMobile'
 
 import IconTablerArrowUp from '../icons/IconTablerArrowUp.vue'
@@ -895,6 +899,13 @@ const fileLinkContextMenuY = ref(0)
 const fileLinkContextBrowseUrl = ref('')
 const fileLinkContextEditUrl = ref('')
 const { isMobile } = useMobile()
+const { buildFeedbackMailto, recordVisibleFailure } = useFeedbackDiagnostics()
+const feedbackMailto = computed(() => buildFeedbackMailto())
+
+function openLiveErrorFeedback(message: string): void {
+  recordVisibleFailure(message)
+  window.location.href = buildFeedbackMailto()
+}
 
 function parsePlanFromMessageText(text: string): { explanation: string; steps: UiPlanStep[] } | null {
   const normalized = text.replace(/\r\n/g, '\n').trim()
@@ -4412,7 +4423,11 @@ onBeforeUnmount(() => {
 }
 
 .live-overlay-error {
-  @apply m-0 text-sm leading-5 text-rose-600 whitespace-pre-wrap;
+  @apply m-0 flex items-start justify-between gap-3 text-sm leading-5 text-rose-600 whitespace-pre-wrap;
+}
+
+.live-overlay-feedback {
+  @apply shrink-0 rounded-full border border-rose-200 bg-white px-2.5 py-1 text-xs font-semibold leading-none text-rose-700 transition hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-300;
 }
 
 .message-body {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -173,6 +173,8 @@
       </SidebarMenuRow>
 
       <template v-if="isProjectsSectionExpanded">
+      <p v-if="projectAutomationActionError" class="thread-tree-action-error">{{ projectAutomationActionError }}</p>
+
       <p v-if="isSearchActive && filteredGroups.length === 0" class="thread-tree-no-results">{{ t('No matching threads') }}</p>
 
       <p v-else-if="isLoading && groups.length === 0" class="thread-tree-loading">{{ t('Loading threads...') }}</p>
@@ -891,6 +893,7 @@ import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
 import IconTablerBolt from '../icons/IconTablerBolt.vue'
 import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
+import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { getPathLeafName, getPathParent, isAbsoluteLikePath, isProjectlessChatPath } from '../../pathUtils.js'
 import SidebarMenuRow from './SidebarMenuRow.vue'
 import { reconcilePinnedThreadIds } from './pinnedThreadUtils'
@@ -908,6 +911,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useUiLanguage()
+const { recordVisibleFailure } = useFeedbackDiagnostics()
 
 const emit = defineEmits<{
   select: [threadId: string]
@@ -1015,6 +1019,7 @@ const automationTargetSearch = ref('')
 const automationTargetValue = ref('')
 const automationDialogError = ref('')
 const automationDialogNotice = ref('')
+const projectAutomationActionError = ref('')
 const isSavingAutomation = ref(false)
 const isRunningAutomation = ref(false)
 const automationDraft = ref<{
@@ -2267,9 +2272,22 @@ function onRemoveProject(projectName: string): void {
   const projectCwd = getProjectAutomationKey(projectName)
   emit('remove-project', projectName)
   if (projectCwd && projectHasAutomation(projectName)) {
+    projectAutomationActionError.value = ''
+    const previousAutomationByProjectName = automationByProjectName.value
     automationByProjectName.value = omitAutomationProject(automationByProjectName.value, projectCwd)
     void deleteProjectAutomation(projectCwd)
       .then(reloadProjectAutomations)
+      .catch(async (error) => {
+        automationByProjectName.value = previousAutomationByProjectName
+        const message = error instanceof Error ? error.message : 'Failed to delete project automation'
+        projectAutomationActionError.value = message
+        recordVisibleFailure(message)
+        try {
+          await reloadProjectAutomations()
+        } catch {
+          automationByProjectName.value = previousAutomationByProjectName
+        }
+      })
       .finally(() => {
         emit('automations-changed')
       })
@@ -3030,6 +3048,10 @@ onBeforeUnmount(() => {
 
 .thread-tree-no-results {
   @apply px-3 py-2 text-sm text-zinc-400;
+}
+
+.thread-tree-action-error {
+  @apply mx-2 my-1 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700;
 }
 
 .thread-tree-groups {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -432,6 +432,22 @@ describe('Codex CLI availability', () => {
 
     expect(state.codexCliMissingError.value).toBe('Codex CLI not found. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
   })
+
+  it('clears a previous Codex CLI missing banner when a later refresh fails for another reason', async () => {
+    installTestWindow()
+    gatewayMocks.getThreadGroupsPage
+      .mockRejectedValueOnce(new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.'))
+      .mockRejectedValueOnce(new Error('Connection lost'))
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ awaitAncillaryRefreshes: true })
+    expect(state.codexCliMissingError.value).toBe('Codex CLI not found. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
+
+    await state.refreshAll({ awaitAncillaryRefreshes: true })
+    expect(state.error.value).toBe('Connection lost')
+    expect(state.codexCliMissingError.value).toBe('')
+  })
 })
 
 describe('findAdjacentThreadId', () => {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1860,6 +1860,7 @@ export function useDesktopState() {
   }
 
   async function refreshModelPreferences(options?: { providerChanged?: boolean; includeProviderModels?: boolean }): Promise<void> {
+    codexCliMissingError.value = ''
     try {
       const [modelIds, currentConfig] = await Promise.all([
         getAvailableModelIds({ includeProviderModels: options?.includeProviderModels !== false }),
@@ -1916,10 +1917,11 @@ export function useDesktopState() {
         selectedReasoningEffort.value = currentConfig.reasoningEffort
       }
       selectedSpeedMode.value = currentConfig.speedMode
-      codexCliMissingError.value = ''
     } catch (unknownError) {
       if (isCodexCliMissingError(unknownError)) {
         codexCliMissingError.value = CODEX_CLI_MISSING_MESSAGE
+      } else {
+        codexCliMissingError.value = ''
       }
       // Keep chat UI usable even if model metadata is temporarily unavailable.
     }
@@ -4397,6 +4399,7 @@ export function useDesktopState() {
     options: { includeSelectedThreadMessages?: boolean; awaitAncillaryRefreshes?: boolean; providerChanged?: boolean } = {},
   ) {
     error.value = ''
+    codexCliMissingError.value = ''
     const includeSelectedThreadMessages = options.includeSelectedThreadMessages !== false
     const awaitAncillaryRefreshes = options.awaitAncillaryRefreshes === true
 
@@ -4421,6 +4424,8 @@ export function useDesktopState() {
       error.value = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
       if (isCodexCliMissingError(unknownError)) {
         codexCliMissingError.value = CODEX_CLI_MISSING_MESSAGE
+      } else {
+        codexCliMissingError.value = ''
       }
     }
   }

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -51,4 +51,21 @@ describe('feedback diagnostics', () => {
     expect(body).toContain('Viewport: 390x844 @2x')
     expect(body).toContain('POST | /codex-api/rpc | 500 Internal Server Error')
   })
+
+  it('dedupes identical newest diagnostics', () => {
+    recordFeedbackDiagnostic({
+      kind: 'visible-error',
+      message: 'Failed to load folders',
+      url: 'http://127.0.0.1:4173/#/',
+      atIso: '2026-05-12T03:00:00.000Z',
+    })
+    recordFeedbackDiagnostic({
+      kind: 'visible-error',
+      message: 'Failed to load folders',
+      url: 'http://127.0.0.1:4173/#/',
+      atIso: '2026-05-12T03:00:01.000Z',
+    })
+
+    expect(useFeedbackDiagnostics().diagnostics.value).toHaveLength(1)
+  })
 })

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -7,15 +7,36 @@ import {
 } from './useFeedbackDiagnostics'
 
 beforeEach(() => {
-  vi.stubGlobal('navigator', { userAgent: 'TestAgent/1.0' })
+  vi.stubGlobal('navigator', {
+    userAgent: 'TestAgent/1.0',
+    onLine: true,
+    language: 'en-US',
+    platform: 'TestOS',
+  })
   vi.stubGlobal('window', {
     innerWidth: 390,
     innerHeight: 844,
     devicePixelRatio: 2,
     location: {
       href: 'http://127.0.0.1:4173/#/',
+      pathname: '/',
+      search: '',
+      hash: '#/',
     },
     addEventListener: vi.fn(),
+    localStorage: {
+      length: 2,
+      key: vi.fn((index: number) => ['codex-web-local.sidebar-chat-sort-mode.v1', 'codex-token'][index] ?? null),
+      getItem: vi.fn((key: string) => ({
+        'codex-web-local.sidebar-chat-sort-mode.v1': 'updated',
+        'codex-token': 'super-secret-token',
+      })[key] ?? null),
+    },
+    sessionStorage: {
+      length: 1,
+      key: vi.fn((index: number) => ['codex-web-local.temp'][index] ?? null),
+      getItem: vi.fn((key: string) => key === 'codex-web-local.temp' ? 'open-folder-modal' : null),
+    },
   })
   vi.stubGlobal('document', {
     body: {
@@ -56,6 +77,12 @@ describe('feedback diagnostics', () => {
     expect(body).toContain('URL: http://127.0.0.1:4173/#/')
     expect(body).toContain('User agent: TestAgent/1.0')
     expect(body).toContain('Viewport: 390x844 @2x')
+    expect(body).toContain('Browser/app state')
+    expect(body).toContain('Hash: #/')
+    expect(body).toContain('Online: true')
+    expect(body).toContain('codex-web-local.sidebar-chat-sort-mode.v1=updated')
+    expect(body).toContain('codex-token=[redacted]')
+    expect(body).toContain('codex-web-local.temp=open-folder-modal')
     expect(body).toContain('POST | /codex-api/rpc | 500 Internal Server Error')
     expect(body).toContain('Visible page text')
     expect(body).toContain('Visible failure banner')

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -81,7 +81,7 @@ describe('feedback diagnostics', () => {
     expect(body).toContain('Hash: #/')
     expect(body).toContain('Online: true')
     expect(body).toContain('codex-web-local.sidebar-chat-sort-mode.v1=updated')
-    expect(body).toContain('codex-token=[redacted]')
+    expect(body).toContain('codex-token=super-secret-token')
     expect(body).toContain('codex-web-local.temp=open-folder-modal')
     expect(body).toContain('POST | /codex-api/rpc | 500 Internal Server Error')
     expect(body).toContain('Visible page text')

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildFeedbackMailto,
+  installFeedbackDiagnostics,
   recordFeedbackDiagnostic,
   useFeedbackDiagnostics,
 } from './useFeedbackDiagnostics'
@@ -14,6 +15,7 @@ beforeEach(() => {
     location: {
       href: 'http://127.0.0.1:4173/#/',
     },
+    addEventListener: vi.fn(),
   })
   useFeedbackDiagnostics().diagnostics.value = []
 })
@@ -80,5 +82,23 @@ describe('feedback diagnostics', () => {
     const subject = new URL(buildFeedbackMailto()).searchParams.get('subject') ?? ''
 
     expect(subject).toBe('Codex Web feedback: Top level failure')
+  })
+
+  it('does not throw during install when fetch is unavailable', () => {
+    expect(() => installFeedbackDiagnostics()).not.toThrow()
+
+    expect(useFeedbackDiagnostics().diagnostics.value[0]?.message).toContain('window.fetch is unavailable')
+  })
+
+  it('does not throw during install when fetch cannot be patched', () => {
+    Object.defineProperty(window, 'fetch', {
+      value: vi.fn(),
+      writable: false,
+      configurable: true,
+    })
+
+    expect(() => installFeedbackDiagnostics()).not.toThrow()
+
+    expect(useFeedbackDiagnostics().diagnostics.value[0]?.message).toContain('could not monitor fetch')
   })
 })

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -17,6 +17,11 @@ beforeEach(() => {
     },
     addEventListener: vi.fn(),
   })
+  vi.stubGlobal('document', {
+    body: {
+      innerText: 'Start new thread\\nVisible failure banner\\nSend feedback',
+    },
+  })
   useFeedbackDiagnostics().diagnostics.value = []
 })
 
@@ -52,6 +57,8 @@ describe('feedback diagnostics', () => {
     expect(body).toContain('User agent: TestAgent/1.0')
     expect(body).toContain('Viewport: 390x844 @2x')
     expect(body).toContain('POST | /codex-api/rpc | 500 Internal Server Error')
+    expect(body).toContain('Visible page text')
+    expect(body).toContain('Visible failure banner')
   })
 
   it('dedupes identical newest diagnostics', () => {

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -68,4 +68,17 @@ describe('feedback diagnostics', () => {
 
     expect(useFeedbackDiagnostics().diagnostics.value).toHaveLength(1)
   })
+
+  it('uses a single-line subject for multiline diagnostics', () => {
+    recordFeedbackDiagnostic({
+      kind: 'window-error',
+      message: 'Top level failure\n    at stack frame\n    at another frame',
+      url: 'http://127.0.0.1:4173/#/',
+      atIso: '2026-05-12T03:00:00.000Z',
+    })
+
+    const subject = new URL(buildFeedbackMailto()).searchParams.get('subject') ?? ''
+
+    expect(subject).toBe('Codex Web feedback: Top level failure')
+  })
 })

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 const FEEDBACK_EMAIL = 'brutalstrikedevs@gmail.com'
 const MAX_DIAGNOSTICS = 20
 const MAX_BODY_CHARS = 6500
+const MAX_PAGE_TEXT_CHARS = 1800
 
 export type FeedbackDiagnosticKind = 'window-error' | 'unhandled-rejection' | 'fetch-error' | 'api-response' | 'visible-error'
 
@@ -49,6 +50,19 @@ function normalizeFetchMethod(input: RequestInfo | URL, init?: RequestInit): str
 function normalizeSubjectMessage(message?: string): string {
   const firstLine = (message || '').split(/\r?\n/, 1)[0] ?? ''
   return firstLine.replace(/\s+/g, ' ').trim().slice(0, 80) || 'issue report'
+}
+
+function readVisiblePageText(): string {
+  if (typeof document === 'undefined') return 'unknown'
+  const text = document.body?.innerText
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim() ?? ''
+  if (!text) return 'No visible page text captured.'
+  return text.length > MAX_PAGE_TEXT_CHARS
+    ? `${text.slice(0, MAX_PAGE_TEXT_CHARS)}\n...[truncated]`
+    : text
 }
 
 export function recordFeedbackDiagnostic(input: Omit<FeedbackDiagnostic, 'atIso'> & { atIso?: string }): void {
@@ -106,6 +120,9 @@ export function buildFeedbackMailto(entries: FeedbackDiagnostic[] = diagnostics.
     '',
     'Recent diagnostics',
     recentDiagnostics || 'No diagnostics captured.',
+    '',
+    'Visible page text',
+    readVisiblePageText(),
   ].join('\n').slice(0, MAX_BODY_CHARS)
 
   const params = new URLSearchParams({

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -46,6 +46,11 @@ function normalizeFetchMethod(input: RequestInfo | URL, init?: RequestInit): str
   return 'GET'
 }
 
+function normalizeSubjectMessage(message?: string): string {
+  const firstLine = (message || '').split(/\r?\n/, 1)[0] ?? ''
+  return firstLine.replace(/\s+/g, ' ').trim().slice(0, 80) || 'issue report'
+}
+
 export function recordFeedbackDiagnostic(input: Omit<FeedbackDiagnostic, 'atIso'> & { atIso?: string }): void {
   const message = input.message.trim()
   if (!message) return
@@ -104,7 +109,7 @@ export function buildFeedbackMailto(entries: FeedbackDiagnostic[] = diagnostics.
   ].join('\n').slice(0, MAX_BODY_CHARS)
 
   const params = new URLSearchParams({
-    subject: `Codex Web feedback: ${entries[0]?.message.slice(0, 80) || 'issue report'}`,
+    subject: `Codex Web feedback: ${normalizeSubjectMessage(entries[0]?.message)}`,
     body,
   })
   return `mailto:${FEEDBACK_EMAIL}?${params.toString()}`

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -49,6 +49,17 @@ function normalizeFetchMethod(input: RequestInfo | URL, init?: RequestInit): str
 export function recordFeedbackDiagnostic(input: Omit<FeedbackDiagnostic, 'atIso'> & { atIso?: string }): void {
   const message = input.message.trim()
   if (!message) return
+  const newest = diagnostics.value[0]
+  if (
+    newest &&
+    newest.kind === input.kind &&
+    newest.message === message &&
+    newest.url === input.url &&
+    newest.method === input.method &&
+    newest.status === input.status
+  ) {
+    return
+  }
 
   const next: FeedbackDiagnostic = {
     ...input,

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -2,12 +2,6 @@ import { computed, ref } from 'vue'
 
 const FEEDBACK_EMAIL = 'brutalstrikedevs@gmail.com'
 const MAX_DIAGNOSTICS = 20
-const MAX_BODY_CHARS = 6500
-const MAX_PAGE_TEXT_CHARS = 1800
-const MAX_STORAGE_ITEMS = 12
-const MAX_STORAGE_VALUE_CHARS = 240
-
-const SENSITIVE_STORAGE_PATTERN = /token|secret|password|passwd|credential|authorization|auth|bearer|cookie|session|key/i
 
 export type FeedbackDiagnosticKind = 'window-error' | 'unhandled-rejection' | 'fetch-error' | 'api-response' | 'visible-error'
 
@@ -64,35 +58,26 @@ function readVisiblePageText(): string {
     .replace(/\n{3,}/g, '\n\n')
     .trim() ?? ''
   if (!text) return 'No visible page text captured.'
-  return text.length > MAX_PAGE_TEXT_CHARS
-    ? `${text.slice(0, MAX_PAGE_TEXT_CHARS)}\n...[truncated]`
-    : text
+  return text
 }
 
-function redactStorageValue(key: string, value: string): string {
-  if (SENSITIVE_STORAGE_PATTERN.test(key) || SENSITIVE_STORAGE_PATTERN.test(value)) return '[redacted]'
-  const normalized = value
+function normalizeStorageValue(value: string): string {
+  return value
     .replace(/\r\n/g, '\n')
     .replace(/[ \t]+/g, ' ')
     .trim()
-  if (!normalized) return ''
-  return normalized.length > MAX_STORAGE_VALUE_CHARS
-    ? `${normalized.slice(0, MAX_STORAGE_VALUE_CHARS)}...[truncated]`
-    : normalized
 }
 
 function readStorageSnapshot(storage: Storage | undefined, label: string): string {
   if (!storage) return `${label}: unavailable`
   try {
     const rows: string[] = []
-    const length = Math.min(storage.length, MAX_STORAGE_ITEMS)
-    for (let index = 0; index < length; index += 1) {
+    for (let index = 0; index < storage.length; index += 1) {
       const key = storage.key(index)
       if (!key) continue
-      rows.push(`${key}=${redactStorageValue(key, storage.getItem(key) ?? '')}`)
+      rows.push(`${key}=${normalizeStorageValue(storage.getItem(key) ?? '')}`)
     }
-    const suffix = storage.length > MAX_STORAGE_ITEMS ? `\n...${storage.length - MAX_STORAGE_ITEMS} more item(s)` : ''
-    return `${label}:\n${rows.join('\n') || 'empty'}${suffix}`
+    return `${label}:\n${rows.join('\n') || 'empty'}`
   } catch (error) {
     return `${label}: unavailable (${normalizeSubjectMessage(normalizeMessage(error))})`
   }
@@ -173,7 +158,7 @@ export function buildFeedbackMailto(entries: FeedbackDiagnostic[] = diagnostics.
     '',
     'Visible page text',
     readVisiblePageText(),
-  ].join('\n').slice(0, MAX_BODY_CHARS)
+  ].join('\n')
 
   const params = new URLSearchParams({
     subject: `Codex Web feedback: ${normalizeSubjectMessage(entries[0]?.message)}`,

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -4,6 +4,10 @@ const FEEDBACK_EMAIL = 'brutalstrikedevs@gmail.com'
 const MAX_DIAGNOSTICS = 20
 const MAX_BODY_CHARS = 6500
 const MAX_PAGE_TEXT_CHARS = 1800
+const MAX_STORAGE_ITEMS = 12
+const MAX_STORAGE_VALUE_CHARS = 240
+
+const SENSITIVE_STORAGE_PATTERN = /token|secret|password|passwd|credential|authorization|auth|bearer|cookie|session|key/i
 
 export type FeedbackDiagnosticKind = 'window-error' | 'unhandled-rejection' | 'fetch-error' | 'api-response' | 'visible-error'
 
@@ -65,6 +69,49 @@ function readVisiblePageText(): string {
     : text
 }
 
+function redactStorageValue(key: string, value: string): string {
+  if (SENSITIVE_STORAGE_PATTERN.test(key) || SENSITIVE_STORAGE_PATTERN.test(value)) return '[redacted]'
+  const normalized = value
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .trim()
+  if (!normalized) return ''
+  return normalized.length > MAX_STORAGE_VALUE_CHARS
+    ? `${normalized.slice(0, MAX_STORAGE_VALUE_CHARS)}...[truncated]`
+    : normalized
+}
+
+function readStorageSnapshot(storage: Storage | undefined, label: string): string {
+  if (!storage) return `${label}: unavailable`
+  try {
+    const rows: string[] = []
+    const length = Math.min(storage.length, MAX_STORAGE_ITEMS)
+    for (let index = 0; index < length; index += 1) {
+      const key = storage.key(index)
+      if (!key) continue
+      rows.push(`${key}=${redactStorageValue(key, storage.getItem(key) ?? '')}`)
+    }
+    const suffix = storage.length > MAX_STORAGE_ITEMS ? `\n...${storage.length - MAX_STORAGE_ITEMS} more item(s)` : ''
+    return `${label}:\n${rows.join('\n') || 'empty'}${suffix}`
+  } catch (error) {
+    return `${label}: unavailable (${normalizeSubjectMessage(normalizeMessage(error))})`
+  }
+}
+
+function readBrowserStateSnapshot(): string {
+  if (typeof window === 'undefined') return 'unknown'
+  return [
+    `Path: ${window.location.pathname || '/'}`,
+    `Hash: ${window.location.hash || '(none)'}`,
+    `Search: ${window.location.search || '(none)'}`,
+    `Online: ${typeof navigator === 'undefined' ? 'unknown' : String(navigator.onLine)}`,
+    `Language: ${typeof navigator === 'undefined' ? 'unknown' : navigator.language}`,
+    `Platform: ${typeof navigator === 'undefined' ? 'unknown' : navigator.platform}`,
+    readStorageSnapshot(window.localStorage, 'localStorage'),
+    readStorageSnapshot(window.sessionStorage, 'sessionStorage'),
+  ].join('\n')
+}
+
 export function recordFeedbackDiagnostic(input: Omit<FeedbackDiagnostic, 'atIso'> & { atIso?: string }): void {
   const message = input.message.trim()
   if (!message) return
@@ -117,6 +164,9 @@ export function buildFeedbackMailto(entries: FeedbackDiagnostic[] = diagnostics.
     `Viewport: ${viewport}`,
     `App version: ${appVersion}`,
     `Worktree: ${worktreeName}`,
+    '',
+    'Browser/app state',
+    readBrowserStateSnapshot(),
     '',
     'Recent diagnostics',
     recentDiagnostics || 'No diagnostics captured.',

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -142,34 +142,57 @@ export function installFeedbackDiagnostics(): void {
   }
 
   if (!fetchInstalled) {
-    fetchInstalled = true
-    originalFetch = window.fetch.bind(window)
-    window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = normalizeFetchUrl(input)
-      const method = normalizeFetchMethod(input, init)
-      try {
-        const response = await originalFetch!(input, init)
-        if (!response.ok) {
+    if (typeof window.fetch !== 'function') {
+      recordFeedbackDiagnostic({
+        kind: 'fetch-error',
+        message: 'Feedback diagnostics could not monitor fetch: window.fetch is unavailable',
+        url: window.location.href,
+      })
+      return
+    }
+
+    try {
+      originalFetch = window.fetch.bind(window)
+      window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = normalizeFetchUrl(input)
+        const method = normalizeFetchMethod(input, init)
+        try {
+          const response = await originalFetch!(input, init)
+          if (!response.ok) {
+            recordFeedbackDiagnostic({
+              kind: url.includes('/codex-api/') ? 'api-response' : 'fetch-error',
+              message: `Request failed with HTTP ${response.status}`,
+              url,
+              method,
+              status: response.status,
+              statusText: response.statusText,
+            })
+          }
+          return response
+        } catch (error) {
           recordFeedbackDiagnostic({
-            kind: url.includes('/codex-api/') ? 'api-response' : 'fetch-error',
-            message: `Request failed with HTTP ${response.status}`,
+            kind: 'fetch-error',
+            message: normalizeMessage(error),
             url,
             method,
-            status: response.status,
-            statusText: response.statusText,
           })
+          throw error
         }
-        return response
-      } catch (error) {
+      }) as typeof window.fetch
+      fetchInstalled = true
+    } catch (error) {
+      originalFetch = null
+      fetchInstalled = false
+      try {
         recordFeedbackDiagnostic({
           kind: 'fetch-error',
-          message: normalizeMessage(error),
-          url,
-          method,
+          message: `Feedback diagnostics could not monitor fetch: ${normalizeMessage(error)}`,
+          url: window.location.href,
         })
-        throw error
+      } catch {
+        // Startup diagnostics must never prevent the app from mounting.
       }
-    }) as typeof window.fetch
+    }
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -311,6 +311,10 @@
   @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
 }
 
+:root.dark .header-git-feedback {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
+}
+
 :root.dark .composer-dropdown-trigger {
   @apply text-zinc-400;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -307,6 +307,10 @@
   @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
 }
 
+:root.dark .live-overlay-feedback {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
+}
+
 :root.dark .composer-dropdown-trigger {
   @apply text-zinc-400;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -203,6 +203,10 @@
   @apply text-zinc-500;
 }
 
+:root.dark .thread-tree-action-error {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100;
+}
+
 :root.dark .section-toggle-row {
   @apply hover:bg-zinc-800 focus-visible:ring-zinc-600;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -303,6 +303,10 @@
   @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
 }
 
+:root.dark .skills-error-feedback {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
+}
+
 :root.dark .composer-dropdown-trigger {
   @apply text-zinc-400;
 }

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,38 @@ Rollback/cleanup:
 
 ---
 
+### Qodo feedback diagnostics reliability fixes
+
+#### Feature/Change Name
+Feedback diagnostics startup hardening, project automation delete failure handling, and coalesced composer overflow measurement.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. At least one sidebar project with a configured project automation
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, temporarily make `DELETE /codex-api/project-automation` fail, for example by stopping the local API bridge or forcing a 500 response in a development proxy.
+2. Open the project menu for a project with an automation and click Remove.
+3. Confirm the sidebar does not trigger an unhandled promise rejection and shows a small project automation error message.
+4. Restore the API bridge and refresh project automations.
+5. Confirm the automation chip/server state is reloaded instead of staying optimistically removed.
+6. Open the app in an environment where `window.fetch` is missing or read-only and confirm the app still mounts.
+7. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
+8. Switch to dark theme and repeat steps 2-7.
+
+#### Expected Results
+- Project automation delete failures are caught, recorded in feedback diagnostics, and surfaced as a visible sidebar error.
+- Automation state is restored or reloaded after a failed delete.
+- Feedback diagnostics never prevent app startup when fetch cannot be patched.
+- Composer overflow checks remain functional without scheduling duplicate same-tick measurements.
+- The sidebar error message remains readable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Restore any temporary API failure/proxy change.
+
+---
+
 ### Composer expands long drafts to full screen
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -353,13 +353,16 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 4. Restore the API bridge and refresh project automations.
 5. Confirm the automation chip/server state is reloaded instead of staying optimistically removed.
 6. Open the app in an environment where `window.fetch` is missing or read-only and confirm the app still mounts.
-7. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
-8. Switch to dark theme and repeat steps 2-7.
+7. Trigger a chat send failure and click Send feedback next to the chat error.
+8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com` and diagnostics prefilled.
+9. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
+10. Switch to dark theme and repeat steps 2-9.
 
 #### Expected Results
 - Project automation delete failures are caught, recorded in feedback diagnostics, and surfaced as a visible sidebar error.
 - Automation state is restored or reloaded after a failed delete.
 - Feedback diagnostics never prevent app startup when fetch cannot be patched.
+- Chat and Skills Hub error feedback links use native `mailto:` anchor handling so Chrome can open the configured email handler.
 - Composer overflow checks remain functional without scheduling duplicate same-tick measurements.
 - The sidebar error message remains readable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -354,7 +354,7 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 5. Confirm the automation chip/server state is reloaded instead of staying optimistically removed.
 6. Open the app in an environment where `window.fetch` is missing or read-only and confirm the app still mounts.
 7. Trigger a chat send failure and click Send feedback next to the chat error.
-8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com`, diagnostics, and bounded visible page text prefilled.
+8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com`, diagnostics, bounded visible page text, and redacted browser/app state prefilled.
 9. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
 10. Switch to dark theme and repeat steps 2-9.
 
@@ -364,6 +364,7 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 - Feedback diagnostics never prevent app startup when fetch cannot be patched.
 - Chat and Skills Hub error feedback links use native `mailto:` anchor handling so Chrome can open the configured email handler.
 - Feedback email bodies include bounded visible page text alongside diagnostics.
+- Feedback email bodies include bounded localStorage/sessionStorage state, route/hash, online state, language, and platform, with sensitive-looking keys and values redacted.
 - Composer overflow checks remain functional without scheduling duplicate same-tick measurements.
 - The sidebar error message remains readable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -380,7 +380,7 @@ Feedback action appears in Settings and on visible error banners after captured 
 1. In light theme, load the home screen, open Settings, and confirm no `Send feedback` row is visible during a clean state.
 2. Trigger a failure, for example run `fetch('/codex-api/rpc', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })` in the browser console or open a folder path that produces a visible load error.
 3. Reopen Settings and confirm a `Send feedback` row with `Issue detected` appears after the failed request is recorded.
-4. Trigger or view a visible error banner, such as the missing Codex CLI composer banner, a settings provider error, a folder picker error, a Skills Hub error, or a branch dropdown error, and confirm that error state includes a compact `Send feedback` action.
+4. Trigger or view a visible error banner, such as the missing Codex CLI composer banner, a chat send/connection error in the live conversation overlay, a settings provider error, a folder picker error, a Skills Hub error, or a branch dropdown error, and confirm that error state includes a compact `Send feedback` action.
 5. Confirm no feedback action appears in the content header during normal use.
 6. Click `Send feedback` and confirm the mail client opens a draft to `brutalstrikedevs@gmail.com`.
 7. Confirm the draft body includes current URL, user agent, viewport, app/worktree version info, and recent diagnostics including the failed request or visible error.
@@ -389,7 +389,7 @@ Feedback action appears in Settings and on visible error banners after captured 
 #### Expected Results
 - The settings feedback action is absent during normal operation.
 - Runtime errors, unhandled rejections, failed fetches/API responses, and visible load failures make the Settings feedback action visible.
-- Visible error states include a local `Send feedback` action so the user can report the error from the same context.
+- Visible error states, including chat send/connection failures, include a local `Send feedback` action so the user can report the error from the same context.
 - The generated `mailto:` draft is prefilled with useful diagnostics and does not submit anything automatically.
 - No feedback action is shown in the app header during normal use.
 - The Settings feedback row and visible-error feedback actions remain readable in light and dark themes.

--- a/tests.md
+++ b/tests.md
@@ -354,7 +354,7 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 5. Confirm the automation chip/server state is reloaded instead of staying optimistically removed.
 6. Open the app in an environment where `window.fetch` is missing or read-only and confirm the app still mounts.
 7. Trigger a chat send failure and click Send feedback next to the chat error.
-8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com`, diagnostics, bounded visible page text, and redacted browser/app state prefilled.
+8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com`, diagnostics, visible page text, and browser/app state prefilled.
 9. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
 10. Switch to dark theme and repeat steps 2-9.
 
@@ -363,8 +363,8 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 - Automation state is restored or reloaded after a failed delete.
 - Feedback diagnostics never prevent app startup when fetch cannot be patched.
 - Chat and Skills Hub error feedback links use native `mailto:` anchor handling so Chrome can open the configured email handler.
-- Feedback email bodies include bounded visible page text alongside diagnostics.
-- Feedback email bodies include bounded localStorage/sessionStorage state, route/hash, online state, language, and platform, with sensitive-looking keys and values redacted.
+- Feedback email bodies include visible page text alongside diagnostics.
+- Feedback email bodies include localStorage/sessionStorage state, route/hash, online state, language, and platform without redaction or per-section truncation.
 - Composer overflow checks remain functional without scheduling duplicate same-tick measurements.
 - The sidebar error message remains readable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -354,7 +354,7 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 5. Confirm the automation chip/server state is reloaded instead of staying optimistically removed.
 6. Open the app in an environment where `window.fetch` is missing or read-only and confirm the app still mounts.
 7. Trigger a chat send failure and click Send feedback next to the chat error.
-8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com` and diagnostics prefilled.
+8. Confirm Chrome or the OS opens the configured `mailto:` handler with `brutalstrikedevs@gmail.com`, diagnostics, and bounded visible page text prefilled.
 9. Type a long draft in the composer and confirm the expand control still appears when the textarea overflows.
 10. Switch to dark theme and repeat steps 2-9.
 
@@ -363,6 +363,7 @@ Feedback diagnostics startup hardening, project automation delete failure handli
 - Automation state is restored or reloaded after a failed delete.
 - Feedback diagnostics never prevent app startup when fetch cannot be patched.
 - Chat and Skills Hub error feedback links use native `mailto:` anchor handling so Chrome can open the configured email handler.
+- Feedback email bodies include bounded visible page text alongside diagnostics.
 - Composer overflow checks remain functional without scheduling duplicate same-tick measurements.
 - The sidebar error message remains readable in light theme and dark theme.
 


### PR DESCRIPTION
## Summary
- show a chat-visible error when the Codex CLI is missing
- collect runtime, unhandled rejection, failed fetch/API, and visible-error diagnostics
- expose feedback from Settings after failures and directly on visible error states

## Verification
- pnpm exec vitest run src/composables/useFeedbackDiagnostics.test.ts src/composables/useDesktopState.test.ts
- pnpm run build:frontend
- Playwright forced visible Skills Hub error: Send feedback appeared with mailto diagnostics
- PROFILE_BASE_URL=http://127.0.0.1:4175 PROFILE_WAIT_MS=7000 pnpm run profile:browser