### PR TITLE
Harden Codex app-server runtime defaults

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,359 @@
+# Security Audit Tracker
+
+Last updated: 2026-05-14
+
+Scope: static review of the local web UI, CLI, server bridge, auth middleware, local file browser/editor, integrated terminal, provider proxy, skills sync, Telegram integration, and supply-chain posture. No dynamic exploit testing has been run yet.
+
+## Overall Verdict
+
+This project is suitable as a personal, local, trusted-LAN development base.
+
+It is not yet suitable as a public, team, or semi-trusted plugin/application security base without hardening. The main pattern is that powerful local desktop capabilities are exposed through one local web origin. If that origin, an authenticated browser session, or same-origin rendered content is compromised, the attacker can reach local files, shell/session operations, and model/tool execution paths.
+
+## Severity Model
+
+- High: likely local command execution, arbitrary file access/write, token exposure, or broad trust-boundary bypass after a plausible UI/session/origin compromise.
+- Medium: meaningful hardening gap or abuse path that usually requires an authenticated user, local access, or a second weakness.
+- Low: configuration hygiene or defense-in-depth issue.
+
+## Open Issues
+
+### SEC-001: Runtime sandbox is hardcoded to full local access
+
+Severity: High
+Status: First fix implemented
+
+Evidence:
+- `src/server/codexAppServerBridge.ts`: `AppServerProcess.buildAppServerConfig()` hardcodes `approval_policy="never"` and `sandbox_mode="danger-full-access"`.
+- `src/server/appServerRuntimeConfig.ts` contains configurable runtime helpers, but this process path does not appear to use them.
+- `scripts/dev.cjs` also defaults `CODEXUI_SANDBOX_MODE=danger-full-access` and `CODEXUI_APPROVAL_POLICY=never`.
+
+Risk:
+If the web UI or authenticated browser session is compromised, the app-server runtime can become no-approval local command execution with full filesystem access.
+
+Recommended fix:
+- Route app-server runtime creation through one central runtime config.
+- Default normal product/CLI startup to `workspace-write` plus `on-request`.
+- Keep `pnpm run dev` as an explicitly unsafe local-development shortcut that injects `danger-full-access` plus `never`.
+- Make dangerous defaults visibly opt-in with a startup warning or clear startup output.
+
+Decision notes:
+- Agreed on 2026-05-14: the security baseline should be `workspace-write + on-request`.
+- `danger-full-access + never` remains acceptable only as an intentional trusted-local/dev mode, not as the generic app-server default.
+- Agreed on 2026-05-14: the safer default applies to normal product/CLI startup and every `codex app-server` child process started by the app, including temporary account-validation app-servers.
+- Agreed on 2026-05-14: `scripts/dev.cjs` may remain an explicit unsafe developer convenience entrypoint because the developer actively chooses that mode.
+- Discussed on 2026-05-14: a VS Code-like permission selector in the composer is desirable, with three user-facing modes: default, automatic review, and full access.
+- For the first fix, runtime permission remains global because the current architecture shares one main `codex app-server` across projects/threads. Per-project or per-thread runtime isolation should be treated as a later architecture change.
+- Agreed on 2026-05-14: the first implementation will not include the composer permission selector. Scope is limited to safer defaults, unified app-server config, unsafe-mode visibility, and tests.
+- Agreed on 2026-05-14: the first implementation may include a read-only warning/status indicator in the composer when the current global runtime is unsafe. This is not a permission selector and should not imply per-message permission isolation.
+- Agreed on 2026-05-14: the first composer warning only needs to trigger for the highest-risk runtime combination: `danger-full-access + never`.
+- Agreed on 2026-05-14: the composer warning label should read `Full access`, with tooltip/title copy explaining that full local access is enabled and Codex will not ask for approvals.
+
+Implementation notes:
+- Implemented on 2026-05-14: normal runtime defaults now resolve to `workspace-write + on-request`.
+- Implemented on 2026-05-14: `AppServerProcess.buildAppServerConfig()` now reuses centralized `buildAppServerArgs()` instead of hardcoding unsafe args.
+- Implemented on 2026-05-14: `GET /codex-api/runtime-config` exposes a read-only runtime status for the frontend.
+- Implemented on 2026-05-14: CLI startup prints a warning when the effective runtime is `danger-full-access + never`.
+- Implemented on 2026-05-14: the composer shows a read-only `Full access` pill when the global runtime is `danger-full-access + never`.
+
+Validation:
+- Start the app with no special env vars and confirm effective sandbox/approval values are safe.
+- Start with explicit dev env vars and confirm the unsafe mode is shown as intentional.
+- In unsafe runtime mode, confirm the composer shows a warning/status indicator near the input controls.
+- `pnpm exec vitest run src/server/appServerRuntimeConfig.test.ts` passed.
+- `pnpm run build:frontend` passed.
+- `pnpm run build:cli` passed.
+- Built CLI without runtime env returned `{"sandboxMode":"workspace-write","approvalPolicy":"on-request","isUnsafe":false}` from `/codex-api/runtime-config`.
+- Built CLI with `CODEXUI_SANDBOX_MODE=danger-full-access CODEXUI_APPROVAL_POLICY=never` printed the full-access warning and returned `{"sandboxMode":"danger-full-access","approvalPolicy":"never","isUnsafe":true}`.
+
+### SEC-002: Local file browser serves arbitrary absolute files on the app origin
+
+Severity: High
+Status: Open
+
+Evidence:
+- `src/server/httpServer.ts`: `/codex-local-browse/*path` serves local paths.
+- `src/server/httpServer.ts`: `/codex-local-file` serves local file content.
+- `src/server/localBrowseUi.ts` renders a browser/editor UI for local files.
+
+Risk:
+Untrusted local HTML opened through this feature can execute under the same origin as privileged `/codex-api/*` endpoints. That creates a same-origin escalation path from "view local file" to "call app APIs".
+
+Recommended fix:
+- Serve browsed local files from an isolated origin, opaque sandboxed iframe, or a forced download/text-rendering mode.
+- Never execute local HTML/JS in the privileged app origin.
+- Add explicit allowlists or project-root scoping where possible.
+
+Validation:
+- Create a local HTML file that attempts to call `/codex-api/*`; verify it cannot access privileged APIs.
+
+### SEC-003: Local text editor can write arbitrary absolute text-like paths
+
+Severity: High
+Status: Open
+
+Evidence:
+- `src/server/httpServer.ts`: `/codex-local-file` supports write operations.
+- `src/server/localBrowseUi.ts`: `isTextEditableFile()` decides which files are editable by extension/name.
+
+Risk:
+Any authenticated or same-origin attacker can potentially edit sensitive local text files such as shell profiles, project configs, token files, service files, or scripts.
+
+Recommended fix:
+- Require explicit per-root trust before edits.
+- Restrict writes to workspace roots by default.
+- Add confirmation for hidden files, dotfiles, scripts, env files, keys, service files, and executable paths.
+
+Validation:
+- Attempt writes outside the workspace and to sensitive filename patterns; verify they are blocked or require explicit confirmation.
+
+### SEC-004: Auth bypass rules are convenience-first
+
+Severity: High
+Status: Open
+
+Evidence:
+- `src/server/authMiddleware.ts` bypasses password auth for localhost-style access and Tailscale IP ranges.
+- `src/cli/index.ts` listens on `0.0.0.0` and auto-enables tunnel behavior when Tailscale is detected.
+
+Risk:
+This is acceptable for a personal trusted machine/tailnet, but it is too broad as a generic default. Tailnet membership or local-network exposure becomes equivalent to app trust.
+
+Recommended fix:
+- Make password/session auth mandatory by default for non-loopback access.
+- Treat Tailscale bypass as explicit opt-in.
+- Show effective network/auth mode at startup.
+
+Validation:
+- Access from loopback, LAN, and Tailscale addresses; confirm only intended modes bypass auth.
+
+### SEC-005: Integrated terminal is a complete shell behind API auth
+
+Severity: High
+Status: Open
+
+Evidence:
+- `src/server/codexAppServerBridge.ts`: terminal websocket/session handlers.
+- `src/server/terminalManager.ts`: process spawning and terminal lifecycle.
+
+Risk:
+Once an attacker has API/session access, terminal APIs provide direct shell capability.
+
+Recommended fix:
+- Gate terminal creation behind explicit capability checks.
+- Add optional workspace-only command policy or disable terminal in shared deployments.
+- Log terminal session creation with source IP/session metadata.
+
+Validation:
+- Confirm terminal APIs are unavailable when the terminal capability is disabled.
+
+### SEC-006: Secrets are exposed or written without explicit restrictive permissions
+
+Severity: Medium/High
+Status: Open
+
+Evidence:
+- `src/server/codexAppServerBridge.ts`: Telegram config GET returns full `botToken`.
+- `src/server/codexAppServerBridge.ts`: Telegram config writes do not appear to force `0600`.
+- `src/server/skillsRoutes.ts`: skills sync token state writes do not appear to force `0600`.
+- `src/server/accountRoutes.ts` has examples of account-related files being written with `0600`.
+
+Risk:
+Tokens can be exposed to any authenticated frontend code and may be stored with permissions inherited from process defaults.
+
+Recommended fix:
+- Return only masked tokens from read endpoints.
+- Use `0600` for all token-bearing files.
+- Add token redaction in logs and debug responses.
+
+Validation:
+- Read config endpoints and confirm secrets are masked.
+- Check written token files with `stat` and confirm mode `600`.
+
+### SEC-007: Supply-chain posture is weak because lockfiles are ignored
+
+Severity: Medium/High
+Status: Open
+
+Evidence:
+- `.gitignore` ignores `package-lock.json` and `pnpm-lock.yaml`.
+- `pnpm audit --prod --json` failed because no `pnpm-lock.yaml` exists.
+
+Risk:
+Builds are not reproducible and dependency audit cannot run reliably. This is a poor base for team or long-lived development.
+
+Recommended fix:
+- Track the package-manager lockfile.
+- Choose one package manager for the repo and document it.
+- Add dependency audit to the release/security checklist.
+
+Validation:
+- Generate and commit the lockfile.
+- Run `pnpm audit --prod` successfully.
+
+### SEC-008: Embedded OpenRouter free-mode keys are reversible
+
+Severity: Medium
+Status: Open
+
+Evidence:
+- `src/server/freeMode.ts` contains encrypted-looking key material and a static `DECRYPT_KEY`.
+
+Risk:
+The embedded keys are extractable by anyone with source access. This should not be treated as secret storage.
+
+Recommended fix:
+- Treat these as public or rotate/remove them.
+- Move real service credentials to server-side secret storage or user-provided configuration.
+
+Validation:
+- Confirm no production credential depends on client-visible or repo-visible reversible material.
+
+### SEC-009: Local file editor loads Ace from a CDN
+
+Severity: Medium
+Status: Open
+
+Evidence:
+- `src/server/localBrowseUi.ts` loads Ace editor assets from a CDN.
+
+Risk:
+The editor runs in a privileged local app context. A CDN compromise or network injection can become privileged same-origin JavaScript.
+
+Recommended fix:
+- Bundle editor assets locally.
+- Add Subresource Integrity if a CDN is still used.
+- Prefer a strict Content Security Policy for local browse/editor pages.
+
+Validation:
+- Run the editor offline and confirm it still works from local assets.
+
+### SEC-010: Composio installer uses curl-to-shell
+
+Severity: Medium
+Status: Open
+
+Evidence:
+- `src/server/codexAppServerBridge.ts`: `installComposioCli()` shells out through a remote install script pattern.
+
+Risk:
+Remote install scripts are difficult to verify and can change independently of this repo.
+
+Recommended fix:
+- Prefer pinned package-manager installs or checksum-verified artifacts.
+- Show the exact command and require user confirmation before execution.
+
+Validation:
+- Verify installer path refuses to run without explicit confirmation and logs the exact source/version.
+
+### SEC-011: Request body handling lacks a uniform size policy
+
+Severity: Medium
+Status: Open
+
+Evidence:
+- `src/server/codexAppServerBridge.ts` has manual body readers and upload handlers.
+- `src/server/unifiedResponsesProxy.ts` buffers request/response bodies.
+- `src/server/accountRoutes.ts` reads full request bodies manually.
+
+Risk:
+Large requests or upstream responses can cause memory pressure or denial of service.
+
+Recommended fix:
+- Centralize body parsing with explicit limits.
+- Add per-route limits for JSON, file upload, and proxy paths.
+- Stream large proxy responses where feasible.
+
+Validation:
+- Send oversized JSON/upload/proxy payloads and confirm predictable `413` or streaming behavior.
+
+### SEC-012: Custom provider endpoint can fetch arbitrary base URLs
+
+Severity: Medium
+Status: Open
+
+Evidence:
+- `src/server/codexAppServerBridge.ts` accepts custom provider `baseUrl` and fetches models.
+- `src/server/customEndpointProxy.ts` proxies custom endpoint traffic.
+
+Risk:
+Authenticated users can point the backend at arbitrary URLs, which can become SSRF-like behavior in shared deployments.
+
+Recommended fix:
+- Restrict custom endpoint usage to trusted local mode, or add allowlists/blocklists.
+- Block private metadata/network ranges unless explicitly allowed.
+- Log destination hostnames.
+
+Validation:
+- Attempt provider URLs against loopback, link-local metadata, and private ranges; confirm policy behavior.
+
+### SEC-013: Firebase client config should be checked for restrictions
+
+Severity: Medium/Low
+Status: Open
+
+Evidence:
+- `src/composables/useGithubSkillsSync.ts` contains Firebase client configuration.
+
+Risk:
+Firebase API keys are often public client config, but security depends on project rules and domain restrictions outside this repo.
+
+Recommended fix:
+- Verify Firebase Auth/Firestore/Storage rules and allowed domains.
+- Document why this client config is safe to publish.
+
+Validation:
+- Review Firebase console rules and restrictions.
+
+### SEC-014: Mutating API routes lack clear CSRF/origin protection
+
+Severity: Medium/Low
+Status: Open
+
+Evidence:
+- `src/server/authMiddleware.ts` uses a session cookie with `SameSite=Lax`.
+- No uniform Origin/CSRF check was identified for mutating `/codex-api/*` routes during static review.
+
+Risk:
+This may be acceptable for local-only usage, but shared/tunneled deployments should not rely only on cookie defaults.
+
+Recommended fix:
+- Add Origin/Host validation for mutating requests.
+- Consider CSRF tokens for browser form-like flows.
+- Keep API token or session checks consistent across websocket and HTTP paths.
+
+Validation:
+- Attempt cross-origin POSTs to mutating endpoints and confirm rejection.
+
+### SEC-015: Legacy password-in-URL login path exists
+
+Severity: Low/Medium
+Status: Open
+
+Evidence:
+- `src/server/authMiddleware.ts` supports a `/password=<value>` style login path.
+- Current tunnel URL builder appears not to emit this by default, but the route remains.
+
+Risk:
+Passwords in URLs can leak through browser history, logs, screenshots, and referrers.
+
+Recommended fix:
+- Remove the URL-password route or gate it behind explicit dev-only mode.
+- Prefer POST-based login.
+
+Validation:
+- Confirm `/password=<value>` is disabled in normal mode.
+
+## Suggested Adjustment Order
+
+1. Runtime safety: fix `SEC-001` first so the default app-server runtime is not full-access/no-approval unless explicitly requested.
+2. Origin isolation: fix `SEC-002` and `SEC-003` together because local browse and local edit share the same trust boundary.
+3. Access boundary: tighten `SEC-004`, `SEC-005`, `SEC-014`, and `SEC-015`.
+4. Secret and supply-chain hygiene: fix `SEC-006`, `SEC-007`, `SEC-008`, and `SEC-009`.
+5. Feature-specific hardening: address `SEC-010`, `SEC-011`, `SEC-012`, and `SEC-013`.
+
+## Current Baseline Notes
+
+- This document is a living tracker, not a completed penetration test.
+- The first audit was static only and should be followed by focused reproduction tests for the highest-risk paths.
+- `pnpm audit --prod --json` could not run because the repo has no committed `pnpm-lock.yaml`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -926,6 +926,7 @@
                   :skills="installedSkills"
                   :thread-token-usage="selectedThreadTokenUsage"
                   :codex-quota="codexQuota"
+                  :runtime-config="appServerRuntimeConfig"
                   :is-turn-in-progress="false"
                   :is-stop-pending="false"
                   :is-interrupting-turn="false" :send-with-enter="sendWithEnter" :in-progress-submit-mode="inProgressSendMode"
@@ -1007,6 +1008,7 @@
                     :skills="installedSkills"
                     :thread-token-usage="selectedThreadTokenUsage"
                     :codex-quota="codexQuota"
+                    :runtime-config="appServerRuntimeConfig"
                     :is-turn-in-progress="isSelectedThreadInProgress"
                     :is-stop-pending="isSelectedThreadInterruptPending"
                     :is-interrupting-turn="isInterruptingTurn"
@@ -1129,6 +1131,7 @@ import {
   createPermanentWorktree,
   createWorktree,
   createProjectlessThreadDirectory,
+  getAppServerRuntimeConfig,
   getGitBranchState,
   getGitBranchCommits,
   getGitRepositoryStatus,
@@ -1156,7 +1159,7 @@ import {
 } from './api/codexGateway'
 import type { ReasoningEffort, SpeedMode, UiAccountEntry, UiRateLimitWindow, UiServerRequest, UiServerRequestReply, UiThreadAutomation, UiThreadTokenUsage } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
-import type { GitCommitOption, LocalDirectoryEntry, TelegramStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
+import type { AppServerRuntimeConfig, GitCommitOption, LocalDirectoryEntry, TelegramStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, isProjectlessChatPath, normalizePathForUi } from './pathUtils.js'
 
@@ -1581,6 +1584,7 @@ const telegramStatus = ref<TelegramStatus>({
   allowAllUsers: false,
   lastError: '',
 })
+const appServerRuntimeConfig = ref<AppServerRuntimeConfig | null>(null)
 const mobileHiddenAtMs = ref<number | null>(null)
 const mobileResumeReloadTriggered = ref(false)
 const mobileResumeSyncInProgress = ref(false)
@@ -2007,6 +2011,7 @@ onMounted(() => {
   void refreshDefaultProjectName()
   void refreshTelegramConfig()
   void refreshTelegramStatus()
+  void refreshAppServerRuntimeConfig()
   void loadFreeModeStatus()
   void refreshThreadTerminalStatus()
   void refreshTerminalQuickCommands()
@@ -2102,6 +2107,14 @@ watch(accounts, () => {
 
 function onSkillsChanged(): void {
   void refreshSkills()
+}
+
+async function refreshAppServerRuntimeConfig(): Promise<void> {
+  try {
+    appServerRuntimeConfig.value = await getAppServerRuntimeConfig()
+  } catch {
+    appServerRuntimeConfig.value = null
+  }
 }
 
 async function refreshTelegramStatus(): Promise<void> {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -64,6 +64,12 @@ type CurrentModelConfig = {
   speedMode: SpeedMode
 }
 
+export type AppServerRuntimeConfig = {
+  sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access'
+  approvalPolicy: 'untrusted' | 'on-failure' | 'on-request' | 'never'
+  isUnsafe: boolean
+}
+
 export type DirectoryPluginSummary = {
   id: string
   name: string
@@ -1941,6 +1947,37 @@ export async function getCurrentModelConfig(): Promise<CurrentModelConfig> {
   const reasoningEffort = normalizeReasoningEffort(payload.config.model_reasoning_effort)
   const speedMode = normalizeSpeedMode(payload.config.service_tier)
   return { model, providerId, reasoningEffort, speedMode }
+}
+
+export async function getAppServerRuntimeConfig(): Promise<AppServerRuntimeConfig> {
+  const response = await fetch('/codex-api/runtime-config')
+  const payload = await readJsonResponse(response)
+  if (!response.ok) {
+    throw new Error(getErrorMessageFromPayload(payload, 'Failed to load Codex runtime configuration'))
+  }
+  const data = asRecord(payload)
+  const sandboxMode = readString(data?.sandboxMode)
+  const approvalPolicy = readString(data?.approvalPolicy)
+  if (
+    sandboxMode !== 'read-only' &&
+    sandboxMode !== 'workspace-write' &&
+    sandboxMode !== 'danger-full-access'
+  ) {
+    throw new Error('Invalid Codex runtime sandbox mode')
+  }
+  if (
+    approvalPolicy !== 'untrusted' &&
+    approvalPolicy !== 'on-failure' &&
+    approvalPolicy !== 'on-request' &&
+    approvalPolicy !== 'never'
+  ) {
+    throw new Error('Invalid Codex runtime approval policy')
+  }
+  return {
+    sandboxMode,
+    approvalPolicy,
+    isUnsafe: data?.isUnsafe === true,
+  }
 }
 
 function normalizeDirectoryPluginApp(value: unknown): DirectoryPluginAppSummary | null {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
   resolveCodexCommand,
 } from '../commandResolution.js'
 import {
+  isUnsafeAppServerRuntimeConfig,
   parseApprovalPolicy,
   parseSandboxMode,
   resolveAppServerRuntimeConfig,
@@ -566,6 +567,13 @@ async function startServer(options: {
     `  Codex sandbox: ${runtimeConfig.sandboxMode}`,
     `  Approval policy: ${runtimeConfig.approvalPolicy}`,
   ]
+  if (isUnsafeAppServerRuntimeConfig(runtimeConfig)) {
+    lines.push(
+      '',
+      '  WARNING: CodexUI is running with full local access and no approvals.',
+      '  Only use this mode on a trusted personal machine.',
+    )
+  }
   const accessUrls = getAccessibleUrls(port)
   if (accessUrls.length > 0) {
     lines.push(`  Local:    ${accessUrls[0]}`)

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -257,6 +257,15 @@
         </div>
 
         <template v-if="!isDictationRecording">
+          <span
+            v-if="showFullAccessWarning"
+            class="thread-composer-runtime-warning"
+            :title="fullAccessWarningTitle"
+            :aria-label="fullAccessWarningTitle"
+          >
+            {{ t('Full access') }}
+          </span>
+
           <ComposerDropdown
             class="thread-composer-control"
             :model-value="selectedModel"
@@ -410,6 +419,7 @@ import {
   removeComposerPrompt,
   searchComposerFiles,
   uploadFile,
+  type AppServerRuntimeConfig,
   type ComposerFileSuggestion,
   type ComposerPromptInfo,
 } from '../../api/codexGateway'
@@ -444,6 +454,7 @@ const props = defineProps<{
   skills?: SkillItem[]
   threadTokenUsage?: UiThreadTokenUsage | null
   codexQuota?: UiRateLimitSnapshot | null
+  runtimeConfig?: AppServerRuntimeConfig | null
   isTurnInProgress?: boolean
   isStopPending?: boolean
   isInterruptingTurn?: boolean
@@ -657,6 +668,10 @@ const standaloneFileAttachments = computed(() => {
 })
 const isInteractionDisabled = computed(() => props.disabled || !props.activeThreadId)
 const isComposerConfigDisabled = computed(() => props.disabled || !props.activeThreadId)
+const showFullAccessWarning = computed(() => props.runtimeConfig?.isUnsafe === true)
+const fullAccessWarningTitle = computed(() =>
+  t('Full local access is enabled and Codex will not ask for approvals.'),
+)
 const isFastModeSupported = computed(() => /^gpt-5\.(?:4|5)(?:$|-)/.test(props.selectedModel.trim()))
 const showFastModeModelIcon = computed(() =>
   props.selectedSpeedMode === 'fast' && isFastModeSupported.value,
@@ -2208,6 +2223,10 @@ watch(
 
 .thread-composer-control {
   @apply shrink-1 min-w-0;
+}
+
+.thread-composer-runtime-warning {
+  @apply inline-flex h-8 shrink-0 items-center rounded-full border border-amber-300 bg-amber-50 px-2.5 text-xs font-medium text-amber-800;
 }
 
 .thread-composer-control :deep(.composer-dropdown-value) {

--- a/src/composables/useUiLanguage.ts
+++ b/src/composables/useUiLanguage.ts
@@ -40,6 +40,8 @@ const zhCN: Record<string, string> = {
   'Click to toggle dictation': '点击切换语音输入',
   'Auto send dictation': '语音输入后自动发送',
   'Provider': '提供方',
+  'Full access': '完全访问',
+  'Full local access is enabled and Codex will not ask for approvals.': '已启用完整本地访问权限，Codex 不会请求审批。',
   'Choose the API provider for the Codex backend': '选择 Codex 后端使用的 API 提供方',
   'OpenRouter API key': 'OpenRouter API Key',
   'Get API key': '获取 API Key',

--- a/src/server/appServerRuntimeConfig.test.ts
+++ b/src/server/appServerRuntimeConfig.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildAppServerArgs,
+  isUnsafeAppServerRuntimeConfig,
+  resolveAppServerRuntimeConfig,
+} from './appServerRuntimeConfig'
+
+describe('app-server runtime config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults to workspace-write with on-request approvals', () => {
+    vi.stubEnv('CODEXUI_SANDBOX_MODE', '')
+    vi.stubEnv('CODEXUI_APPROVAL_POLICY', '')
+
+    expect(resolveAppServerRuntimeConfig()).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-request',
+    })
+
+    expect(buildAppServerArgs()).toEqual([
+      'app-server',
+      '-c',
+      'approval_policy="on-request"',
+      '-c',
+      'sandbox_mode="workspace-write"',
+    ])
+  })
+
+  it('honors explicit unsafe local runtime environment values', () => {
+    vi.stubEnv('CODEXUI_SANDBOX_MODE', 'danger-full-access')
+    vi.stubEnv('CODEXUI_APPROVAL_POLICY', 'never')
+
+    const config = resolveAppServerRuntimeConfig()
+
+    expect(config).toEqual({
+      sandboxMode: 'danger-full-access',
+      approvalPolicy: 'never',
+    })
+    expect(isUnsafeAppServerRuntimeConfig(config)).toBe(true)
+    expect(buildAppServerArgs()).toContain('approval_policy="never"')
+    expect(buildAppServerArgs()).toContain('sandbox_mode="danger-full-access"')
+  })
+
+  it('falls back to safe defaults for invalid environment values', () => {
+    vi.stubEnv('CODEXUI_SANDBOX_MODE', 'bad-sandbox')
+    vi.stubEnv('CODEXUI_APPROVAL_POLICY', 'bad-policy')
+
+    expect(resolveAppServerRuntimeConfig()).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-request',
+    })
+  })
+})

--- a/src/server/appServerRuntimeConfig.ts
+++ b/src/server/appServerRuntimeConfig.ts
@@ -14,14 +14,14 @@ const APPROVAL_POLICIES = new Set([
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access'
 export type CodexApprovalPolicy = 'untrusted' | 'on-failure' | 'on-request' | 'never'
 
-type AppServerRuntimeConfig = {
+export type AppServerRuntimeConfig = {
   sandboxMode: CodexSandboxMode
   approvalPolicy: CodexApprovalPolicy
 }
 
 const DEFAULT_RUNTIME_CONFIG: AppServerRuntimeConfig = {
-  sandboxMode: 'danger-full-access',
-  approvalPolicy: 'never',
+  sandboxMode: 'workspace-write',
+  approvalPolicy: 'on-request',
 }
 
 function normalizeRuntimeValue(value: string | undefined): string {
@@ -49,6 +49,10 @@ export function resolveAppServerRuntimeConfig(): AppServerRuntimeConfig {
     sandboxMode: readSandboxModeFromEnv(),
     approvalPolicy: readApprovalPolicyFromEnv(),
   }
+}
+
+export function isUnsafeAppServerRuntimeConfig(config: AppServerRuntimeConfig = resolveAppServerRuntimeConfig()): boolean {
+  return config.sandboxMode === 'danger-full-access' && config.approvalPolicy === 'never'
 }
 
 export function buildAppServerArgs(): string[] {

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -11,7 +11,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
 import { handleAccountRoutes } from './accountRoutes.js'
-import { buildAppServerArgs } from './appServerRuntimeConfig.js'
+import { buildAppServerArgs, isUnsafeAppServerRuntimeConfig, resolveAppServerRuntimeConfig } from './appServerRuntimeConfig.js'
 import { handleReviewRoutes } from './reviewGit.js'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
 import { TelegramThreadBridge } from './telegramThreadBridge.js'
@@ -4709,11 +4709,7 @@ class AppServerProcess {
   }
 
   private buildAppServerConfig(): { args: string[]; env: Record<string, string> } {
-    const args = [
-      'app-server',
-      '-c', 'approval_policy="never"',
-      '-c', 'sandbox_mode="danger-full-access"',
-    ]
+    const args = [...this.appServerArgs]
     let extraEnv: Record<string, string> = {}
     const serverPort = parseInt(process.env.CODEXUI_SERVER_PORT ?? '', 10) || undefined
     const statePath = join(getCodexHomeDir(), FREE_MODE_STATE_FILE)
@@ -6200,6 +6196,16 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'POST' && url.pathname === '/codex-api/upload-file') {
         handleFileUpload(req, res)
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/runtime-config') {
+        const runtimeConfig = resolveAppServerRuntimeConfig()
+        setJson(res, 200, {
+          sandboxMode: runtimeConfig.sandboxMode,
+          approvalPolicy: runtimeConfig.approvalPolicy,
+          isUnsafe: isUnsafeAppServerRuntimeConfig(runtimeConfig),
+        })
         return
       }
 

--- a/src/style.css
+++ b/src/style.css
@@ -283,6 +283,10 @@
   @apply text-zinc-400 hover:text-zinc-200;
 }
 
+:root.dark .thread-composer-runtime-warning {
+  @apply border-amber-500/50 bg-amber-950/60 text-amber-200;
+}
+
 :root.dark .thread-composer-submit {
   @apply bg-zinc-200 text-zinc-900 hover:bg-white;
 }

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,42 @@ Rollback/cleanup:
 
 ---
 
+### Codex runtime safer defaults and full-access warning
+
+#### Feature/Change Name
+SEC-001 app-server runtime default hardening and composer full-access status.
+
+#### Prerequisites/Setup
+1. Dev server can be started with `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. A product/CLI startup path is available without setting `CODEXUI_SANDBOX_MODE` or `CODEXUI_APPROVAL_POLICY`.
+3. Light theme and dark theme are available from the appearance switcher.
+
+#### Steps
+1. Run the unit test: `pnpm exec vitest run src/server/appServerRuntimeConfig.test.ts`.
+2. Start the app without `CODEXUI_SANDBOX_MODE` or `CODEXUI_APPROVAL_POLICY`.
+3. Call `GET /codex-api/runtime-config`.
+4. Confirm the response reports `sandboxMode: "workspace-write"`, `approvalPolicy: "on-request"`, and `isUnsafe: false`.
+5. Open the composer in light theme and confirm no `Full access` warning pill is visible.
+6. Start the app with `CODEXUI_SANDBOX_MODE=danger-full-access CODEXUI_APPROVAL_POLICY=never`.
+7. Confirm startup output includes a warning about full local access and no approvals.
+8. Call `GET /codex-api/runtime-config` again and confirm `isUnsafe: true`.
+9. Open the composer in light theme and confirm the `Full access` warning pill is visible near the composer controls.
+10. Hover or inspect the warning and confirm the title says full local access is enabled and Codex will not ask for approvals.
+11. Switch to dark theme and repeat steps 9-10.
+
+#### Expected Results
+- Normal startup uses `workspace-write + on-request`.
+- Explicit unsafe startup still works for trusted local development.
+- The app-server bridge and temporary account-validation app-server both consume the centralized runtime config.
+- The composer warning is read-only and does not imply per-message permission switching.
+- The warning is visible and legible in both light theme and dark theme.
+
+#### Rollback/Cleanup
+- Stop the temporary dev server.
+- Unset `CODEXUI_SANDBOX_MODE` and `CODEXUI_APPROVAL_POLICY` after unsafe-mode testing.
+
+---
+
 ### Qodo feedback diagnostics reliability fixes
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- change Codex app-server default runtime to `workspace-write + on-request`
- route the main app-server process through centralized runtime config instead of hardcoded full access
- add a read-only runtime config endpoint and composer `Full access` warning for unsafe mode
- document the SEC-001 audit decision and manual test steps

## Verification
- `pnpm exec vitest run src/server/appServerRuntimeConfig.test.ts`
- `pnpm run build:frontend`
- `pnpm run build:cli`
- verified default CLI runtime returns `workspace-write/on-request/isUnsafe:false`
- verified unsafe runtime prints warning and returns `danger-full-access/never/isUnsafe:true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration fetching from the server with validation.
  * Introduced a "Full access" warning indicator displayed when the app runs in unsafe mode.
  * Updated default configuration to safer values for sandbox mode and approval policy.

* **Documentation**
  * Added comprehensive security audit documentation tracking identified issues and recommendations.
  * Added regression test documentation for runtime configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codexUI/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->