### PR TITLE
Handle item/reasoning/textDelta notifications

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -3083,7 +3083,8 @@ export function useDesktopState() {
 
     if (
       notification.method === 'item/reasoning/summaryTextDelta' ||
-      notification.method === 'item/reasoning/summaryPartAdded'
+      notification.method === 'item/reasoning/summaryPartAdded' ||
+      notification.method === 'item/reasoning/textDelta'
     ) {
       return {
         threadId,
@@ -3260,6 +3261,17 @@ export function useDesktopState() {
 
     // Канонический источник дельт для UI — уже нормализованный item/*.
     if (notification.method === 'item/reasoning/summaryTextDelta') {
+      const itemId = readString(params.itemId)
+      const delta = readString(params.delta)
+      if (!itemId || !delta) return null
+      return { messageId: liveReasoningMessageId(itemId), delta }
+    }
+
+    // codex also emits the full reasoning-chain stream as item/reasoning/textDelta
+    // (alongside the summary stream). Without handling it, reasoning text the
+    // model streams via this channel is dropped and the UI shows only the
+    // summary, making long thinking phases look like a stall.
+    if (notification.method === 'item/reasoning/textDelta') {
       const itemId = readString(params.itemId)
       const delta = readString(params.delta)
       if (!itemId || !delta) return null


### PR DESCRIPTION
## Problem

codex emits the full reasoning-chain stream as `item/reasoning/textDelta` in addition to the `item/reasoning/summaryTextDelta` summary stream. `useDesktopState.ts` only recognises the summary variant, so reasoning text streamed via the `textDelta` channel is dropped — the UI shows only the summary, which makes long thinking phases look like a stall ("Thinking…" with no streaming text for tens of seconds).

## Change

Add the `item/reasoning/textDelta` variant to:
- `readReasoningDelta()` — same params shape as the existing summary handler (`{ itemId, delta }`), routed to `liveReasoningTextByThreadId` via `liveReasoningMessageId(itemId)`
- the `Thinking` activity recognition (so the activity label still flips correctly)

Both additions mirror the existing `summaryTextDelta` handling exactly — no new code paths, just one more recognised method name in each spot.

## Notes

- 13 insertions / 1 deletion, all in `src/composables/useDesktopState.ts`.
- Verified against codex 0.130 (`item/reasoning/textDelta` is in the app-server protocol; gpt-5.x with `model_reasoning_summary = "detailed"` is the common trigger for the channel carrying content).
- No behaviour change for existing summary-only sessions — the extra branch only fires on the new method name.