### PR TITLE
Recover prolite rate limit responses

### DIFF
--- a/src/server/accountRoutes.ts
+++ b/src/server/accountRoutes.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { buildAppServerArgs } from './appServerRuntimeConfig.js'
+import { callRpcWithRateLimitDecodeRecovery } from './rateLimitDecodeRecovery.js'
 
 type AppServerLike = {
   rpc(method: string, params: unknown): Promise<unknown>
@@ -384,7 +385,7 @@ async function readRuntimeAccountMetadata(appServer: AppServerLike): Promise<Tok
 
 async function validateSwitchedAccount(appServer: AppServerLike): Promise<AccountInspection> {
   const metadata = await readRuntimeAccountMetadata(appServer)
-  const quotaPayload = await appServer.rpc('account/rateLimits/read', null)
+  const quotaPayload = await callRpcWithRateLimitDecodeRecovery(appServer, 'account/rateLimits/read', null)
   return {
     metadata,
     quotaSnapshot: pickCodexRateLimitSnapshot(quotaPayload),
@@ -557,7 +558,7 @@ async function inspectStoredAccount(entry: StoredAccountEntry): Promise<AccountI
   return await withTemporaryCodexAppServer(authRaw, async (rpc) => {
     const accountPayload = asRecord(await rpc('account/read', { refreshToken: false }))
     const account = asRecord(accountPayload?.account)
-    const quotaPayload = await rpc('account/rateLimits/read', null)
+    const quotaPayload = await callRpcWithRateLimitDecodeRecovery({ rpc }, 'account/rateLimits/read', null)
     return {
       metadata: {
         email: typeof account?.email === 'string' && account.email.trim().length > 0 ? account.email.trim() : entry.email,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -12,6 +12,7 @@ import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
 import { handleAccountRoutes } from './accountRoutes.js'
 import { buildAppServerArgs } from './appServerRuntimeConfig.js'
+import { callRpcWithRateLimitDecodeRecovery } from './rateLimitDecodeRecovery.js'
 import { handleReviewRoutes } from './reviewGit.js'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
 import { TelegramThreadBridge } from './telegramThreadBridge.js'
@@ -1356,7 +1357,7 @@ export async function callRpcWithArchiveRecovery(
   params: unknown,
 ): Promise<unknown> {
   try {
-    return await appServer.rpc(method, params ?? null)
+    return await callRpcWithRateLimitDecodeRecovery(appServer, method, params)
   } catch (error) {
     if (method !== 'thread/archive') {
       throw error

--- a/src/server/rateLimitDecodeRecovery.test.ts
+++ b/src/server/rateLimitDecodeRecovery.test.ts
@@ -55,6 +55,28 @@ const proliteDecodeError = new Error(`failed to fetch codex rate limits: Decode 
 }`)
 
 describe('recoverRateLimitsFromPlanTypeDecodeError', () => {
+  it('rounds recovered second-based windows to integer minutes', () => {
+    const recovered = recoverRateLimitsFromPlanTypeDecodeError(new Error(`failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/codex/quotas: unknown variant prolite at line 5 column 24; content-type=application/json; body={
+      "plan_type": "prolite",
+      "rate_limit": {
+        "primary_window": {
+          "used_percent": 10,
+          "limit_window_seconds": 125,
+          "reset_at": 1778653823
+        }
+      }
+    }`))
+
+    expect(recovered).toMatchObject({
+      rateLimits: {
+        primary: {
+          windowDurationMins: 2,
+          windowMinutes: 2,
+        },
+      },
+    })
+  })
+
   it('recovers quota payloads when Codex rejects a new ChatGPT plan type', () => {
     expect(recoverRateLimitsFromPlanTypeDecodeError(proliteDecodeError)).toEqual({
       rateLimits: {

--- a/src/server/rateLimitDecodeRecovery.test.ts
+++ b/src/server/rateLimitDecodeRecovery.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  callRpcWithRateLimitDecodeRecovery,
+  recoverRateLimitsFromPlanTypeDecodeError,
+} from './rateLimitDecodeRecovery'
+
+const proliteDecodeError = new Error(`failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/codex/quotas: unknown variant prolite, expected one of guest, free, go, plus, pro, free_workspace, team, business, education, quorum, k12, enterprise, edu at line 5 column 24; content-type=application/json; body={
+  "user_id": "user-xxxx",
+  "account_id": "user-xxxx",
+  "email": "user@example.test",
+  "plan_type": "prolite",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window": {
+      "used_percent": 7,
+      "limit_window_seconds": 18000,
+      "reset_after_seconds": 3445,
+      "reset_at": 1778653823
+    },
+    "secondary_window": {
+      "used_percent": 16,
+      "limit_window_seconds": 604800,
+      "reset_after_seconds": 504330,
+      "reset_at": 1779154708
+    }
+  },
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 0,
+          "limit_window_seconds": 18000,
+          "reset_after_seconds": 18000,
+          "reset_at": 1778668378
+        },
+        "secondary_window": {
+          "used_percent": 0,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 604800,
+          "reset_at": 1779255178
+        }
+      }
+    }
+  ],
+  "credits": {
+    "has_credits": false,
+    "unlimited": false,
+    "balance": "0"
+  }
+}`)
+
+describe('recoverRateLimitsFromPlanTypeDecodeError', () => {
+  it('recovers quota payloads when Codex rejects a new ChatGPT plan type', () => {
+    expect(recoverRateLimitsFromPlanTypeDecodeError(proliteDecodeError)).toEqual({
+      rateLimits: {
+        limitId: 'codex',
+        limitName: null,
+        primary: {
+          usedPercent: 7,
+          windowDurationMins: 300,
+          windowMinutes: 300,
+          resetsAt: 1778653823,
+        },
+        secondary: {
+          usedPercent: 16,
+          windowDurationMins: 10080,
+          windowMinutes: 10080,
+          resetsAt: 1779154708,
+        },
+        credits: {
+          hasCredits: false,
+          unlimited: false,
+          balance: '0',
+        },
+        planType: 'prolite',
+      },
+      rateLimitsByLimitId: {
+        codex: {
+          limitId: 'codex',
+          limitName: null,
+          primary: {
+            usedPercent: 7,
+            windowDurationMins: 300,
+            windowMinutes: 300,
+            resetsAt: 1778653823,
+          },
+          secondary: {
+            usedPercent: 16,
+            windowDurationMins: 10080,
+            windowMinutes: 10080,
+            resetsAt: 1779154708,
+          },
+          credits: {
+            hasCredits: false,
+            unlimited: false,
+            balance: '0',
+          },
+          planType: 'prolite',
+        },
+        codex_bengalfox: {
+          limitId: 'codex_bengalfox',
+          limitName: 'GPT-5.3-Codex-Spark',
+          primary: {
+            usedPercent: 0,
+            windowDurationMins: 300,
+            windowMinutes: 300,
+            resetsAt: 1778668378,
+          },
+          secondary: {
+            usedPercent: 0,
+            windowDurationMins: 10080,
+            windowMinutes: 10080,
+            resetsAt: 1779255178,
+          },
+          credits: null,
+          planType: 'prolite',
+        },
+      },
+    })
+  })
+
+  it('does not recover unrelated errors', () => {
+    expect(recoverRateLimitsFromPlanTypeDecodeError(new Error('failed to read rate limits'))).toBeNull()
+  })
+})
+
+describe('callRpcWithRateLimitDecodeRecovery', () => {
+  it('returns the recovered quota payload for account rate-limit decode errors', async () => {
+    const calls: Array<{ method: string; params: unknown }> = []
+    const appServer = {
+      async rpc(method: string, params: unknown): Promise<unknown> {
+        calls.push({ method, params })
+        throw proliteDecodeError
+      },
+    }
+
+    await expect(callRpcWithRateLimitDecodeRecovery(appServer, 'account/rateLimits/read', null)).resolves.toMatchObject({
+      rateLimits: {
+        planType: 'prolite',
+      },
+    })
+    expect(calls).toEqual([{ method: 'account/rateLimits/read', params: null }])
+  })
+
+  it('rethrows errors from other RPC methods', async () => {
+    const appServer = {
+      async rpc(): Promise<unknown> {
+        throw proliteDecodeError
+      },
+    }
+
+    await expect(callRpcWithRateLimitDecodeRecovery(appServer, 'thread/read', {})).rejects.toThrow('unknown variant prolite')
+  })
+})

--- a/src/server/rateLimitDecodeRecovery.ts
+++ b/src/server/rateLimitDecodeRecovery.ts
@@ -104,10 +104,11 @@ function normalizeWindow(value: unknown): RateLimitWindow | null {
   if (usedPercent === null) return null
 
   const limitWindowSeconds = readNumber(record.limit_window_seconds)
+  const windowMinutes = limitWindowSeconds === null ? null : Math.round(limitWindowSeconds / 60)
   return {
     usedPercent,
-    windowDurationMins: limitWindowSeconds === null ? null : limitWindowSeconds / 60,
-    windowMinutes: limitWindowSeconds === null ? null : limitWindowSeconds / 60,
+    windowDurationMins: windowMinutes,
+    windowMinutes,
     resetsAt: readNumber(record.reset_at),
   }
 }

--- a/src/server/rateLimitDecodeRecovery.ts
+++ b/src/server/rateLimitDecodeRecovery.ts
@@ -1,0 +1,205 @@
+type RpcExecutor = {
+  rpc(method: string, params: unknown): Promise<unknown>
+}
+
+type RateLimitWindow = {
+  usedPercent: number
+  windowDurationMins: number | null
+  windowMinutes: number | null
+  resetsAt: number | null
+}
+
+type RateLimitSnapshot = {
+  limitId: string | null
+  limitName: string | null
+  primary: RateLimitWindow | null
+  secondary: RateLimitWindow | null
+  credits: {
+    hasCredits: boolean
+    unlimited: boolean
+    balance: string | null
+  } | null
+  planType: string | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function parseJsonObjectAt(text: string, startIndex: number): unknown {
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return JSON.parse(text.slice(startIndex, index + 1))
+      }
+    }
+  }
+
+  return null
+}
+
+function extractResponseBodyFromDecodeError(error: unknown): Record<string, unknown> | null {
+  const message = getErrorMessage(error)
+  if (!message.includes('unknown variant') || !message.includes('plan_type') || !message.includes('body=')) {
+    return null
+  }
+
+  const bodyMarkerIndex = message.indexOf('body=')
+  const bodyStartIndex = message.indexOf('{', bodyMarkerIndex)
+  if (bodyStartIndex < 0) return null
+
+  try {
+    return asRecord(parseJsonObjectAt(message, bodyStartIndex))
+  } catch {
+    return null
+  }
+}
+
+function normalizeWindow(value: unknown): RateLimitWindow | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  const usedPercent = readNumber(record.used_percent)
+  if (usedPercent === null) return null
+
+  const limitWindowSeconds = readNumber(record.limit_window_seconds)
+  return {
+    usedPercent,
+    windowDurationMins: limitWindowSeconds === null ? null : limitWindowSeconds / 60,
+    windowMinutes: limitWindowSeconds === null ? null : limitWindowSeconds / 60,
+    resetsAt: readNumber(record.reset_at),
+  }
+}
+
+function normalizeCredits(value: unknown): RateLimitSnapshot['credits'] {
+  const record = asRecord(value)
+  if (!record) return null
+
+  const hasCredits = readBoolean(record.has_credits)
+  const unlimited = readBoolean(record.unlimited)
+  if (hasCredits === null || unlimited === null) return null
+
+  return {
+    hasCredits,
+    unlimited,
+    balance: readString(record.balance),
+  }
+}
+
+function buildSnapshot(
+  limitId: string | null,
+  limitName: string | null,
+  rateLimit: unknown,
+  planType: string | null,
+  credits: unknown,
+): RateLimitSnapshot | null {
+  const record = asRecord(rateLimit)
+  if (!record) return null
+
+  const primary = normalizeWindow(record.primary_window)
+  const secondary = normalizeWindow(record.secondary_window)
+  const normalizedCredits = normalizeCredits(credits)
+  if (!primary && !secondary && !normalizedCredits) return null
+
+  return {
+    limitId,
+    limitName,
+    primary,
+    secondary,
+    credits: normalizedCredits,
+    planType,
+  }
+}
+
+export function recoverRateLimitsFromPlanTypeDecodeError(error: unknown): unknown | null {
+  const body = extractResponseBodyFromDecodeError(error)
+  if (!body) return null
+
+  const planType = readString(body.plan_type)
+  const primarySnapshot = buildSnapshot('codex', null, body.rate_limit, planType, body.credits)
+  if (!primarySnapshot) return null
+
+  const rateLimitsByLimitId: Record<string, RateLimitSnapshot> = {
+    codex: primarySnapshot,
+  }
+
+  const additionalRateLimits = Array.isArray(body.additional_rate_limits) ? body.additional_rate_limits : []
+  for (const entry of additionalRateLimits) {
+    const entryRecord = asRecord(entry)
+    if (!entryRecord) continue
+    const limitId = readString(entryRecord.metered_feature) ?? readString(entryRecord.limit_name)
+    if (!limitId) continue
+    const snapshot = buildSnapshot(
+      limitId,
+      readString(entryRecord.limit_name),
+      entryRecord.rate_limit,
+      planType,
+      null,
+    )
+    if (snapshot) {
+      rateLimitsByLimitId[limitId] = snapshot
+    }
+  }
+
+  return {
+    rateLimits: primarySnapshot,
+    rateLimitsByLimitId,
+  }
+}
+
+export async function callRpcWithRateLimitDecodeRecovery(
+  appServer: RpcExecutor,
+  method: string,
+  params: unknown,
+): Promise<unknown> {
+  try {
+    return await appServer.rpc(method, params ?? null)
+  } catch (error) {
+    if (method === 'account/rateLimits/read') {
+      const recovered = recoverRateLimitsFromPlanTypeDecodeError(error)
+      if (recovered) return recovered
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- Add a recovery path for `account/rateLimits/read` when Codex rejects a new ChatGPT `plan_type` such as `prolite`.
- Parse the JSON response body embedded in the decode error and normalize it into the existing rate-limit payload shape.
- Apply the recovery through the generic app-server RPC bridge and account inspection paths.
- Add regression coverage using a `prolite` quota response payload.

## Root Cause
Codex app-server can fail decoding the ChatGPT quota response before returning it to codexUI because `prolite` is not in the app-server `PlanType` enum. The HTTP response
already contains valid quota data, but the decode error prevents the UI from reading it.

## Validation
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vue-tsc --noEmit`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsup`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and recovery when account rate limit/quota responses are malformed or fail to decode, ensuring account usage data is returned when possible.
* **Tests**
  * Added coverage to verify recovery behavior for decoded rate-limit payloads and ensure correct propagation or rethrowing of errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codexUI/pull/176)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->