### PR TITLE
Enable memories for spawned Codex app server

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -499,6 +499,7 @@ async function startServer(options: {
   tunnel: boolean
   open: boolean
   login: boolean
+  memories: boolean
   sandboxMode?: string
   approvalPolicy?: string
   projectPath?: string
@@ -523,6 +524,7 @@ async function startServer(options: {
   if (options.approvalPolicy) {
     process.env.CODEXUI_APPROVAL_POLICY = options.approvalPolicy
   }
+  process.env.CODEXUI_MEMORIES = options.memories ? 'true' : 'false'
   const runtimeConfig = resolveAppServerRuntimeConfig()
   if (options.login && !hasCodexAuth()) {
     console.log('\nCodex is not logged in. You can log in later via settings or run `codexui login`.\n')
@@ -637,6 +639,8 @@ program
   .option('--no-open', 'do not open browser on startup')
   .option('--login', 'run automatic Codex login bootstrap', true)
   .option('--no-login', 'skip automatic Codex login bootstrap')
+  .option('--memories', 'enable Codex memories for spawned app-server processes', true)
+  .option('--no-memories', 'disable Codex memories for spawned app-server processes')
   .option('--sandbox-mode <mode>', 'Codex sandbox mode: read-only, workspace-write, danger-full-access')
   .option('--approval-policy <policy>', 'Codex approval policy: untrusted, on-failure, on-request, never')
   .action(async (
@@ -647,6 +651,7 @@ program
       tunnel: boolean
       open: boolean
       login: boolean
+      memories: boolean
       sandboxMode?: string
       approvalPolicy?: string
       openProject?: string

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -524,7 +524,6 @@ async function startServer(options: {
   if (options.approvalPolicy) {
     process.env.CODEXUI_APPROVAL_POLICY = options.approvalPolicy
   }
-  process.env.CODEXUI_MEMORIES = options.memories ? 'true' : 'false'
   const runtimeConfig = resolveAppServerRuntimeConfig()
   if (options.login && !hasCodexAuth()) {
     console.log('\nCodex is not logged in. You can log in later via settings or run `codexui login`.\n')
@@ -665,7 +664,16 @@ program
       || arg.startsWith('--tunnel=')
       || arg.startsWith('--no-tunnel=')
     ))
+    const memoriesFlagExplicit = rawArgv.some((arg) => (
+      arg === '--memories'
+      || arg === '--no-memories'
+      || arg.startsWith('--memories=')
+      || arg.startsWith('--no-memories=')
+    ))
     const effectiveTunnel = tunnelFlagExplicit ? opts.tunnel : hasDetectedTailscaleIp()
+    if (memoriesFlagExplicit) {
+      process.env.CODEXUI_MEMORIES = opts.memories ? 'true' : 'false'
+    }
 
     let openProjectOnly = (opts.openProject ?? '').trim()
     if (!openProjectOnly && openProjectFlagIndex >= 0 && projectPath?.trim()) {

--- a/src/server/appServerRuntimeConfig.test.ts
+++ b/src/server/appServerRuntimeConfig.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { buildAppServerArgs } from './appServerRuntimeConfig'
+
+describe('app-server runtime config', () => {
+  it('enables Codex memories by default for spawned app-server processes', () => {
+    expect(buildAppServerArgs()).toEqual(expect.arrayContaining([
+      '-c',
+      'features.memories=true',
+    ]))
+  })
+})

--- a/src/server/appServerRuntimeConfig.test.ts
+++ b/src/server/appServerRuntimeConfig.test.ts
@@ -3,9 +3,24 @@ import { buildAppServerArgs } from './appServerRuntimeConfig'
 
 describe('app-server runtime config', () => {
   it('enables Codex memories by default for spawned app-server processes', () => {
-    expect(buildAppServerArgs()).toEqual(expect.arrayContaining([
-      '-c',
-      'features.memories=true',
-    ]))
+    const args = buildAppServerArgs()
+    const featureIndex = args.indexOf('features.memories=true')
+
+    expect(featureIndex).toBeGreaterThan(0)
+    expect(args[featureIndex - 1]).toBe('-c')
+  })
+
+  it('can disable Codex memories through runtime configuration', () => {
+    process.env.CODEXUI_MEMORIES = 'false'
+    try {
+      const args = buildAppServerArgs()
+      const featureIndex = args.indexOf('features.memories=false')
+
+      expect(featureIndex).toBeGreaterThan(0)
+      expect(args[featureIndex - 1]).toBe('-c')
+      expect(args).not.toContain('features.memories=true')
+    } finally {
+      delete process.env.CODEXUI_MEMORIES
+    }
   })
 })

--- a/src/server/appServerRuntimeConfig.ts
+++ b/src/server/appServerRuntimeConfig.ts
@@ -17,11 +17,13 @@ export type CodexApprovalPolicy = 'untrusted' | 'on-failure' | 'on-request' | 'n
 type AppServerRuntimeConfig = {
   sandboxMode: CodexSandboxMode
   approvalPolicy: CodexApprovalPolicy
+  memories: boolean
 }
 
 const DEFAULT_RUNTIME_CONFIG: AppServerRuntimeConfig = {
   sandboxMode: 'danger-full-access',
   approvalPolicy: 'never',
+  memories: true,
 }
 
 function normalizeRuntimeValue(value: string | undefined): string {
@@ -44,10 +46,22 @@ function readApprovalPolicyFromEnv(): CodexApprovalPolicy {
   return DEFAULT_RUNTIME_CONFIG.approvalPolicy
 }
 
+function readMemoriesFromEnv(): boolean {
+  const candidate = normalizeRuntimeValue(process.env.CODEXUI_MEMORIES)
+  if (candidate === 'false' || candidate === '0' || candidate === 'no') {
+    return false
+  }
+  if (candidate === 'true' || candidate === '1' || candidate === 'yes') {
+    return true
+  }
+  return DEFAULT_RUNTIME_CONFIG.memories
+}
+
 export function resolveAppServerRuntimeConfig(): AppServerRuntimeConfig {
   return {
     sandboxMode: readSandboxModeFromEnv(),
     approvalPolicy: readApprovalPolicyFromEnv(),
+    memories: readMemoriesFromEnv(),
   }
 }
 
@@ -60,7 +74,7 @@ export function buildAppServerArgs(): string[] {
     '-c',
     `sandbox_mode="${config.sandboxMode}"`,
     '-c',
-    'features.memories=true',
+    `features.memories=${config.memories ? 'true' : 'false'}`,
   ]
 }
 

--- a/src/server/appServerRuntimeConfig.ts
+++ b/src/server/appServerRuntimeConfig.ts
@@ -59,6 +59,8 @@ export function buildAppServerArgs(): string[] {
     `approval_policy="${config.approvalPolicy}"`,
     '-c',
     `sandbox_mode="${config.sandboxMode}"`,
+    '-c',
+    'features.memories=true',
   ]
 }
 

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -4843,7 +4843,6 @@ class AppServerProcess {
   private readonly pending = new Map<number, { resolve: (value: unknown) => void; reject: (reason?: unknown) => void }>()
   private readonly notificationListeners = new Set<(value: { method: string; params: unknown }) => void>()
   private readonly pendingServerRequests = new Map<number, PendingServerRequest>()
-  private readonly appServerArgs = buildAppServerArgs()
   private readonly streamEventsByThreadId = new Map<string, StreamEventFrame[]>()
   private readonly lastThreadReadSnapshotByThreadId = new Map<string, unknown>()
   private readonly threadTurnPageReadCacheByThreadId = new Map<string, { result: unknown; expiresAt: number }>()
@@ -4863,11 +4862,7 @@ class AppServerProcess {
   }
 
   private buildAppServerConfig(): { args: string[]; env: Record<string, string> } {
-    const args = [
-      'app-server',
-      '-c', 'approval_policy="never"',
-      '-c', 'sandbox_mode="danger-full-access"',
-    ]
+    const args = buildAppServerArgs()
     let extraEnv: Record<string, string> = {}
     const serverPort = parseInt(process.env.CODEXUI_SERVER_PORT ?? '', 10) || undefined
     args.push(...getProviderCompatibilityConfigArgs(serverPort))

--- a/tests.md
+++ b/tests.md
@@ -5796,6 +5796,7 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
+- Remove the temporary isolated `CODEX_HOME` if it is no longer needed.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -5796,7 +5796,34 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
-- Remove the temporary isolated `CODEX_HOME` if it is no longer needed.
+
+---
+
+### Codex app-server memories default
+
+#### Feature/Change Name
+Packaged CLI starts Codex app-server with memories enabled by default.
+
+#### Prerequisites/Setup
+1. Build the CLI: `pnpm run build:cli`.
+2. Use a temporary Codex home that does not already enable memories, for example `CODEX_HOME=$(mktemp -d)`.
+
+#### Steps
+1. Run the unit test: `pnpm exec vitest run src/server/appServerRuntimeConfig.test.ts`.
+2. Start the packaged CLI in light theme with the temporary Codex home: `CODEX_HOME=<temp-home> node dist-cli/index.js --no-open --no-tunnel --no-login --no-password --port 5900`.
+3. Trigger any route or action that starts the underlying Codex app-server.
+4. Confirm the spawned app-server command includes `-c features.memories=true`, or confirm `codex features list` with equivalent config reports `memories` enabled.
+5. Open `http://127.0.0.1:5900/#/` and confirm the app shell still renders normally in light theme.
+6. Switch to dark theme and confirm the app shell still renders normally.
+
+#### Expected Results
+- `buildAppServerArgs()` includes `-c features.memories=true`.
+- The packaged CLI no longer depends on the user's `~/.codex/config.toml` to enable memories for its spawned app-server.
+- Light and dark themes are unchanged because this is a runtime launch/config change, not a UI surface change.
+
+#### Rollback/Cleanup
+- Stop the temporary packaged CLI process.
+- Remove the temporary `CODEX_HOME`.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -5799,10 +5799,10 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 ---
 
-### Codex app-server memories default
+### Codex app-server memories default and opt-out
 
 #### Feature/Change Name
-Packaged CLI starts Codex app-server with memories enabled by default.
+Packaged CLI starts Codex app-server with memories enabled by default and supports `--no-memories`.
 
 #### Prerequisites/Setup
 1. Build the CLI: `pnpm run build:cli`.
@@ -5813,11 +5813,16 @@ Packaged CLI starts Codex app-server with memories enabled by default.
 2. Start the packaged CLI in light theme with the temporary Codex home: `CODEX_HOME=<temp-home> node dist-cli/index.js --no-open --no-tunnel --no-login --no-password --port 5900`.
 3. Trigger any route or action that starts the underlying Codex app-server.
 4. Confirm the spawned app-server command includes `-c features.memories=true`, or confirm `codex features list` with equivalent config reports `memories` enabled.
-5. Open `http://127.0.0.1:5900/#/` and confirm the app shell still renders normally in light theme.
-6. Switch to dark theme and confirm the app shell still renders normally.
+5. Stop the temporary CLI process.
+6. Start the packaged CLI with opt-out: `CODEX_HOME=<temp-home> node dist-cli/index.js --no-open --no-tunnel --no-login --no-password --no-memories --port 5900`.
+7. Trigger any route or action that starts the underlying Codex app-server.
+8. Confirm the spawned app-server command includes `-c features.memories=false`.
+9. Open `http://127.0.0.1:5900/#/` and confirm the app shell still renders normally in light theme.
+10. Switch to dark theme and confirm the app shell still renders normally.
 
 #### Expected Results
 - `buildAppServerArgs()` includes `-c features.memories=true`.
+- `CODEXUI_MEMORIES=false` and `--no-memories` produce `-c features.memories=false`.
 - The packaged CLI no longer depends on the user's `~/.codex/config.toml` to enable memories for its spawned app-server.
 - Light and dark themes are unchanged because this is a runtime launch/config change, not a UI surface change.
 


### PR DESCRIPTION
## Summary
- pass `-c features.memories=true` by default whenever codexapp spawns `codex app-server`
- add `--no-memories` / `CODEXUI_MEMORIES=false` opt-out that spawns with `-c features.memories=false`
- route the main bridge through the shared app-server arg builder
- tighten regression coverage so the memories config must be paired with `-c`
- update manual test documentation

## Verification
- `pnpm exec vitest run src/server/appServerRuntimeConfig.test.ts`
- `pnpm run build:cli`
- confirmed `dist-cli/index.js` contains memory default/opt-out wiring
- `node dist-cli/index.js --help` shows `--no-memories` with dependencies available
- `git diff --check`

## Performance
- Launch-config-only change: adds one static Codex config override at app-server spawn time. No UI render, request loop, payload, cache, or long-running runtime path changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memories enabled by default for spawned app-server; CLI adds --memories / --no-memories to control it and passes the choice to the server startup.

* **Tests**
  * Added tests verifying memories default-on, opt-out behavior, and environment cleanup after test run.

* **Documentation**
  * Added manual regression steps for verifying app-server memories default and the opt-out path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codexUI/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->