### PR TITLE
Add fullscreen composer expansion

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -880,6 +880,9 @@
               </div>
 
               <div class="composer-with-queue">
+                <div v-if="codexCliMissingError" class="composer-runtime-error" role="alert">
+                  {{ t(codexCliMissingError) }}
+                </div>
                 <ThreadTerminalPanel
                   v-if="homeTerminalOpen && composerCwd"
                   ref="homeTerminalPanelRef"
@@ -939,6 +942,9 @@
                 </div>
 
                 <div class="composer-with-queue">
+                  <div v-if="codexCliMissingError" class="composer-runtime-error" role="alert">
+                    {{ t(codexCliMissingError) }}
+                  </div>
                   <QueuedMessages
                     :messages="selectedThreadQueuedMessages"
                     @edit="onEditQueuedMessage"
@@ -1316,6 +1322,7 @@ const {
   selectedModelId,
   selectedReasoningEffort,
   selectedSpeedMode,
+  codexCliMissingError,
   installedSkills,
   accountRateLimitSnapshots,
   messages,
@@ -4608,6 +4615,10 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .composer-with-queue {
   @apply w-full shrink-0 px-2 sm:px-6 flex flex-col gap-2;
+}
+
+.composer-runtime-error {
+  @apply w-full rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-800 shadow-sm;
 }
 
 .content-thread-terminal-panel {

--- a/src/App.vue
+++ b/src/App.vue
@@ -136,7 +136,10 @@
                   </button>
                 </div>
                 <template v-if="!isAccountsSectionCollapsed">
-                  <p v-if="accountActionError" class="sidebar-settings-account-error">{{ accountActionError }}</p>
+                  <div v-if="accountActionError" class="sidebar-settings-account-error visible-error-with-feedback">
+                    <span>{{ accountActionError }}</span>
+                    <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+                  </div>
                   <div class="sidebar-settings-account-login">
                     <button
                       class="sidebar-settings-account-login-button"
@@ -246,6 +249,14 @@
                 <span class="sidebar-settings-label">{{ t('Auto send dictation') }}</span>
                 <span class="sidebar-settings-toggle" :class="{ 'is-on': dictationAutoSend }" />
               </button>
+              <a
+                v-if="hasFeedbackDiagnostics"
+                class="sidebar-settings-row sidebar-settings-feedback-row"
+                :href="feedbackMailto"
+              >
+                <span class="sidebar-settings-label">{{ t('Send feedback') }}</span>
+                <span class="sidebar-settings-value">{{ t('Issue detected') }}</span>
+              </a>
 
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the API provider for the Codex backend')">
                 <span class="sidebar-settings-label">{{ t('Provider') }}</span>
@@ -262,7 +273,8 @@
                 </select>
               </div>
               <div v-if="providerError" class="sidebar-settings-row sidebar-settings-error">
-                {{ providerError }}
+                <span>{{ providerError }}</span>
+                <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
               </div>
               <div v-if="selectedProvider === 'openrouter'" class="sidebar-settings-row sidebar-settings-row--input">
                 <div class="sidebar-settings-provider-info">
@@ -443,7 +455,8 @@
                   {{ t('Put one Telegram user ID per line or separate them with commas. Use `*` to allow all Telegram users. Unauthorized users will see their own ID in the rejection message so they can copy it here.') }}
                 </div>
                 <div v-if="telegramConfigError" class="sidebar-settings-telegram-error">
-                  {{ telegramConfigError }}
+                  <span>{{ telegramConfigError }}</span>
+                  <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
                 </div>
                 <div class="sidebar-settings-telegram-actions">
                   <button
@@ -702,7 +715,10 @@
                             {{ createFolderSubmitLabel }}
                           </button>
                         </div>
-                        <p v-if="createFolderError" class="new-thread-open-folder-error">{{ createFolderError }}</p>
+                        <div v-if="createFolderError" class="new-thread-open-folder-error visible-error-with-feedback">
+                          <span>{{ createFolderError }}</span>
+                          <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+                        </div>
                       </div>
                       <input
                         ref="existingFolderFilterInputRef"
@@ -713,7 +729,10 @@
                         @keydown.esc.prevent="onCloseExistingFolderPanel"
                       />
                       <div v-if="existingFolderError" class="new-thread-open-folder-error-actions">
-                        <p class="new-thread-open-folder-error">{{ existingFolderError }}</p>
+                        <div class="new-thread-open-folder-error visible-error-with-feedback">
+                          <span>{{ existingFolderError }}</span>
+                          <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+                        </div>
                         <button
                           class="new-thread-folder-action"
                           type="button"
@@ -819,7 +838,10 @@
                           @keydown.enter.prevent="onSubmitProjectSetup"
                         />
                       </label>
-                      <p v-if="projectSetupError" class="new-thread-open-folder-error">{{ projectSetupError }}</p>
+                      <div v-if="projectSetupError" class="new-thread-open-folder-error visible-error-with-feedback">
+                        <span>{{ projectSetupError }}</span>
+                        <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+                      </div>
                       <div class="new-thread-project-modal-actions">
                         <button class="new-thread-folder-action" type="button" :disabled="isProjectSetupSubmitting" @click="onCloseProjectSetupModal">
                           {{ t('Cancel') }}
@@ -881,7 +903,8 @@
 
               <div class="composer-with-queue">
                 <div v-if="codexCliMissingError" class="composer-runtime-error" role="alert">
-                  {{ t(codexCliMissingError) }}
+                  <span>{{ t(codexCliMissingError) }}</span>
+                  <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
                 </div>
                 <ThreadTerminalPanel
                   v-if="homeTerminalOpen && composerCwd"
@@ -943,7 +966,8 @@
 
                 <div class="composer-with-queue">
                   <div v-if="codexCliMissingError" class="composer-runtime-error" role="alert">
-                    {{ t(codexCliMissingError) }}
+                    <span>{{ t(codexCliMissingError) }}</span>
+                    <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
                   </div>
                   <QueuedMessages
                     :messages="selectedThreadQueuedMessages"
@@ -1050,7 +1074,10 @@
         :placeholder="t('Paste localhost callback URL')"
         :disabled="isCompletingCodexLogin"
       >
-      <p v-if="accountActionError" class="codex-login-modal-error">{{ accountActionError }}</p>
+      <div v-if="accountActionError" class="codex-login-modal-error visible-error-with-feedback">
+        <span>{{ accountActionError }}</span>
+        <a class="visible-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+      </div>
       <div class="codex-login-modal-actions">
         <button
           class="codex-login-modal-cancel"
@@ -1094,6 +1121,7 @@ import IconTablerX from './components/icons/IconTablerX.vue'
 import { useDesktopState } from './composables/useDesktopState'
 import { useMobile } from './composables/useMobile'
 import { useUiLanguage } from './composables/useUiLanguage'
+import { useFeedbackDiagnostics } from './composables/useFeedbackDiagnostics'
 import {
   checkoutGitBranch,
   cloneGithubRepository,
@@ -1335,6 +1363,7 @@ const {
   isInterruptingTurn,
   isSelectedThreadInterruptPending,
   isUpdatingSpeedMode,
+  error: desktopError,
   refreshAll,
   refreshSkills,
   selectThread,
@@ -1387,6 +1416,12 @@ type AutomationEditRequest = {
 }
 const sidebarThreadTreeRef = ref<SidebarThreadTreeExposed | null>(null)
 const automationsPanelRef = ref<AutomationsPanelExposed | null>(null)
+const {
+  hasFeedbackDiagnostics,
+  buildFeedbackMailto,
+  recordVisibleFailure,
+} = useFeedbackDiagnostics()
+const feedbackMailto = computed(() => buildFeedbackMailto())
 const homeThreadComposerRef = ref<ThreadComposerExposed | null>(null)
 const threadComposerRef = ref<ThreadComposerExposed | null>(null)
 const threadConversationRef = ref<{ jumpToLatest: () => void } | null>(null)
@@ -1525,6 +1560,18 @@ const isExistingFolderLoading = ref(false)
 const isOpeningExistingFolder = ref(false)
 const showHiddenFolders = ref(false)
 const existingFolderFilter = ref('')
+const visibleFeedbackErrors = [
+  desktopError,
+  codexCliMissingError,
+  threadBranchError,
+  threadBranchCommitsError,
+  accountActionError,
+  providerError,
+  telegramConfigError,
+  createFolderError,
+  projectSetupError,
+  existingFolderError,
+]
 const telegramStatus = ref<TelegramStatus>({
   configured: false,
   active: false,
@@ -1963,6 +2010,15 @@ onMounted(() => {
   void loadFreeModeStatus()
   void refreshThreadTerminalStatus()
   void refreshTerminalQuickCommands()
+})
+
+watch(visibleFeedbackErrors, (values) => {
+  for (const value of values) {
+    const message = value.trim()
+    if (message) {
+      recordVisibleFailure(message)
+    }
+  }
 })
 
 onUnmounted(() => {
@@ -4618,7 +4674,15 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 }
 
 .composer-runtime-error {
-  @apply w-full rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-800 shadow-sm;
+  @apply flex w-full items-start justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-800 shadow-sm;
+}
+
+.visible-error-with-feedback {
+  @apply flex items-start justify-between gap-3;
+}
+
+.visible-error-feedback {
+  @apply shrink-0 rounded-full border border-rose-200 bg-white px-2.5 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-300;
 }
 
 .content-thread-terminal-panel {

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -28,7 +28,8 @@
         </div>
 
         <div v-if="statusMessage" class="header-git-status" :class="{ 'is-error': statusKind === 'error' }">
-          {{ statusMessage }}
+          <span>{{ statusMessage }}</span>
+          <a v-if="statusKind === 'error'" class="header-git-feedback" :href="feedbackMailto">Send feedback</a>
         </div>
 
         <div class="header-git-search-wrap">
@@ -68,7 +69,10 @@
 
             <div v-if="expandedBranch === branch.value" class="header-git-commits">
               <div v-if="commitsLoadingFor === branch.value" class="header-git-commits-empty">Loading commits...</div>
-              <div v-else-if="commitsError" class="header-git-commits-empty is-error">{{ commitsError }}</div>
+              <div v-else-if="commitsError" class="header-git-commits-empty is-error">
+                <span>{{ commitsError }}</span>
+                <a class="header-git-feedback" :href="feedbackMailto">Send feedback</a>
+              </div>
               <button
                 v-for="commit in commitsByBranch[branch.value] || []"
                 :key="commit.sha"
@@ -110,6 +114,7 @@ import IconTablerChevronDown from '../icons/IconTablerChevronDown.vue'
 import IconTablerChevronRight from '../icons/IconTablerChevronRight.vue'
 import IconTablerFilePencil from '../icons/IconTablerFilePencil.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
+import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 
 const props = defineProps<{
   currentBranch: string | null
@@ -142,6 +147,8 @@ const isOpen = ref(false)
 const searchQuery = ref('')
 const expandedBranch = ref('')
 const showReview = computed(() => props.showReview !== false)
+const { buildFeedbackMailto } = useFeedbackDiagnostics()
+const feedbackMailto = computed(() => buildFeedbackMailto())
 
 const displayLabel = computed(() => {
   if (props.currentBranch) return props.currentBranch
@@ -280,7 +287,7 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onDocumentPointe
 }
 
 .header-git-status {
-  @apply mx-1 my-1 rounded-lg bg-amber-50 px-2 py-1.5 text-xs text-amber-800;
+  @apply mx-1 my-1 flex items-start justify-between gap-2 rounded-lg bg-amber-50 px-2 py-1.5 text-xs text-amber-800;
 }
 
 .header-git-status.is-error {
@@ -366,6 +373,10 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onDocumentPointe
 }
 
 .header-git-commits-empty.is-error {
-  @apply text-red-700;
+  @apply flex items-start justify-between gap-2 text-red-700;
+}
+
+.header-git-feedback {
+  @apply shrink-0 rounded-full border border-red-200 bg-white px-2 py-0.5 text-[0.65rem] font-semibold text-red-700 transition hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-200;
 }
 </style>

--- a/src/components/content/SkillsHub.vue
+++ b/src/components/content/SkillsHub.vue
@@ -26,13 +26,15 @@
         <span>{{ t('Action') }}: {{ syncStatus.startup.lastAction }}</span>
       </div>
       <div v-if="syncStatus.startup.lastError" class="skills-sync-error">
-        {{ syncStatus.startup.lastError }}
+        <span>{{ syncStatus.startup.lastError }}</span>
+        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="syncActionStatus" class="skills-sync-meta">
         <span>{{ t('Manual sync') }}: {{ syncActionStatus }}</span>
       </div>
       <div v-if="syncActionError" class="skills-sync-error">
-        {{ syncActionError }}
+        <span>{{ syncActionError }}</span>
+        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
       </div>
       <div v-if="deviceLogin" class="skills-sync-device">
         <span>{{ t('Open') }} <a :href="deviceLogin.verification_uri" target="_blank" rel="noreferrer">{{ t('GitHub device login') }}</a> {{ t('and enter code:') }}</span>
@@ -77,7 +79,10 @@
           {{ isSearchingSkills ? t('Searching...') : t('Search') }}
         </button>
       </form>
-      <div v-if="skillSearchError" class="skills-hub-error">{{ skillSearchError }}</div>
+      <div v-if="skillSearchError" class="skills-hub-error">
+        <span>{{ skillSearchError }}</span>
+        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+      </div>
     </div>
 
     <div v-if="skillSearchResults.length > 0" class="skills-hub-section">
@@ -117,7 +122,10 @@
 
     <div class="skills-hub-section">
       <div v-if="isLoading" class="skills-hub-loading">{{ t('Loading skills...') }}</div>
-      <div v-else-if="error" class="skills-hub-error">{{ error }}</div>
+      <div v-else-if="error" class="skills-hub-error">
+        <span>{{ error }}</span>
+        <a class="skills-error-feedback" :href="feedbackMailto">{{ t('Send feedback') }}</a>
+      </div>
       <div v-else-if="installedSkills.length === 0" class="skills-hub-empty">{{ t('No installed skills found.') }}</div>
     </div>
 
@@ -142,6 +150,7 @@ import IconTablerChevronRight from '../icons/IconTablerChevronRight.vue'
 import SkillCard from './SkillCard.vue'
 import SkillDetailModal, { type HubSkill } from './SkillDetailModal.vue'
 import { useGithubSkillsSync } from '../../composables/useGithubSkillsSync'
+import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 
 const EMPTY_SKILL: HubSkill = { name: '', owner: '', description: '', url: '', installed: false }
@@ -165,6 +174,8 @@ const isInstallActionInFlight = ref(false)
 const isUninstallActionInFlight = ref(false)
 let toastTimer: ReturnType<typeof setTimeout> | null = null
 const { t } = useUiLanguage()
+const { buildFeedbackMailto } = useFeedbackDiagnostics()
+const feedbackMailto = computed(() => buildFeedbackMailto())
 
 const props = defineProps<{
   tryInFlightKey?: string
@@ -434,7 +445,7 @@ onMounted(() => {
 }
 
 .skills-sync-error {
-  @apply text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-md px-2 py-1;
+  @apply flex items-start justify-between gap-3 text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-md px-2 py-1;
 }
 
 .skills-sync-actions {
@@ -510,7 +521,15 @@ onMounted(() => {
 }
 
 .skills-hub-error {
-  @apply text-sm text-rose-600 py-4 text-center rounded-lg border border-rose-200 bg-rose-50;
+  @apply flex items-start justify-between gap-3 text-sm text-rose-600 p-4 text-left rounded-lg border border-rose-200 bg-rose-50;
+}
+
+.skills-error-feedback {
+  @apply shrink-0 rounded-full border border-rose-200 bg-white px-2.5 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-300;
+}
+
+:global(:root.dark) .skills-error-feedback {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
 }
 
 .skills-hub-empty {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -84,7 +84,10 @@
 
       <div
         class="thread-composer-input-wrap"
-        :class="{ 'thread-composer-input-wrap--drag-active': isDragActive }"
+        :class="{
+          'thread-composer-input-wrap--drag-active': isDragActive,
+          'thread-composer-input-wrap--expanded': isComposerExpanded,
+        }"
         @dragenter="onInputDragEnter"
         @dragover="onInputDragOver"
         @dragleave="onInputDragLeave"
@@ -130,6 +133,18 @@
           @keydown="onInputKeydown"
           @paste="onInputPaste"
         />
+        <button
+          v-if="hasExpandedComposerToggle"
+          class="thread-composer-expand"
+          type="button"
+          :aria-label="isComposerExpanded ? t('Exit full screen composer') : t('Expand composer')"
+          :title="isComposerExpanded ? t('Exit full screen composer') : t('Expand composer')"
+          :disabled="isInteractionDisabled"
+          @click="toggleComposerExpanded"
+        >
+          <IconTablerMinimize v-if="isComposerExpanded" class="thread-composer-expand-icon" />
+          <IconTablerMaximize v-else class="thread-composer-expand-icon" />
+        </button>
       </div>
 
       <div
@@ -402,7 +417,9 @@ import IconTablerArrowUp from '../icons/IconTablerArrowUp.vue'
 import IconTablerBolt from '../icons/IconTablerBolt.vue'
 import IconTablerFilePencil from '../icons/IconTablerFilePencil.vue'
 import IconTablerFolder from '../icons/IconTablerFolder.vue'
+import IconTablerMaximize from '../icons/IconTablerMaximize.vue'
 import IconTablerMicrophone from '../icons/IconTablerMicrophone.vue'
+import IconTablerMinimize from '../icons/IconTablerMinimize.vue'
 import IconTablerPlayerStopFilled from '../icons/IconTablerPlayerStopFilled.vue'
 import ComposerDropdown from './ComposerDropdown.vue'
 import ComposerSearchDropdown from './ComposerSearchDropdown.vue'
@@ -555,6 +572,8 @@ const mentionQuery = ref('')
 const fileMentionSuggestions = ref<ComposerFileSuggestion[]>([])
 const isFileMentionOpen = ref(false)
 const fileMentionHighlightedIndex = ref(0)
+const isComposerExpanded = ref(false)
+const isDraftOverflowing = ref(false)
 const draftGeneration = ref(0)
 let fileMentionSearchToken = 0
 let fileMentionDebounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -703,6 +722,10 @@ const placeholderText = computed(() =>
 )
 const hasSubmitContent = computed(() =>
   draft.value.trim().length > 0 || selectedImages.value.length > 0 || fileAttachments.value.length > 0,
+)
+const draftLineCount = computed(() => draft.value.split('\n').length)
+const hasExpandedComposerToggle = computed(() =>
+  isComposerExpanded.value || draftLineCount.value >= 6 || isDraftOverflowing.value,
 )
 const quotaSummaryText = computed(() => buildQuotaSummaryText(props.codexQuota ?? null))
 const quotaWeeklyRefreshText = computed(() => '')
@@ -940,6 +963,7 @@ function onSubmit(mode: 'steer' | 'queue' = 'steer'): void {
   })
   clearPersistedDraftForThread(props.activeThreadId)
   clearDraftState()
+  isComposerExpanded.value = false
   folderUploadGroups.value = []
   isAttachMenuOpen.value = false
   closeFileMention()
@@ -983,6 +1007,7 @@ function clearDraftState(): void {
     fileAttachments: [],
     skills: [],
   })
+  isComposerExpanded.value = false
 }
 
 function getDraftStorageKey(threadId: string): string {
@@ -1070,6 +1095,26 @@ function getCurrentDraftPayload(): ComposerDraftPayload {
 
 function onInterrupt(): void {
   emit('interrupt')
+}
+
+function updateComposerOverflowState(): void {
+  const input = inputRef.value
+  if (!input) {
+    isDraftOverflowing.value = false
+    return
+  }
+  isDraftOverflowing.value = input.scrollHeight > input.clientHeight + 2
+}
+
+function queueComposerOverflowMeasurement(): void {
+  void nextTick(updateComposerOverflowState)
+}
+
+function toggleComposerExpanded(): void {
+  if (isInteractionDisabled.value) return
+  isComposerExpanded.value = !isComposerExpanded.value
+  queueComposerOverflowMeasurement()
+  void nextTick(() => inputRef.value?.focus())
 }
 
 function onModelSelect(value: string): void {
@@ -1496,6 +1541,7 @@ function onInputChange(): void {
   if (dictationFeedback.value) {
     dictationFeedback.value = ''
   }
+  queueComposerOverflowMeasurement()
   updateFileMentionState()
 }
 
@@ -1614,7 +1660,10 @@ function applyFileMention(suggestion: ComposerFileSuggestion): void {
 function hydrateDraft(payload: ComposerDraftPayload): void {
   cancelDictation()
   replaceDraftState(payload)
-  nextTick(() => inputRef.value?.focus())
+  void nextTick(() => {
+    inputRef.value?.focus()
+    updateComposerOverflowState()
+  })
 }
 
 function appendTextToDraft(text: string): void {
@@ -1756,6 +1805,7 @@ onMounted(() => {
   window.addEventListener('dragend', onWindowDragCleanup)
   window.addEventListener('blur', onWindowDragCleanup)
   void reloadPrompts()
+  queueComposerOverflowMeasurement()
 })
 
 defineExpose<ThreadComposerExposed>({
@@ -1800,6 +1850,10 @@ watch([draft, selectedImages, fileAttachments, selectedSkills], () => {
   persistDraftForThread(lastActiveThreadId, getCurrentDraftPayload())
 }, { deep: true })
 
+watch(draft, () => {
+  queueComposerOverflowMeasurement()
+})
+
 watch(
   () => props.cwd,
   () => {
@@ -1826,8 +1880,16 @@ watch(
   @apply w-full max-w-[min(var(--chat-column-max,72rem),100%)] mx-auto;
 }
 
+.thread-composer:has(.thread-composer-input-wrap--expanded) {
+  @apply fixed inset-0 z-50 max-w-none bg-white/95 p-3 sm:p-6;
+}
+
 .thread-composer-shell {
   @apply relative rounded-2xl border border-zinc-300 bg-white p-2 sm:p-3 shadow-sm;
+}
+
+.thread-composer:has(.thread-composer-input-wrap--expanded) .thread-composer-shell {
+  @apply mx-auto flex h-full w-full max-w-[min(var(--chat-column-max,72rem),100%)] flex-col shadow-2xl;
 }
 
 .thread-composer-shell--drag-active {
@@ -1957,6 +2019,10 @@ watch(
   @apply relative;
 }
 
+.thread-composer-input-wrap--expanded {
+  @apply min-h-0 flex-1;
+}
+
 .thread-composer-input-wrap--drag-active {
   @apply rounded-xl bg-zinc-50;
 }
@@ -2022,7 +2088,11 @@ watch(
 }
 
 .thread-composer-input {
-  @apply w-full min-w-0 min-h-10 sm:min-h-11 max-h-40 rounded-xl border-0 bg-transparent px-1 py-2 text-sm text-zinc-900 outline-none transition resize-none overflow-y-auto;
+  @apply w-full min-w-0 min-h-10 sm:min-h-11 max-h-40 rounded-xl border-0 bg-transparent px-1 py-2 pr-10 text-sm text-zinc-900 outline-none transition resize-none overflow-y-auto;
+}
+
+.thread-composer-input-wrap--expanded .thread-composer-input {
+  @apply h-full max-h-none pr-12 text-base leading-6;
 }
 
 .thread-composer-input:focus {
@@ -2031,6 +2101,14 @@ watch(
 
 .thread-composer-input:disabled {
   @apply bg-zinc-100 text-zinc-500 cursor-not-allowed;
+}
+
+.thread-composer-expand {
+  @apply absolute right-0.5 top-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full border-0 bg-zinc-100 text-zinc-500 shadow-sm transition hover:bg-zinc-200 hover:text-zinc-900 disabled:cursor-not-allowed disabled:text-zinc-400;
+}
+
+.thread-composer-expand-icon {
+  @apply h-[18px] w-[18px];
 }
 
 .thread-composer-controls {

--- a/src/components/icons/IconTablerMaximize.vue
+++ b/src/components/icons/IconTablerMaximize.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M4 8V4h4" />
+    <path d="M20 8V4h-4" />
+    <path d="M4 16v4h4" />
+    <path d="M20 16v4h-4" />
+  </svg>
+</template>

--- a/src/components/icons/IconTablerMinimize.vue
+++ b/src/components/icons/IconTablerMinimize.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M8 4v4H4" />
+    <path d="M16 4v4h4" />
+    <path d="M8 20v-4H4" />
+    <path d="M16 20v-4h4" />
+  </svg>
+</template>

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -1367,7 +1367,7 @@ onMounted(async () => {
     automationByThreadId.value = {}
   }
   try {
-    automationByProjectName.value = await getProjectAutomationMap()
+    await reloadProjectAutomations()
   } catch {
     automationByProjectName.value = {}
   }
@@ -2010,13 +2010,8 @@ function updateAutomationForProject(
   return { ...state, [projectName]: next }
 }
 
-function removeAutomationForProject(
-  state: Record<string, UiThreadAutomation[]>,
-  projectName: string,
-  automationId: string,
-): Record<string, UiThreadAutomation[]> {
-  const next = (state[projectName] ?? []).filter((automation) => automation.id !== automationId)
-  return next.length > 0 ? { ...state, [projectName]: next } : omitAutomationProject(state, projectName)
+async function reloadProjectAutomations(): Promise<void> {
+  automationByProjectName.value = await getProjectAutomationMap()
 }
 
 async function submitAutomationDialog(): Promise<void> {
@@ -2059,7 +2054,7 @@ async function submitAutomationDialog(): Promise<void> {
       ? await upsertProjectAutomation({ ...input, projectName })
       : await upsertThreadAutomation({ ...input, threadId })
     if (automationDialogScope.value === 'project') {
-      automationByProjectName.value = updateAutomationForProject(automationByProjectName.value, projectName, saved)
+      await reloadProjectAutomations()
     } else {
       automationByThreadId.value = updateAutomationForThread(automationByThreadId.value, threadId, saved)
     }
@@ -2086,7 +2081,7 @@ async function onDeleteAutomationFromDialog(): Promise<void> {
   try {
     if (automationDialogScope.value === 'project') {
       await deleteProjectAutomation(projectName, automationId)
-      automationByProjectName.value = removeAutomationForProject(automationByProjectName.value, projectName, automationId)
+      await reloadProjectAutomations()
     } else {
       await deleteThreadAutomation(threadId, automationId)
       automationByThreadId.value = removeAutomationForThread(automationByThreadId.value, threadId, automationId)
@@ -2272,8 +2267,12 @@ function onRemoveProject(projectName: string): void {
   const projectCwd = getProjectAutomationKey(projectName)
   emit('remove-project', projectName)
   if (projectCwd && projectHasAutomation(projectName)) {
-    void deleteProjectAutomation(projectCwd).catch(() => undefined)
     automationByProjectName.value = omitAutomationProject(automationByProjectName.value, projectCwd)
+    void deleteProjectAutomation(projectCwd)
+      .then(reloadProjectAutomations)
+      .finally(() => {
+        emit('automations-changed')
+      })
   }
   closeProjectMenu()
 }

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -421,6 +421,19 @@ describe('collaboration mode selection', () => {
   })
 })
 
+describe('Codex CLI availability', () => {
+  it('surfaces a chat runtime error when the app-server bridge cannot find Codex CLI', async () => {
+    installTestWindow()
+    gatewayMocks.getThreadGroupsPage.mockRejectedValue(new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.'))
+
+    const state = useDesktopState()
+
+    await state.refreshAll({ awaitAncillaryRefreshes: true })
+
+    expect(state.codexCliMissingError.value).toBe('Codex CLI not found. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
+  })
+})
+
 describe('findAdjacentThreadId', () => {
   it('selects the next thread after the archived thread', () => {
     const threads = [

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -91,6 +91,12 @@ const RECENT_THREAD_MESSAGE_LOAD_REUSE_MS = 2000
 const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
 const GLOBAL_SERVER_REQUEST_SCOPE = '__global__'
 const MODEL_FALLBACK_ID = 'gpt-5.4-mini'
+const CODEX_CLI_MISSING_MESSAGE = 'Codex CLI not found. Install @openai/codex or set CODEXUI_CODEX_COMMAND.'
+
+function isCodexCliMissingError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return message.includes('Codex CLI is not available')
+}
 
 function loadReadStateMap(): Record<string, string> {
   if (typeof window === 'undefined') return {}
@@ -1388,6 +1394,7 @@ export function useDesktopState() {
   const selectedReasoningEffort = ref<ReasoningEffort | ''>('medium')
   const selectedSpeedMode = ref<SpeedMode>('standard')
   const activeProviderId = ref('')
+  const codexCliMissingError = ref('')
   const readStateByThreadId = ref<Record<string, string>>(loadReadStateMap())
   const unreadCutoffIso = ref(loadUnreadCutoffIso())
   const projectOrder = ref<string[]>(loadProjectOrder())
@@ -1909,7 +1916,11 @@ export function useDesktopState() {
         selectedReasoningEffort.value = currentConfig.reasoningEffort
       }
       selectedSpeedMode.value = currentConfig.speedMode
-    } catch {
+      codexCliMissingError.value = ''
+    } catch (unknownError) {
+      if (isCodexCliMissingError(unknownError)) {
+        codexCliMissingError.value = CODEX_CLI_MISSING_MESSAGE
+      }
       // Keep chat UI usable even if model metadata is temporarily unavailable.
     }
   }
@@ -4408,6 +4419,9 @@ export function useDesktopState() {
       }
     } catch (unknownError) {
       error.value = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
+      if (isCodexCliMissingError(unknownError)) {
+        codexCliMissingError.value = CODEX_CLI_MISSING_MESSAGE
+      }
     }
   }
 
@@ -5431,6 +5445,7 @@ export function useDesktopState() {
     selectedModelId,
     selectedReasoningEffort,
     selectedSpeedMode,
+    codexCliMissingError,
     installedSkills,
     accountRateLimitSnapshots,
     messages,

--- a/src/composables/useFeedbackDiagnostics.test.ts
+++ b/src/composables/useFeedbackDiagnostics.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildFeedbackMailto,
+  recordFeedbackDiagnostic,
+  useFeedbackDiagnostics,
+} from './useFeedbackDiagnostics'
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', { userAgent: 'TestAgent/1.0' })
+  vi.stubGlobal('window', {
+    innerWidth: 390,
+    innerHeight: 844,
+    devicePixelRatio: 2,
+    location: {
+      href: 'http://127.0.0.1:4173/#/',
+    },
+  })
+  useFeedbackDiagnostics().diagnostics.value = []
+})
+
+describe('feedback diagnostics', () => {
+  it('keeps feedback hidden until a diagnostic is recorded', () => {
+    const state = useFeedbackDiagnostics()
+
+    expect(state.hasFeedbackDiagnostics.value).toBe(false)
+
+    state.recordVisibleFailure('Failed to load folders')
+
+    expect(state.hasFeedbackDiagnostics.value).toBe(true)
+  })
+
+  it('builds a mailto with context and recent diagnostics', () => {
+    recordFeedbackDiagnostic({
+      kind: 'api-response',
+      message: 'Request failed with HTTP 500',
+      url: '/codex-api/rpc',
+      method: 'POST',
+      status: 500,
+      statusText: 'Internal Server Error',
+      atIso: '2026-05-12T03:00:00.000Z',
+    })
+
+    const mailto = buildFeedbackMailto()
+    const parsed = new URL(mailto)
+    const body = parsed.searchParams.get('body') ?? ''
+
+    expect(mailto.startsWith('mailto:brutalstrikedevs@gmail.com?')).toBe(true)
+    expect(parsed.searchParams.get('subject')).toContain('Request failed with HTTP 500')
+    expect(body).toContain('URL: http://127.0.0.1:4173/#/')
+    expect(body).toContain('User agent: TestAgent/1.0')
+    expect(body).toContain('Viewport: 390x844 @2x')
+    expect(body).toContain('POST | /codex-api/rpc | 500 Internal Server Error')
+  })
+})

--- a/src/composables/useFeedbackDiagnostics.ts
+++ b/src/composables/useFeedbackDiagnostics.ts
@@ -1,0 +1,178 @@
+import { computed, ref } from 'vue'
+
+const FEEDBACK_EMAIL = 'brutalstrikedevs@gmail.com'
+const MAX_DIAGNOSTICS = 20
+const MAX_BODY_CHARS = 6500
+
+export type FeedbackDiagnosticKind = 'window-error' | 'unhandled-rejection' | 'fetch-error' | 'api-response' | 'visible-error'
+
+export type FeedbackDiagnostic = {
+  kind: FeedbackDiagnosticKind
+  message: string
+  atIso: string
+  url?: string
+  method?: string
+  status?: number
+  statusText?: string
+}
+
+const diagnostics = ref<FeedbackDiagnostic[]>([])
+let listenersInstalled = false
+let fetchInstalled = false
+let originalFetch: typeof window.fetch | null = null
+
+function normalizeMessage(value: unknown): string {
+  if (value instanceof Error) return value.stack || value.message
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function normalizeFetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.toString()
+  return input.url
+}
+
+function normalizeFetchMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  const initMethod = init?.method?.trim()
+  if (initMethod) return initMethod.toUpperCase()
+  if (typeof input === 'object' && 'method' in input && typeof input.method === 'string' && input.method.trim()) {
+    return input.method.trim().toUpperCase()
+  }
+  return 'GET'
+}
+
+export function recordFeedbackDiagnostic(input: Omit<FeedbackDiagnostic, 'atIso'> & { atIso?: string }): void {
+  const message = input.message.trim()
+  if (!message) return
+
+  const next: FeedbackDiagnostic = {
+    ...input,
+    message,
+    atIso: input.atIso ?? new Date().toISOString(),
+  }
+  diagnostics.value = [next, ...diagnostics.value].slice(0, MAX_DIAGNOSTICS)
+}
+
+export function buildFeedbackMailto(entries: FeedbackDiagnostic[] = diagnostics.value): string {
+  const viewport = typeof window === 'undefined'
+    ? 'unknown'
+    : `${window.innerWidth}x${window.innerHeight} @${window.devicePixelRatio || 1}x`
+  const currentUrl = typeof window === 'undefined' ? 'unknown' : window.location.href
+  const userAgent = typeof navigator === 'undefined' ? 'unknown' : navigator.userAgent
+  const appVersion = import.meta.env.VITE_APP_VERSION || 'unknown'
+  const worktreeName = import.meta.env.VITE_WORKTREE_NAME || 'unknown'
+  const recentDiagnostics = entries.slice(0, 12).map((entry, index) => {
+    const parts = [
+      `${index + 1}. [${entry.atIso}] ${entry.kind}`,
+      entry.method ? `${entry.method}` : '',
+      entry.url ?? '',
+      typeof entry.status === 'number' ? `${entry.status} ${entry.statusText ?? ''}`.trim() : '',
+      entry.message,
+    ].filter(Boolean)
+    return parts.join(' | ')
+  }).join('\n')
+
+  const body = [
+    'What happened?',
+    '',
+    '',
+    'Context',
+    `URL: ${currentUrl}`,
+    `User agent: ${userAgent}`,
+    `Viewport: ${viewport}`,
+    `App version: ${appVersion}`,
+    `Worktree: ${worktreeName}`,
+    '',
+    'Recent diagnostics',
+    recentDiagnostics || 'No diagnostics captured.',
+  ].join('\n').slice(0, MAX_BODY_CHARS)
+
+  const params = new URLSearchParams({
+    subject: `Codex Web feedback: ${entries[0]?.message.slice(0, 80) || 'issue report'}`,
+    body,
+  })
+  return `mailto:${FEEDBACK_EMAIL}?${params.toString()}`
+}
+
+export function openFeedbackMail(): void {
+  if (typeof window === 'undefined') return
+  window.location.href = buildFeedbackMailto()
+}
+
+export function installFeedbackDiagnostics(): void {
+  if (typeof window === 'undefined') return
+
+  if (!listenersInstalled) {
+    listenersInstalled = true
+    window.addEventListener('error', (event) => {
+      recordFeedbackDiagnostic({
+        kind: 'window-error',
+        message: event.error ? normalizeMessage(event.error) : event.message,
+        url: event.filename || window.location.href,
+      })
+    })
+    window.addEventListener('unhandledrejection', (event) => {
+      recordFeedbackDiagnostic({
+        kind: 'unhandled-rejection',
+        message: normalizeMessage(event.reason),
+        url: window.location.href,
+      })
+    })
+  }
+
+  if (!fetchInstalled) {
+    fetchInstalled = true
+    originalFetch = window.fetch.bind(window)
+    window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = normalizeFetchUrl(input)
+      const method = normalizeFetchMethod(input, init)
+      try {
+        const response = await originalFetch!(input, init)
+        if (!response.ok) {
+          recordFeedbackDiagnostic({
+            kind: url.includes('/codex-api/') ? 'api-response' : 'fetch-error',
+            message: `Request failed with HTTP ${response.status}`,
+            url,
+            method,
+            status: response.status,
+            statusText: response.statusText,
+          })
+        }
+        return response
+      } catch (error) {
+        recordFeedbackDiagnostic({
+          kind: 'fetch-error',
+          message: normalizeMessage(error),
+          url,
+          method,
+        })
+        throw error
+      }
+    }) as typeof window.fetch
+  }
+}
+
+export function useFeedbackDiagnostics() {
+  const hasFeedbackDiagnostics = computed(() => diagnostics.value.length > 0)
+
+  function recordVisibleFailure(message: string, url?: string): void {
+    recordFeedbackDiagnostic({
+      kind: 'visible-error',
+      message,
+      url: url || (typeof window === 'undefined' ? undefined : window.location.href),
+    })
+  }
+
+  return {
+    diagnostics,
+    hasFeedbackDiagnostics,
+    recordVisibleFailure,
+    openFeedbackMail,
+    buildFeedbackMailto,
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,11 @@ import App from './App.vue'
 import router from './router'
 import './style.css'
 import { t } from './composables/useUiLanguage'
+import { installFeedbackDiagnostics } from './composables/useFeedbackDiagnostics'
 
 console.log('Welcome to codexui. github: https://github.com/friuns2/codexUI')
+
+installFeedbackDiagnostics()
 
 createApp(App).use(router).mount('#app')
 

--- a/src/server/codexAppServerBridge.inlinePayload.test.ts
+++ b/src/server/codexAppServerBridge.inlinePayload.test.ts
@@ -1,6 +1,12 @@
 import { existsSync } from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { BackendQueueProcessor, mergeSessionSkillInputsIntoTurns, sanitizeThreadTurnsInlinePayloads } from './codexAppServerBridge'
+import {
+  BackendQueueProcessor,
+  mergeSessionSkillInputsIntoTurns,
+  parseAutomationToml,
+  sanitizeThreadTurnsInlinePayloads,
+  toAutomationApiRecord,
+} from './codexAppServerBridge'
 
 const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 const pngDataUrl = `data:image/png;base64,${pngBase64}`
@@ -368,5 +374,46 @@ describe('backend queue scheduling', () => {
     expect(processThreadQueue).toHaveBeenCalledTimes(1)
 
     processor.dispose()
+  })
+})
+
+describe('automation TOML handling', () => {
+  it('parses TOML string arrays without requiring JSON-only syntax', () => {
+    const automation = parseAutomationToml([
+      'version = 1',
+      'id = "cron-smoke"',
+      'kind = "cron"',
+      'name = "Cron Smoke"',
+      'prompt = "run"',
+      'status = "ACTIVE"',
+      'rrule = "FREQ=DAILY"',
+      "cwds = ['/tmp/project-one', '/tmp/project,two']",
+      'created_at = 111',
+      'updated_at = 222',
+      '[scheduler]',
+      'execution_environment = "local"',
+    ].join('\n'))
+
+    expect(automation?.cwds).toEqual(['/tmp/project-one', '/tmp/project,two'])
+    expect(automation?.createdAtMs).toBe(111)
+    expect(automation?.extraTomlLines).toContain('[scheduler]')
+  })
+
+  it('omits preserved TOML internals from automation API records', () => {
+    const automation = parseAutomationToml([
+      'version = 1',
+      'id = "cron-smoke"',
+      'kind = "cron"',
+      'name = "Cron Smoke"',
+      'prompt = "run"',
+      'status = "ACTIVE"',
+      'rrule = "FREQ=DAILY"',
+      'cwds = ["/tmp/project-one"]',
+      '[scheduler]',
+      'execution_environment = "local"',
+    ].join('\n'))
+
+    expect(automation).toBeTruthy()
+    expect(toAutomationApiRecord(automation as NonNullable<typeof automation>)).not.toHaveProperty('extraTomlLines')
   })
 })

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -3275,21 +3275,60 @@ function serializeTomlString(value: string): string {
 function parseTomlStringArray(value: string): string[] {
   const trimmed = value.trim()
   if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return []
-  try {
-    const parsed = JSON.parse(trimmed)
-    return Array.isArray(parsed)
-      ? parsed.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
-      : []
-  } catch {
-    return []
+  const values: string[] = []
+  let index = 1
+  const endIndex = trimmed.length - 1
+
+  while (index < endIndex) {
+    while (index < endIndex && /[\s,]/u.test(trimmed[index] ?? '')) index += 1
+    if (index >= endIndex) break
+
+    const quote = trimmed[index]
+    if (quote !== '"' && quote !== "'") return []
+    const start = index
+    index += 1
+    let valueText = ''
+
+    if (quote === "'") {
+      const closeIndex = trimmed.indexOf("'", index)
+      if (closeIndex < 0 || closeIndex > endIndex) return []
+      valueText = trimmed.slice(index, closeIndex)
+      index = closeIndex + 1
+    } else {
+      let escaped = false
+      while (index < endIndex) {
+        const char = trimmed[index] ?? ''
+        if (escaped) {
+          escaped = false
+        } else if (char === '\\') {
+          escaped = true
+        } else if (char === '"') {
+          break
+        }
+        index += 1
+      }
+      if (index >= endIndex || trimmed[index] !== '"') return []
+      try {
+        valueText = JSON.parse(trimmed.slice(start, index + 1)) as string
+      } catch {
+        return []
+      }
+      index += 1
+    }
+
+    if (valueText.trim().length > 0) values.push(valueText)
+    while (index < endIndex && /\s/u.test(trimmed[index] ?? '')) index += 1
+    if (index < endIndex && trimmed[index] !== ',') return []
   }
+
+  return values
 }
 
 function serializeTomlStringArray(values: string[]): string {
   return `[${values.map((value) => serializeTomlString(value)).join(', ')}]`
 }
 
-function parseAutomationToml(raw: string): ThreadAutomationRecord | null {
+export function parseAutomationToml(raw: string): ThreadAutomationRecord | null {
   const values: Record<string, string> = {}
   const extraTomlLines: string[] = []
   const knownKeys = new Set([
@@ -3386,6 +3425,29 @@ function serializeAutomationToml(record: ThreadAutomationRecord): string {
   )
   lines.push(...record.extraTomlLines)
   return `${lines.join('\n')}\n`
+}
+
+export function toAutomationApiRecord(record: ThreadAutomationRecord): Omit<ThreadAutomationRecord, 'extraTomlLines'> {
+  const { extraTomlLines: _extraTomlLines, ...apiRecord } = record
+  return apiRecord
+}
+
+function toAutomationApiMap(
+  automationsByTarget: Record<string, ThreadAutomationRecord[]>,
+): Record<string, Array<Omit<ThreadAutomationRecord, 'extraTomlLines'>>> {
+  return Object.fromEntries(
+    Object.entries(automationsByTarget).map(([target, automations]) => [
+      target,
+      automations.map(toAutomationApiRecord),
+    ]),
+  )
+}
+
+function toAutomationApiData(
+  automation: ThreadAutomationRecord | ThreadAutomationRecord[] | null,
+): Omit<ThreadAutomationRecord, 'extraTomlLines'> | Array<Omit<ThreadAutomationRecord, 'extraTomlLines'>> | null {
+  if (Array.isArray(automation)) return automation.map(toAutomationApiRecord)
+  return automation ? toAutomationApiRecord(automation) : null
 }
 
 function slugifyAutomationId(threadId: string, name: string): string {
@@ -7255,13 +7317,13 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'GET' && url.pathname === '/codex-api/thread-automations') {
         const automationsByThreadId = await listThreadHeartbeatAutomations()
-        setJson(res, 200, { data: automationsByThreadId })
+        setJson(res, 200, { data: toAutomationApiMap(automationsByThreadId) })
         return
       }
 
       if (req.method === 'GET' && url.pathname === '/codex-api/project-automations') {
         const automationsByProjectName = await listProjectCronAutomations()
-        setJson(res, 200, { data: automationsByProjectName })
+        setJson(res, 200, { data: toAutomationApiMap(automationsByProjectName) })
         return
       }
 
@@ -7275,7 +7337,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const automation = automationId
           ? await readThreadHeartbeatAutomation(threadId, automationId)
           : await readThreadHeartbeatAutomations(threadId)
-        setJson(res, 200, { data: automation })
+        setJson(res, 200, { data: toAutomationApiData(automation) })
         return
       }
 
@@ -7289,7 +7351,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const automation = automationId
           ? await readProjectCronAutomation(projectName, automationId)
           : await readProjectCronAutomations(projectName)
-        setJson(res, 200, { data: automation })
+        setJson(res, 200, { data: toAutomationApiData(automation) })
         return
       }
 
@@ -7357,7 +7419,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
         const automation = await writeThreadHeartbeatAutomation({ threadId, id, name, prompt, rrule, status })
-        setJson(res, 200, { data: automation })
+        setJson(res, 200, { data: toAutomationApiRecord(automation) })
         return
       }
 
@@ -7378,7 +7440,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
         const automation = await writeProjectCronAutomation({ projectName, id, name, prompt, rrule, status })
-        setJson(res, 200, { data: automation })
+        setJson(res, 200, { data: toAutomationApiRecord(automation) })
         return
       }
 

--- a/src/style.css
+++ b/src/style.css
@@ -287,6 +287,10 @@
   @apply bg-zinc-200 text-zinc-900 hover:bg-white;
 }
 
+:root.dark .composer-runtime-error {
+  @apply border-rose-800/70 bg-rose-950/70 text-rose-100 shadow-none;
+}
+
 :root.dark .composer-dropdown-trigger {
   @apply text-zinc-400;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -545,6 +545,10 @@
   @apply text-emerald-400;
 }
 
+:root.dark .thread-row-automation-chip {
+  @apply bg-amber-900/40 text-amber-200 ring-1 ring-amber-700/40;
+}
+
 :root.dark .rename-thread-button {
   @apply text-zinc-300 hover:bg-zinc-700;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -291,6 +291,10 @@
   @apply border-rose-800/70 bg-rose-950/70 text-rose-100 shadow-none;
 }
 
+:root.dark .visible-error-feedback {
+  @apply border-rose-800/80 bg-rose-950 text-rose-100 hover:bg-rose-900 focus:ring-rose-700;
+}
+
 :root.dark .composer-dropdown-trigger {
   @apply text-zinc-400;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -243,6 +243,10 @@
   @apply border-zinc-700 bg-zinc-800;
 }
 
+:root.dark .thread-composer:has(.thread-composer-input-wrap--expanded) {
+  @apply bg-zinc-950/95;
+}
+
 :root.dark .thread-composer-shell--drag-active {
   @apply border-zinc-400 shadow-zinc-950/60;
 }
@@ -253,6 +257,10 @@
 
 :root.dark .thread-composer-input:disabled {
   @apply bg-zinc-700 text-zinc-500;
+}
+
+:root.dark .thread-composer-expand {
+  @apply bg-zinc-700 text-zinc-300 hover:bg-zinc-600 hover:text-white;
 }
 
 :root.dark .thread-composer-input-wrap--drag-active {

--- a/tests.md
+++ b/tests.md
@@ -105,12 +105,16 @@ This file tracks manual regression and feature verification steps.
 4. Open `/automations` from the sidebar and confirm the new project automation appears with the visible project display name.
 5. Edit the automation from `/automations`, change its name and status, save, and confirm the project row chip count and tooltip update without a full page refresh.
 6. Seed or keep a cron automation record whose `cwds` contains two project paths, then edit it from one project and confirm both project rows show the updated name/status.
-7. Remove one project that has an attached automation while `/automations` is open and confirm the panel removes the deleted project row after the cleanup completes.
-8. Switch to dark theme and repeat opening the project menu and `/automations`; confirm rows, chips, buttons, inputs, and empty states remain readable.
+7. Seed a cron automation record with a TOML-style single-quoted `cwds` array such as `cwds = ['/tmp/project-one', '/tmp/project,two']`, refresh `/automations`, and confirm it is still listed.
+8. Inspect `/codex-api/project-automations` for the seeded record and confirm the response includes public automation fields but not `extraTomlLines`.
+9. Remove one project that has an attached automation while `/automations` is open and confirm the panel removes the deleted project row after the cleanup completes.
+10. Switch to dark theme and repeat opening the project menu and `/automations`; confirm rows, chips, buttons, inputs, and empty states remain readable.
 
 #### Expected Results
 - Project-scoped cron automations are listed under every associated `cwd`.
 - Editing a multi-`cwd` project automation refreshes all affected sidebar chips/tooltips, not only the currently edited project.
+- Existing TOML cron records with valid non-JSON string arrays remain visible and manageable.
+- Automation API responses do not include internal preserved TOML metadata such as `extraTomlLines`.
 - Removing a project deletes or detaches that project's automation association and refreshes the `/automations` panel.
 - Preserved TOML metadata and table sections remain intact after saving or deleting a project automation.
 - Light and dark theme project automation surfaces remain readable.

--- a/tests.md
+++ b/tests.md
@@ -90,6 +90,35 @@ This file tracks manual regression and feature verification steps.
 #### Rollback/Cleanup
 - Remove any test automations from the thread automation dialog or delete their folders under `$CODEX_HOME/automations/<automation-id>/`.
 
+### Feature: Project automations and `/automations` panel
+
+#### Prerequisites
+- App is running from this repository.
+- At least two sidebar projects have absolute workspace paths.
+- Local Codex home is writable (`$CODEX_HOME` or `~/.codex`).
+- Light and dark themes are both available from Settings.
+
+#### Steps
+1. In light theme, open a project overflow menu for a project without an attached automation.
+2. Confirm the menu shows `Add automation…`, then create a project automation with a name, prompt, RRULE schedule, and status.
+3. Confirm the project row shows an automation chip and the same menu changes to `Manage automations…`.
+4. Open `/automations` from the sidebar and confirm the new project automation appears with the visible project display name.
+5. Edit the automation from `/automations`, change its name and status, save, and confirm the project row chip count and tooltip update without a full page refresh.
+6. Seed or keep a cron automation record whose `cwds` contains two project paths, then edit it from one project and confirm both project rows show the updated name/status.
+7. Remove one project that has an attached automation while `/automations` is open and confirm the panel removes the deleted project row after the cleanup completes.
+8. Switch to dark theme and repeat opening the project menu and `/automations`; confirm rows, chips, buttons, inputs, and empty states remain readable.
+
+#### Expected Results
+- Project-scoped cron automations are listed under every associated `cwd`.
+- Editing a multi-`cwd` project automation refreshes all affected sidebar chips/tooltips, not only the currently edited project.
+- Removing a project deletes or detaches that project's automation association and refreshes the `/automations` panel.
+- Preserved TOML metadata and table sections remain intact after saving or deleting a project automation.
+- Light and dark theme project automation surfaces remain readable.
+
+#### Rollback/Cleanup
+- Remove any test project automations from the project automation dialog or delete their folders under `$CODEX_HOME/automations/<automation-id>/`.
+- Remove temporary test projects or workspace roots created for verification.
+
 ### Feature: Projectless new chat folders
 
 #### Prerequisites

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,36 @@ Rollback/cleanup:
 
 ---
 
+### Composer expands long drafts to full screen
+
+#### Feature/Change Name
+Thread composer full-screen expand control for multi-line drafts.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. Any existing thread is open and send controls are enabled
+3. Light theme and dark theme both available from the appearance switcher
+
+#### Steps
+1. In light theme, type or paste at least six lines into the composer.
+2. Confirm the expand button appears in the composer input area.
+3. Click the expand button.
+4. Confirm the composer fills the viewport, keeps the draft text, and leaves model/skill/thinking/send controls usable at the bottom.
+5. Click the collapse button.
+6. Confirm the composer returns to its normal inline size with the draft still intact.
+7. Switch to dark theme and repeat steps 1-6.
+
+#### Expected Results
+- Short drafts do not show the expand control.
+- Long or overflowing drafts show an icon-only expand control.
+- Full-screen mode uses the same draft state and submit controls as inline mode.
+- Full-screen and inline states are readable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Clear the draft from the composer.
+
+---
+
 ### Error-triggered feedback button
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -303,6 +303,39 @@ Rollback/cleanup:
 
 ---
 
+### Error-triggered feedback button
+
+#### Feature/Change Name
+Feedback action appears in Settings and on visible error banners after captured UI/runtime/API failures, then opens prefilled email diagnostics.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173` or an alternate free port).
+2. Browser devtools available to inject a test error or failed fetch.
+3. Light theme and dark theme both available from the appearance switcher.
+
+#### Steps
+1. In light theme, load the home screen, open Settings, and confirm no `Send feedback` row is visible during a clean state.
+2. Trigger a failure, for example run `fetch('/codex-api/rpc', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })` in the browser console or open a folder path that produces a visible load error.
+3. Reopen Settings and confirm a `Send feedback` row with `Issue detected` appears after the failed request is recorded.
+4. Trigger or view a visible error banner, such as the missing Codex CLI composer banner, a settings provider error, a folder picker error, a Skills Hub error, or a branch dropdown error, and confirm that error state includes a compact `Send feedback` action.
+5. Confirm no feedback action appears in the content header during normal use.
+6. Click `Send feedback` and confirm the mail client opens a draft to `brutalstrikedevs@gmail.com`.
+7. Confirm the draft body includes current URL, user agent, viewport, app/worktree version info, and recent diagnostics including the failed request or visible error.
+8. Switch to dark theme and repeat steps 1-7.
+
+#### Expected Results
+- The settings feedback action is absent during normal operation.
+- Runtime errors, unhandled rejections, failed fetches/API responses, and visible load failures make the Settings feedback action visible.
+- Visible error states include a local `Send feedback` action so the user can report the error from the same context.
+- The generated `mailto:` draft is prefilled with useful diagnostics and does not submit anything automatically.
+- No feedback action is shown in the app header during normal use.
+- The Settings feedback row and visible-error feedback actions remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Close the generated email draft without sending if this was only a test.
+
+---
+
 ### Missing Codex CLI chat error
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -303,6 +303,32 @@ Rollback/cleanup:
 
 ---
 
+### Missing Codex CLI chat error
+
+#### Feature/Change Name
+Fresh installs without a runnable Codex CLI show a visible chat runtime error.
+
+#### Prerequisites/Setup
+1. Start the app in an isolated environment without `codex` in `PATH` and without `CODEXUI_CODEX_COMMAND`.
+2. Use a mobile viewport such as `390x844`.
+3. Light theme and dark theme both available from the appearance switcher when the app can reach settings.
+
+#### Steps
+1. In light theme, open the app home/new chat screen.
+2. Confirm the composer area shows `Codex CLI not found. Install @openai/codex or set CODEXUI_CODEX_COMMAND.`
+3. Confirm the model dropdown no longer fails silently as the only visible symptom.
+4. Switch to dark theme and repeat steps 1-3.
+
+#### Expected Results
+- The missing CLI condition is visible in the chat/composer area.
+- The banner remains readable and does not overlap the mobile composer controls.
+- Dark theme uses a dark error surface, not a light-theme panel.
+
+#### Rollback/Cleanup
+- Stop and remove the isolated container or test server.
+
+---
+
 ### Composio logged-out connector preview
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- show an expand control for long or overflowing composer drafts
- add full-screen composer mode while preserving draft state and existing controls
- document manual light/dark verification steps in tests.md

## Verification
- pnpm run build:frontend
- Browser check on http://127.0.0.1:4173/#/ in light and dark mode
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser