### PR TITLE
Fix automation editor on small screens

### DIFF
--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -3371,7 +3371,13 @@ onBeforeUnmount(() => {
 }
 
 .automation-thread-panel {
-  @apply max-w-lg;
+  @apply max-w-lg overflow-y-auto;
+  max-height: min(90vh, calc(100dvh - 2rem));
+  overscroll-behavior: contain;
+}
+
+.automation-thread-panel .rename-thread-subtitle {
+  @apply flex-none overflow-visible;
 }
 
 .automation-thread-field {
@@ -3467,5 +3473,21 @@ onBeforeUnmount(() => {
 
 .automation-thread-notice {
   @apply mb-0 text-emerald-600;
+}
+
+@media (max-height: 640px) {
+  .automation-thread-panel {
+    @apply p-3;
+  }
+
+  .automation-thread-field,
+  .automation-target-picker,
+  .automation-thread-list {
+    @apply mb-2;
+  }
+
+  .automation-thread-textarea {
+    min-height: 7rem;
+  }
 }
 </style>

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -3380,6 +3380,10 @@ onBeforeUnmount(() => {
   @apply flex-none overflow-visible;
 }
 
+.automation-thread-panel .rename-thread-actions {
+  @apply sticky bottom-0 -mx-4 -mb-4 border-t border-zinc-200 bg-white px-4 py-3;
+}
+
 .automation-thread-field {
   @apply mb-3 flex flex-col gap-1;
 }
@@ -3478,6 +3482,10 @@ onBeforeUnmount(() => {
 @media (max-height: 640px) {
   .automation-thread-panel {
     @apply p-3;
+  }
+
+  .automation-thread-panel .rename-thread-actions {
+    @apply -mx-3 -mb-3 px-3 py-2;
   }
 
   .automation-thread-field,

--- a/src/style.css
+++ b/src/style.css
@@ -569,6 +569,10 @@
   @apply text-emerald-400;
 }
 
+:root.dark .automation-thread-panel .rename-thread-actions {
+  @apply border-zinc-700 bg-zinc-800;
+}
+
 :root.dark .thread-row-automation-chip {
   @apply bg-amber-900/40 text-amber-200 ring-1 ring-amber-700/40;
 }

--- a/tests.md
+++ b/tests.md
@@ -349,13 +349,15 @@ Automation editor small-device overflow handling.
 #### Steps
 1. In light theme, open a thread or project menu and choose `Manage automations...`.
 2. Confirm the `Edit automation` dialog opens inside the viewport and can be vertically scrolled.
-3. Scroll to the bottom of the dialog and confirm `Run now` when available, `Remove`, `Cancel`, and `Save` are reachable.
-4. Confirm the name input, prompt textarea, schedule controls, status select, notices, and error text do not overlap while scrolling.
-5. Switch to dark theme and repeat steps 1-4.
+3. Confirm `Run now` when available, `Remove`, `Cancel`, and `Save` remain visible at the bottom before scrolling.
+4. Scroll through the dialog and confirm the same bottom actions stay visible while the form content moves behind them.
+5. Confirm the name input, prompt textarea, schedule controls, status select, notices, and error text do not overlap while scrolling.
+6. Switch to dark theme and repeat steps 1-5.
 
 #### Expected Results
 - The automation editor does not extend offscreen without a way to reach lower controls on small-height devices.
 - Vertical scrolling stays inside the modal, with the page behind the overlay remaining fixed.
+- The automation editor action row remains sticky and usable while the form content scrolls.
 - Light and dark theme automation editor controls remain readable and usable.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -336,6 +336,33 @@ Rollback/cleanup:
 
 ---
 
+### Automation editor scrolls on small viewports
+
+#### Feature/Change Name
+Automation editor small-device overflow handling.
+
+#### Prerequisites/Setup
+1. Dev server running (`pnpm run dev --host 127.0.0.1 --port 4173`)
+2. At least one thread or project automation exists, or create one from a thread/project menu.
+3. Browser viewport set to a small device size such as 375x667.
+
+#### Steps
+1. In light theme, open a thread or project menu and choose `Manage automations...`.
+2. Confirm the `Edit automation` dialog opens inside the viewport and can be vertically scrolled.
+3. Scroll to the bottom of the dialog and confirm `Run now` when available, `Remove`, `Cancel`, and `Save` are reachable.
+4. Confirm the name input, prompt textarea, schedule controls, status select, notices, and error text do not overlap while scrolling.
+5. Switch to dark theme and repeat steps 1-4.
+
+#### Expected Results
+- The automation editor does not extend offscreen without a way to reach lower controls on small-height devices.
+- Vertical scrolling stays inside the modal, with the page behind the overlay remaining fixed.
+- Light and dark theme automation editor controls remain readable and usable.
+
+#### Rollback/Cleanup
+- Remove any temporary test automation from the automation dialog if one was created for this test.
+
+---
+
 ### Codex thread deep links render as local web thread URLs
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- make the automation editor scroll inside small viewports
- keep the automation editor action row sticky and visible while the form scrolls
- document light/dark small-device manual verification in tests.md

## Verification
- pnpm run build:frontend
- Playwright small-device check at 375x667 against http://127.0.0.1:4173/#/automations
- Confirmed action row position is sticky and visible at top and scrolled bottom in light and dark themes

Screenshots saved locally under output/playwright/automation-editor-sticky-small-*.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling behavior and layout issues in the automation editor on small viewports, preventing UI elements from being clipped and ensuring action buttons remain accessible.

* **Style**
  * Enhanced dark mode styling for better visual consistency.

* **Tests**
  * Added regression test to verify proper functionality across different screen sizes and themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codexUI/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->