### PR TITLE
Fix bold-wrapped chat links

### DIFF
--- a/llm-wiki/raw/fixes/codex-thread-link-pr174.md
+++ b/llm-wiki/raw/fixes/codex-thread-link-pr174.md
@@ -1,0 +1,58 @@
+# Codex Thread Link Rendering And Review Follow-Up
+
+Captured: 2026-05-15
+
+## Source Context
+
+Branch: `codex/fix-bold-wrapped-chat-links`
+
+Pull request: `friuns2/codexUI#174`
+
+Relevant files:
+- `src/components/content/ThreadConversation.vue`
+- `tests.md`
+- `scripts/profile-browser-runtime.cjs`
+
+## Problem
+
+Chat messages could expose markdown formatting markers or app-internal thread URLs in ways that were wrong for the web UI:
+
+- Bold-wrapped links could show literal `**` around the link.
+- Triple-asterisk-wrapped links such as `***https://example.com***` could leave stray `*` characters or include `*` in the href.
+- Bare `codex://threads/<id>` links needed to become browser-openable web thread URLs.
+- Markdown links such as `[Open thread](codex://threads/<id>)` needed to preserve `Open thread` as visible text while rewriting only the href.
+
+## Review Findings
+
+Qodo and CodeRabbit comments were treated as advisory findings and checked against the current code before changes were made.
+
+Accepted findings:
+- Triple-asterisk links were a real parser bug and were fixed with asterisk-wrapper handling shared by bare URL and markdown-link parsing.
+- Markdown `codex://threads/<id>` links originally rendered the rewritten local URL as visible text; this was fixed so the authored Markdown label remains visible.
+- `toLocalThreadUrl()` initially hardcoded `http://localhost:5173/#/thread/<id>`, which was a real portability bug for Vite auto-increment ports, `127.0.0.1:4173` profiling, and other origins.
+
+Final thread-link behavior:
+- Bare `codex://threads/<id>` renders as a local web thread URL.
+- Markdown `[label](codex://threads/<id>)` renders `label` as visible text and points to the local web thread URL.
+- The local web thread URL is built from the current `window.location.origin` and pathname, not a fixed `localhost:5173` origin. Server-side fallback returns `/#/thread/<id>`.
+
+## Verification
+
+Build and focused browser checks were run after the review follow-up:
+
+- `pnpm run build:frontend` passed after temporarily symlinking the shared `node_modules` tree for this worktree.
+- CJS Playwright opened `http://localhost:5174/#/thread/019e28d8-cf3b-7f63-a0fa-495a0c5c90bd`.
+- The bare link `codex://threads/019e04cb-9670-7d91-be85-3ba35312170c` rendered as `http://localhost:5174/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
+- The Markdown link `[Open thread](codex://threads/019e04cb-9670-7d91-be85-3ba35312170c)` rendered visible text `Open thread` with href `http://localhost:5174/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
+- Light-theme and dark-theme link assertions both passed.
+- `PROFILE_BASE_URL=http://localhost:5174 PROFILE_ROUTE='#/thread/019e28d8-cf3b-7f63-a0fa-495a0c5c90bd' PROFILE_WAIT_MS=7000 pnpm run profile:browser` completed.
+- Profile result: `totalApiKB=239.3`, `threadRead=4` warning remained an existing route behavior, not caused by the parser/link change.
+
+## PR Follow-Up
+
+The dynamic-origin fix was committed as `7f6307b2 Use current origin for codex thread links` and pushed to PR `friuns2/codexUI#174`.
+
+After the push:
+- `/review` was posted as an ordinary PR comment.
+- CodeRabbit status check passed.
+- Qodo acknowledged the new review request and was still analyzing when checked shortly after the push; the old persistent comment still contained pre-fix text.

--- a/llm-wiki/wiki/concepts/realtime-chat-rendering.md
+++ b/llm-wiki/wiki/concepts/realtime-chat-rendering.md
@@ -48,6 +48,20 @@ The bridge should not send those strings directly to the browser. Instead, threa
 
 This is a read-path/UI-payload optimization. It does not compact historical JSONL files on disk.
 
+## Chat Link Parsing And Thread URLs
+
+`ThreadConversation.vue` also owns local inline parsing for chat links. A PR #174 review follow-up established these rules for Codex thread links and bold-wrapped URLs:
+
+- bare `codex://threads/<id>` should render as a browser-openable local web thread URL
+- Markdown links such as `[Open thread](codex://threads/<id>)` should preserve the authored label as visible text while rewriting only the href
+- the rewritten thread URL must use the current browser origin and app path, not a hardcoded `http://localhost:5173`
+- bold and triple-asterisk wrappers around bare URLs or Markdown links should not leak literal `*` characters into visible text or hrefs
+
+Review-bot comments on this path should be verified against current code before patching. In PR #174, Qodo and CodeRabbit surfaced three real issues: triple-asterisk parsing, Markdown label loss, and fixed-port thread URLs. The fixed-port issue was resolved by building local thread URLs from `window.location.origin` plus the current pathname, with a server-side fallback of `/#/thread/<id>`.
+
+Source:
+- [Codex thread link rendering and PR #174 review follow-up](../../raw/fixes/codex-thread-link-pr174.md)
+
 ## Verification Notes
 
 Use `scripts/profile-testchat-realtime.cjs` for realtime rendering checks and `scripts/profile-browser-runtime.cjs` for startup/large-thread profiles.
@@ -57,5 +71,7 @@ Useful assertions:
 - no persistent `todo-render-profile-*` directories remain after TestChat profiling
 - long task count remains low/zero during streaming
 - file links still render with correct href/title/text
+- Codex thread links render with the current app origin; Markdown labels such as `Open thread` remain visible
+- bold/triple-asterisk wrapped links render without stray `*` characters
 - large image-heavy threads render images through `/codex-local-image`, not `data:` URLs
 - `thread/resume` payloads stay bounded even when raw JSONL files are tens of MB

--- a/llm-wiki/wiki/index.md
+++ b/llm-wiki/wiki/index.md
@@ -24,5 +24,6 @@
 - [../raw/features/thread-heartbeat-automations.md](../raw/features/thread-heartbeat-automations.md): source facts for thread heartbeat automations, multiple automations per thread, and Run now queue behavior.
 - [../raw/features/project-cron-automations.md](../raw/features/project-cron-automations.md): source facts for project cron automations in the sidebar.
 - [../raw/projects/codex-web-local.md](../raw/projects/codex-web-local.md): immutable source snapshot for project facts.
+- [../raw/fixes/codex-thread-link-pr174.md](../raw/fixes/codex-thread-link-pr174.md): source facts for PR #174 chat link parsing fixes, review-bot findings, and dynamic-origin thread URLs.
 - [../raw/fixes/opencode-zen-big-pickle-codex-cli.md](../raw/fixes/opencode-zen-big-pickle-codex-cli.md): Big Pickle + Codex CLI fix details.
 - [../raw/fixes/opencode-zen-reasoning-content-proxy.md](../raw/fixes/opencode-zen-reasoning-content-proxy.md): Codex Web Local Zen proxy reasoning_content round-trip fix and Docker verification.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## [2026-05-15] ingest | codex thread link rendering review follow-up
+- Added source: `raw/fixes/codex-thread-link-pr174.md`.
+- Updated wiki page: `concepts/realtime-chat-rendering.md`.
+- Documents: PR #174 chat link parser fixes, Qodo/CodeRabbit finding triage, dynamic-origin `codex://threads/<id>` URL rewriting, light/dark Playwright checks, and profile result.
+- Updated `index.md`.
+
 ## [2026-05-02] ingest | Directory Hub Composio and Skills search
 - Added source: `raw/features/directory-hub-composio-skills-search.md`.
 - Created wiki page: `concepts/directory-hub-composio-skills.md`.

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -1652,7 +1652,9 @@ function parseMarkdownLinkToken(value: string): { label: string; target: string 
 function toLocalThreadUrl(value: string): string | null {
   const match = value.trim().match(/^codex:\/\/threads\/([A-Za-z0-9-]+)$/u)
   if (!match) return null
-  return `http://localhost:5173/#/thread/${match[1]}`
+  if (typeof window === 'undefined') return `/#/thread/${match[1]}`
+  const basePath = window.location.pathname.replace(/\/?$/u, '/')
+  return `${window.location.origin}${basePath}#/thread/${match[1]}`
 }
 
 function headingTag(level: number): string {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -2228,12 +2228,22 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
     if (typeof match.index !== 'number') continue
     const start = match.index
     const end = start + match[0].length
+    const isBoldWrapped =
+      start - 2 >= cursor &&
+      text.slice(start - 2, start) === '**' &&
+      text.slice(end, end + 2) === '**'
+    const hasLeadingBoldMarker =
+      start - 2 >= cursor &&
+      text.slice(start - 2, start) === '**' &&
+      match[0].endsWith('**')
+    const segmentStart = isBoldWrapped || hasLeadingBoldMarker ? start - 2 : start
+    const segmentEnd = isBoldWrapped ? end + 2 : end
 
-    if (start > cursor) {
-      segments.push({ kind: 'text', value: text.slice(cursor, start) })
+    if (segmentStart > cursor) {
+      segments.push({ kind: 'text', value: text.slice(cursor, segmentStart) })
     }
 
-    let token = match[0]
+    let token = hasLeadingBoldMarker ? match[0].slice(0, -2) : match[0]
     let trailingPunctuation = ''
     while (/[.,;:!?，。；：！？、]$/u.test(token)) {
       trailingPunctuation = token.slice(-1) + trailingPunctuation
@@ -2276,7 +2286,7 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
       }
     }
 
-    cursor = end
+    cursor = segmentEnd
   }
 
   if (cursor < text.length) {
@@ -2435,16 +2445,22 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     const match = findNextMarkdownLink(text, scanFrom)
     if (!match) break
     const { start, end, token } = match
+    const isBoldWrapped =
+      start - 2 >= cursor &&
+      text.slice(start - 2, start) === '**' &&
+      text.slice(end, end + 2) === '**'
+    const segmentStart = isBoldWrapped ? start - 2 : start
+    const segmentEnd = isBoldWrapped ? end + 2 : end
 
-    if (start > cursor) {
-      segments.push(...splitPlainTextByLinks(text.slice(cursor, start)))
+    if (segmentStart > cursor) {
+      segments.push(...splitPlainTextByLinks(text.slice(cursor, segmentStart)))
     }
 
     const markdownToken = parseMarkdownLinkToken(token)
     if (!markdownToken) {
-      segments.push(...splitPlainTextByLinks(text.slice(start, end)))
-      cursor = end
-      scanFrom = end
+      segments.push(...splitPlainTextByLinks(text.slice(segmentStart, segmentEnd)))
+      cursor = segmentEnd
+      scanFrom = segmentEnd
       continue
     }
     const label = markdownToken.label
@@ -2467,8 +2483,8 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
       }
     }
 
-    cursor = end
-    scanFrom = end
+    cursor = segmentEnd
+    scanFrom = segmentEnd
   }
 
   if (cursor < text.length) {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -2524,7 +2524,7 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     const localThreadUrl = toLocalThreadUrl(target)
 
     if (localThreadUrl) {
-      segments.push({ kind: 'url', value: localThreadUrl, href: localThreadUrl })
+      segments.push({ kind: 'url', value: label || localThreadUrl, href: localThreadUrl })
     } else if (/^https?:\/\//u.test(target)) {
       segments.push({ kind: 'url', value: label || target, href: target })
     } else {
@@ -2614,7 +2614,7 @@ function parseInlineSegmentsUncached(text: string): InlineSegment[] {
           if (localThreadUrl) {
             segments.push({
               kind: 'url',
-              value: localThreadUrl,
+              value: markdownLink.label || localThreadUrl,
               href: localThreadUrl,
             })
           } else if (/^https?:\/\//u.test(markdownLink.target)) {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -1583,6 +1583,57 @@ function trimLinkWrappers(value: string): { core: string; leading: string; trail
   return { core, leading, trailing }
 }
 
+function countAsterisksBefore(value: string, endIndex: number, minIndex: number): number {
+  let count = 0
+  let index = endIndex - 1
+  while (index >= minIndex && value[index] === '*') {
+    count += 1
+    index -= 1
+  }
+  return count
+}
+
+function countAsterisksAfter(value: string, startIndex: number): number {
+  let count = 0
+  let index = startIndex
+  while (index < value.length && value[index] === '*') {
+    count += 1
+    index += 1
+  }
+  return count
+}
+
+function readAsteriskLinkWrapper(
+  source: string,
+  matchStart: number,
+  matchEnd: number,
+  cursor: number,
+  matchedToken: string,
+): { segmentStart: number; segmentEnd: number; tokenEndTrim: number } | null {
+  const leadingCount = countAsterisksBefore(source, matchStart, cursor)
+  if (leadingCount < 2) return null
+
+  const trailingOutsideCount = countAsterisksAfter(source, matchEnd)
+  if (trailingOutsideCount >= leadingCount) {
+    return {
+      segmentStart: matchStart - leadingCount,
+      segmentEnd: matchEnd + leadingCount,
+      tokenEndTrim: 0,
+    }
+  }
+
+  const trailingInsideCount = countAsterisksBefore(matchedToken, matchedToken.length, 0)
+  if (trailingInsideCount >= leadingCount) {
+    return {
+      segmentStart: matchStart - leadingCount,
+      segmentEnd: matchEnd,
+      tokenEndTrim: leadingCount,
+    }
+  }
+
+  return null
+}
+
 function parseMarkdownLinkToken(value: string): { label: string; target: string } | null {
   const trimmed = value.trim()
   if (!trimmed.startsWith('[') || !trimmed.endsWith(')')) return null
@@ -2228,22 +2279,17 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
     if (typeof match.index !== 'number') continue
     const start = match.index
     const end = start + match[0].length
-    const isBoldWrapped =
-      start - 2 >= cursor &&
-      text.slice(start - 2, start) === '**' &&
-      text.slice(end, end + 2) === '**'
-    const hasLeadingBoldMarker =
-      start - 2 >= cursor &&
-      text.slice(start - 2, start) === '**' &&
-      match[0].endsWith('**')
-    const segmentStart = isBoldWrapped || hasLeadingBoldMarker ? start - 2 : start
-    const segmentEnd = isBoldWrapped ? end + 2 : end
+    const asteriskWrapper = readAsteriskLinkWrapper(text, start, end, cursor, match[0])
+    const segmentStart = asteriskWrapper?.segmentStart ?? start
+    const segmentEnd = asteriskWrapper?.segmentEnd ?? end
 
     if (segmentStart > cursor) {
       segments.push({ kind: 'text', value: text.slice(cursor, segmentStart) })
     }
 
-    let token = hasLeadingBoldMarker ? match[0].slice(0, -2) : match[0]
+    let token = asteriskWrapper?.tokenEndTrim
+      ? match[0].slice(0, -asteriskWrapper.tokenEndTrim)
+      : match[0]
     let trailingPunctuation = ''
     while (/[.,;:!?，。；：！？、]$/u.test(token)) {
       trailingPunctuation = token.slice(-1) + trailingPunctuation
@@ -2445,12 +2491,9 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     const match = findNextMarkdownLink(text, scanFrom)
     if (!match) break
     const { start, end, token } = match
-    const isBoldWrapped =
-      start - 2 >= cursor &&
-      text.slice(start - 2, start) === '**' &&
-      text.slice(end, end + 2) === '**'
-    const segmentStart = isBoldWrapped ? start - 2 : start
-    const segmentEnd = isBoldWrapped ? end + 2 : end
+    const asteriskWrapper = readAsteriskLinkWrapper(text, start, end, cursor, token)
+    const segmentStart = asteriskWrapper?.segmentStart ?? start
+    const segmentEnd = asteriskWrapper?.segmentEnd ?? end
 
     if (segmentStart > cursor) {
       segments.push(...splitPlainTextByLinks(text.slice(cursor, segmentStart)))

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -1649,6 +1649,12 @@ function parseMarkdownLinkToken(value: string): { label: string; target: string 
   return { label, target }
 }
 
+function toLocalThreadUrl(value: string): string | null {
+  const match = value.trim().match(/^codex:\/\/threads\/([A-Za-z0-9-]+)$/u)
+  if (!match) return null
+  return `http://localhost:5173/#/thread/${match[1]}`
+}
+
 function headingTag(level: number): string {
   const normalizedLevel = Math.min(6, Math.max(1, Math.trunc(level)))
   return `h${String(normalizedLevel)}`
@@ -2272,7 +2278,7 @@ function editMessage(messageId: string): void {
 
 function splitPlainTextByLinks(text: string): InlineSegment[] {
   const segments: InlineSegment[] = []
-  const pattern = /https?:\/\/[^\s<>"'`，。；：！？、()[\]{}「」『』《》]+|file:\/\/[^\n<>"'`，。；：！？、[\]{}「」『』《》]+|["'](?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^\n"']+["']|`(?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^`\n]+`/gu
+  const pattern = /codex:\/\/threads\/[A-Za-z0-9-]+|https?:\/\/[^\s<>"'`，。；：！？、()[\]{}「」『』《》]+|file:\/\/[^\n<>"'`，。；：！？、[\]{}「」『』《》]+|["'](?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^\n"']+["']|`(?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^`\n]+`/gu
   let cursor = 0
 
   for (const match of text.matchAll(pattern)) {
@@ -2304,7 +2310,14 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
       segments.push({ kind: 'text', value: leading })
     }
 
-    if (token.startsWith('**') && token.endsWith('**') && token.length > 4) {
+    const localThreadUrl = toLocalThreadUrl(token)
+
+    if (localThreadUrl) {
+      segments.push({ kind: 'url', value: localThreadUrl, href: localThreadUrl })
+      if (trailing) {
+        segments.push({ kind: 'text', value: trailing })
+      }
+    } else if (token.startsWith('**') && token.endsWith('**') && token.length > 4) {
       segments.push({ kind: 'bold', value: token.slice(2, -2) })
       if (trailing) {
         segments.push({ kind: 'text', value: trailing })
@@ -2508,8 +2521,11 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     }
     const label = markdownToken.label
     const target = markdownToken.target
+    const localThreadUrl = toLocalThreadUrl(target)
 
-    if (/^https?:\/\//u.test(target)) {
+    if (localThreadUrl) {
+      segments.push({ kind: 'url', value: localThreadUrl, href: localThreadUrl })
+    } else if (/^https?:\/\//u.test(target)) {
       segments.push({ kind: 'url', value: label || target, href: target })
     } else {
       const ref = parseFileReference(target)
@@ -2594,7 +2610,14 @@ function parseInlineSegmentsUncached(text: string): InlineSegment[] {
       if (token.length > 0) {
         const markdownLink = parseMarkdownLinkToken(token)
         if (markdownLink) {
-          if (/^https?:\/\//u.test(markdownLink.target)) {
+          const localThreadUrl = toLocalThreadUrl(markdownLink.target)
+          if (localThreadUrl) {
+            segments.push({
+              kind: 'url',
+              value: localThreadUrl,
+              href: localThreadUrl,
+            })
+          } else if (/^https?:\/\//u.test(markdownLink.target)) {
             segments.push({
               kind: 'url',
               value: markdownLink.label || markdownLink.target,
@@ -2614,27 +2637,36 @@ function parseInlineSegmentsUncached(text: string): InlineSegment[] {
               segments.push({ kind: 'code', value: token })
             }
           }
-        } else if (/^https?:\/\/[^\s]+$/u.test(token)) {
-          segments.push({
-            kind: 'url',
-            value: token,
-            href: token,
-          })
         } else {
-          const fileReference = parseFileReference(token)
-          if (fileReference) {
-            const displayPath = fileReference.line
-              ? `${fileReference.path}:${String(fileReference.line)}`
-              : fileReference.path
+          const localThreadUrl = toLocalThreadUrl(token)
+          if (localThreadUrl) {
             segments.push({
-              kind: 'file',
+              kind: 'url',
+              value: localThreadUrl,
+              href: localThreadUrl,
+            })
+          } else if (/^https?:\/\/[^\s]+$/u.test(token)) {
+            segments.push({
+              kind: 'url',
               value: token,
-              path: fileReference.path,
-              displayPath,
-              downloadName: getBasename(fileReference.path),
+              href: token,
             })
           } else {
-            segments.push({ kind: 'code', value: token })
+            const fileReference = parseFileReference(token)
+            if (fileReference) {
+              const displayPath = fileReference.line
+                ? `${fileReference.path}:${String(fileReference.line)}`
+                : fileReference.path
+              segments.push({
+                kind: 'file',
+                value: token,
+                path: fileReference.path,
+                displayPath,
+                downloadName: getBasename(fileReference.path),
+              })
+            } else {
+              segments.push({ kind: 'code', value: token })
+            }
           }
         }
       } else {

--- a/tests.md
+++ b/tests.md
@@ -351,12 +351,13 @@ Codex thread link conversion in chat messages.
 2. Send or inspect a message containing a bare Codex thread link, for example `codex://threads/019e04cb-9670-7d91-be85-3ba35312170c`.
 3. Send or inspect a message containing a Markdown Codex thread link, for example `[Open thread](codex://threads/019e04cb-9670-7d91-be85-3ba35312170c)`.
 4. Confirm each rendered row contains a clickable `a.message-file-link`.
-5. Confirm each link href and visible text both equal `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
-6. Switch to dark theme and repeat steps 2 through 5.
+5. Confirm the bare link href and visible text both equal `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
+6. Confirm the Markdown link href equals `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c` and visible text equals `Open thread`.
+7. Switch to dark theme and repeat steps 2 through 6.
 
 #### Expected Results
 - Bare `codex://threads/<id>` links render as local web thread URLs.
-- Markdown links targeting `codex://threads/<id>` ignore the Markdown label and display the local web thread URL.
+- Markdown links targeting `codex://threads/<id>` keep their Markdown label while linking to the local web thread URL.
 - Link color and contrast remain usable in light theme and dark theme.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -349,12 +349,13 @@ Bold-wrapped Markdown link marker cleanup in chat messages.
 #### Steps
 1. In light theme, open `TestChat`.
 2. Send or inspect a message containing a bold-wrapped Markdown link, for example `**https://anyclaw.store/claim/a7m2z7**` or `**[claim link](https://anyclaw.store/claim/a7m2z7)**`.
-3. Confirm the rendered row contains one clickable `a.message-file-link` for the URL.
-4. Confirm no literal `**` characters appear before or after the link.
-5. Switch to dark theme and repeat steps 2 through 4.
+3. Repeat with triple-asterisk wrapping: `***https://anyclaw.store/claim/a7m2z7***` and `***[claim link](https://anyclaw.store/claim/a7m2z7)***`.
+4. Confirm the rendered row contains one clickable `a.message-file-link` for the URL.
+5. Confirm no literal `**`, `***`, or stray `*` characters appear before or after the link.
+6. Switch to dark theme and repeat steps 2 through 5.
 
 #### Expected Results
-- Bold-wrapped bare URLs and Markdown links render as clickable links without visible Markdown emphasis markers.
+- Bold-wrapped and triple-asterisk-wrapped bare URLs and Markdown links render as clickable links without visible Markdown emphasis markers.
 - Existing URL/file-link href, title, and visible link text behavior is unchanged.
 - Link color and contrast remain usable in light theme and dark theme.
 

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,34 @@ Rollback/cleanup:
 
 ---
 
+### Codex thread deep links render as local web thread URLs
+
+#### Feature/Change Name
+Codex thread link conversion in chat messages.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`).
+2. A `TestChat` project/thread is available.
+3. Light theme and dark theme are both available.
+
+#### Steps
+1. In light theme, open `TestChat`.
+2. Send or inspect a message containing a bare Codex thread link, for example `codex://threads/019e04cb-9670-7d91-be85-3ba35312170c`.
+3. Send or inspect a message containing a Markdown Codex thread link, for example `[Open thread](codex://threads/019e04cb-9670-7d91-be85-3ba35312170c)`.
+4. Confirm each rendered row contains a clickable `a.message-file-link`.
+5. Confirm each link href and visible text both equal `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
+6. Switch to dark theme and repeat steps 2 through 5.
+
+#### Expected Results
+- Bare `codex://threads/<id>` links render as local web thread URLs.
+- Markdown links targeting `codex://threads/<id>` ignore the Markdown label and display the local web thread URL.
+- Link color and contrast remain usable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Revert the thread-link conversion in `src/components/content/ThreadConversation.vue` if `codex://threads/<id>` should render literally again.
+
+---
+
 ### Bold-wrapped Markdown links render without literal markers
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,33 @@ Rollback/cleanup:
 
 ---
 
+### Bold-wrapped Markdown links render without literal markers
+
+#### Feature/Change Name
+Bold-wrapped Markdown link marker cleanup in chat messages.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`).
+2. A `TestChat` project/thread is available.
+3. Light theme and dark theme are both available.
+
+#### Steps
+1. In light theme, open `TestChat`.
+2. Send or inspect a message containing a bold-wrapped Markdown link, for example `**https://anyclaw.store/claim/a7m2z7**` or `**[claim link](https://anyclaw.store/claim/a7m2z7)**`.
+3. Confirm the rendered row contains one clickable `a.message-file-link` for the URL.
+4. Confirm no literal `**` characters appear before or after the link.
+5. Switch to dark theme and repeat steps 2 through 4.
+
+#### Expected Results
+- Bold-wrapped bare URLs and Markdown links render as clickable links without visible Markdown emphasis markers.
+- Existing URL/file-link href, title, and visible link text behavior is unchanged.
+- Link color and contrast remain usable in light theme and dark theme.
+
+#### Rollback/Cleanup
+- Revert the parser change in `src/components/content/ThreadConversation.vue` if bold-wrapped links need to show raw Markdown markers again.
+
+---
+
 ### Qodo feedback diagnostics reliability fixes
 
 #### Feature/Change Name

--- a/tests.md
+++ b/tests.md
@@ -345,14 +345,15 @@ Codex thread link conversion in chat messages.
 1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`).
 2. A `TestChat` project/thread is available.
 3. Light theme and dark theme are both available.
+4. Note the current app origin from the browser address bar, for example `http://127.0.0.1:4173`.
 
 #### Steps
 1. In light theme, open `TestChat`.
 2. Send or inspect a message containing a bare Codex thread link, for example `codex://threads/019e04cb-9670-7d91-be85-3ba35312170c`.
 3. Send or inspect a message containing a Markdown Codex thread link, for example `[Open thread](codex://threads/019e04cb-9670-7d91-be85-3ba35312170c)`.
 4. Confirm each rendered row contains a clickable `a.message-file-link`.
-5. Confirm the bare link href and visible text both equal `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
-6. Confirm the Markdown link href equals `http://localhost:5173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c` and visible text equals `Open thread`.
+5. Confirm the bare link href and visible text both equal `<current app origin>/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`, for example `http://127.0.0.1:4173/#/thread/019e04cb-9670-7d91-be85-3ba35312170c`.
+6. Confirm the Markdown link href equals `<current app origin>/#/thread/019e04cb-9670-7d91-be85-3ba35312170c` and visible text equals `Open thread`.
 7. Switch to dark theme and repeat steps 2 through 6.
 
 #### Expected Results


### PR DESCRIPTION
## Summary
- Strip surrounding bold markers from auto-linked URLs in chat messages
- Handle bold-wrapped Markdown links without leaving literal `**` around the rendered link
- Document the light/dark manual verification path in `tests.md`

## Verification
- `pnpm run build:frontend`
- CJS Playwright TestChat check at `http://127.0.0.1:4173/#/thread/019e24f5-b794-7d30-bb65-5fd72e0b45fe`, viewport `390x844`
  - light and dark theme assertions passed
  - href/title/link text equal `https://anyclaw.store/claim/a7m2z7`
  - no visible `**` in rendered link row
- `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser`
- `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_ROUTE='#/thread/019e24f5-b794-7d30-bb65-5fd72e0b45fe' PROFILE_WAIT_MS=7000 pnpm run profile:browser`

## Performance Audit
- Home profile: `totalApiKB=235.3`, `threadList=1`, warning `threadRead=4`
- Thread profile: `totalApiKB=231.3`, `threadResume=1`, warning `threadRead=4`
- The change is parser-only and does not add network requests or unbounded fanout. Existing `threadRead=4` warning remains unrelated to this link-rendering fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline codex:// thread links (including in plain text and inside inline/code spans) now render as local web thread URLs and are clickable, preserving trailing punctuation and optional line hints.

* **Bug Fixes**
  * Bold- and triple-asterisk-wrapped URLs/Markdown links no longer show literal emphasis markers; they render as single clickable links without stray asterisks.

* **Tests**
  * Added manual regression tests covering codex thread deep links and bold/triple-asterisk-wrapped links in light/dark themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codexUI/pull/174)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->