### PR TITLE
Reduce startup profiler duplicate requests

### DIFF
--- a/scripts/profile-browser-runtime.cjs
+++ b/scripts/profile-browser-runtime.cjs
@@ -49,7 +49,8 @@ function buildWarnings(duplicateCounts, apiSummary, apiRows) {
 
   if (duplicateCounts.threadListFirstPage > 1) warnings.push(`threadListFirstPage=${duplicateCounts.threadListFirstPage}`)
   if (duplicateCounts.threadResume > 1) warnings.push(`threadResume=${duplicateCounts.threadResume}`)
-  if (duplicateCounts.threadRead > 0) warnings.push(`threadRead=${duplicateCounts.threadRead}`)
+  if (duplicateCounts.threadReadWithTurns > 1) warnings.push(`threadReadWithTurns=${duplicateCounts.threadReadWithTurns}`)
+  if (duplicateCounts.threadReadDuplicateKeys > 0) warnings.push(`threadReadDuplicateKeys=${duplicateCounts.threadReadDuplicateKeys}`)
   if (duplicateCounts.skillsList > 1) warnings.push(`skillsList=${duplicateCounts.skillsList}`)
   if (duplicateCounts.rateLimitsRead > 1) warnings.push(`rateLimitsRead=${duplicateCounts.rateLimitsRead}`)
   if (providerModels && providerModels.maxMs > 1000) warnings.push(`providerModels=${providerModels.maxMs}ms`)
@@ -61,6 +62,9 @@ function buildWarnings(duplicateCounts, apiSummary, apiRows) {
 function requestKey(row) {
   if (row.rpc === 'thread/list') {
     return row.cursor ? 'thread/list:cursor' : 'thread/list:first-page'
+  }
+  if (row.rpc === 'thread/read') {
+    return `thread/read:${row.threadId || 'unknown'}:${row.includeTurns === true ? 'turns' : 'summary'}`
   }
   return row.rpc || row.path
 }
@@ -139,6 +143,10 @@ async function main() {
       cursor: parsedBody?.params && typeof parsedBody.params === 'object' && typeof parsedBody.params.cursor === 'string'
         ? parsedBody.params.cursor
         : '',
+      threadId: parsedBody?.params && typeof parsedBody.params === 'object' && typeof parsedBody.params.threadId === 'string'
+        ? parsedBody.params.threadId
+        : '',
+      includeTurns: parsedBody?.params && typeof parsedBody.params === 'object' && parsedBody.params.includeTurns === true,
       requestBytes: body ? Buffer.byteLength(body, 'utf8') : 0,
     }
   })
@@ -160,6 +168,8 @@ async function main() {
       path: new URL(response.url()).pathname,
       rpc: profile.rpc,
       cursor: profile.cursor,
+      threadId: profile.threadId,
+      includeTurns: profile.includeTurns,
       status: response.status(),
       ms: round(performance.now() - profile.startedAt),
       requestBytes: profile.requestBytes,
@@ -217,6 +227,17 @@ async function main() {
     threadListCursor: apiRows.filter((row) => row.rpc === 'thread/list' && row.cursor).length,
     threadResume: apiRows.filter((row) => row.rpc === 'thread/resume').length,
     threadRead: apiRows.filter((row) => row.rpc === 'thread/read').length,
+    threadReadWithTurns: apiRows.filter((row) => row.rpc === 'thread/read' && row.includeTurns === true).length,
+    threadReadDuplicateKeys: Array.from(
+      apiRows
+        .filter((row) => row.rpc === 'thread/read')
+        .reduce((counts, row) => {
+          const key = requestKey(row)
+          counts.set(key, (counts.get(key) || 0) + 1)
+          return counts
+        }, new Map())
+        .values(),
+    ).filter((count) => count > 1).length,
     skillsList: apiRows.filter((row) => row.rpc === 'skills/list').length,
     rateLimitsRead: apiRows.filter((row) => row.rpc === 'account/rateLimits/read').length,
     providerModels: apiRows.filter((row) => row.path === '/codex-api/provider-models').length,

--- a/src/App.vue
+++ b/src/App.vue
@@ -2167,7 +2167,7 @@ async function maybeImportExternalCodexAuthAccount(): Promise<boolean> {
 }
 
 function onSkillsChanged(): void {
-  void refreshSkills()
+  void refreshSkills({ force: true })
 }
 
 async function refreshTelegramStatus(): Promise<void> {
@@ -4326,6 +4326,8 @@ async function initialize(): Promise<void> {
 
   if (route.name === 'thread' && routeThreadId.value) {
     primeSelectedThread(routeThreadId.value)
+  } else if (route.name === 'home' || route.name === 'skills' || route.name === 'automations') {
+    primeSelectedThread('')
   }
 
   await refreshAll({

--- a/src/App.vue
+++ b/src/App.vue
@@ -4327,7 +4327,7 @@ async function initialize(): Promise<void> {
   if (route.name === 'thread' && routeThreadId.value) {
     primeSelectedThread(routeThreadId.value)
   } else if (route.name === 'home' || route.name === 'skills' || route.name === 'automations') {
-    primeSelectedThread('')
+    primeSelectedThread('', { persist: false })
   }
 
   await refreshAll({

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -449,6 +449,9 @@ describe('Codex CLI availability', () => {
     expect(state.codexCliMissingError.value).toBe('')
   })
 
+})
+
+describe('startup request deduplication', () => {
   it('reuses a just-loaded thread list during startup refresh bursts', async () => {
     installTestWindow()
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
@@ -533,6 +536,47 @@ describe('Codex CLI availability', () => {
 
       expect(gatewayMocks.getSkillsList).toHaveBeenCalledTimes(1)
       expect(state.installedSkills.value).toEqual([])
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('bypasses recent thread-list reuse for event-driven thread refreshes', async () => {
+    installTestWindow()
+    vi.mocked(window.setTimeout).mockImplementation(((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        void Promise.resolve().then(() => callback())
+      }
+      return 1
+    }) as typeof window.setTimeout)
+    let notificationHandler: ((notification: { method: string; params?: unknown }) => void) | undefined
+    gatewayMocks.subscribeCodexNotifications.mockImplementation((handler) => {
+      notificationHandler = handler as typeof notificationHandler
+      return vi.fn()
+    })
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
+      nextCursor: null,
+    })
+
+    try {
+      const state = useDesktopState()
+      await state.refreshAll({ includeSelectedThreadMessages: false })
+      const callsBeforeNotification = gatewayMocks.getThreadGroupsPage.mock.calls.length
+      state.startPolling()
+      expect(notificationHandler).toBeDefined()
+      notificationHandler!({
+        method: 'thread/name/updated',
+        params: {
+          threadId: 'thread-1',
+          threadName: 'Updated title',
+        },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(gatewayMocks.getThreadGroupsPage.mock.calls.length).toBeGreaterThan(callsBeforeNotification)
     } finally {
       nowSpy.mockRestore()
     }
@@ -1058,47 +1102,6 @@ describe('provider model selection', () => {
       'system:Worked for <1s',
       'assistant:Hi.',
     ])
-  })
-
-  it('bypasses recent thread-list reuse for event-driven thread refreshes', async () => {
-    installTestWindow()
-    vi.mocked(window.setTimeout).mockImplementation(((callback: TimerHandler) => {
-      if (typeof callback === 'function') {
-        void Promise.resolve().then(() => callback())
-      }
-      return 1
-    }) as typeof window.setTimeout)
-    let notificationHandler: ((notification: { method: string; params?: unknown }) => void) | undefined
-    gatewayMocks.subscribeCodexNotifications.mockImplementation((handler) => {
-      notificationHandler = handler as typeof notificationHandler
-      return vi.fn()
-    })
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
-    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
-      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
-      nextCursor: null,
-    })
-
-    try {
-      const state = useDesktopState()
-      await state.refreshAll({ includeSelectedThreadMessages: false })
-      const callsBeforeNotification = gatewayMocks.getThreadGroupsPage.mock.calls.length
-      state.startPolling()
-      expect(notificationHandler).toBeDefined()
-      notificationHandler!({
-        method: 'thread/name/updated',
-        params: {
-          threadId: 'thread-1',
-          threadName: 'Updated title',
-        },
-      })
-      await Promise.resolve()
-      await Promise.resolve()
-
-      expect(gatewayMocks.getThreadGroupsPage.mock.calls.length).toBeGreaterThan(callsBeforeNotification)
-    } finally {
-      nowSpy.mockRestore()
-    }
   })
 
   it('surfaces selected thread load failures and still refreshes models', async () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -448,6 +448,64 @@ describe('Codex CLI availability', () => {
     expect(state.error.value).toBe('Connection lost')
     expect(state.codexCliMissingError.value).toBe('')
   })
+
+  it('reuses a just-loaded thread list during startup refresh bursts', async () => {
+    installTestWindow()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
+      nextCursor: null,
+    })
+
+    try {
+      const state = useDesktopState()
+      await state.refreshAll({ includeSelectedThreadMessages: false })
+      await state.refreshAll({ includeSelectedThreadMessages: false })
+
+      expect(gatewayMocks.getThreadGroupsPage).toHaveBeenCalledTimes(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('reuses a just-loaded skills list for the same selected cwd', async () => {
+    installTestWindow()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
+    gatewayMocks.getSkillsList.mockResolvedValue([
+      {
+        name: 'example',
+        description: 'Example skill',
+        path: '/tmp/project/.agents/skills/example/SKILL.md',
+        scope: 'project',
+        enabled: true,
+      },
+    ])
+    gatewayMocks.getAccountRateLimits.mockResolvedValue(null)
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: '',
+      reasoningEffort: 'medium',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+
+    try {
+      const state = useDesktopState()
+      state.primeSelectedThread('thread-1')
+      await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+      await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+      expect(gatewayMocks.getSkillsList).toHaveBeenCalledTimes(1)
+      expect(gatewayMocks.getSkillsList).toHaveBeenCalledWith(['/tmp/project'])
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
 })
 
 describe('live error overlay', () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -506,6 +506,37 @@ describe('Codex CLI availability', () => {
       nowSpy.mockRestore()
     }
   })
+
+  it('reuses a just-loaded empty skills list for the same selected cwd', async () => {
+    installTestWindow()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
+      nextCursor: null,
+    })
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.getAccountRateLimits.mockResolvedValue(null)
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.5',
+      providerId: '',
+      reasoningEffort: 'medium',
+      speedMode: 'standard',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+
+    try {
+      const state = useDesktopState()
+      state.primeSelectedThread('thread-1')
+      await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+      await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+      expect(gatewayMocks.getSkillsList).toHaveBeenCalledTimes(1)
+      expect(state.installedSkills.value).toEqual([])
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
 })
 
 describe('live error overlay', () => {
@@ -1018,6 +1049,8 @@ describe('provider model selection', () => {
     })
     await Promise.resolve()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
 
     expect(gatewayMocks.getThreadDetail).toHaveBeenCalledWith('mini-thread')
     expect(state.messages.value.map((message) => `${message.role}:${message.text}`)).toEqual([
@@ -1025,6 +1058,47 @@ describe('provider model selection', () => {
       'system:Worked for <1s',
       'assistant:Hi.',
     ])
+  })
+
+  it('bypasses recent thread-list reuse for event-driven thread refreshes', async () => {
+    installTestWindow()
+    vi.mocked(window.setTimeout).mockImplementation(((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        void Promise.resolve().then(() => callback())
+      }
+      return 1
+    }) as typeof window.setTimeout)
+    let notificationHandler: ((notification: { method: string; params?: unknown }) => void) | undefined
+    gatewayMocks.subscribeCodexNotifications.mockImplementation((handler) => {
+      notificationHandler = handler as typeof notificationHandler
+      return vi.fn()
+    })
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({
+      groups: [{ projectName: 'Project', threads: [thread('thread-1', '/tmp/project')] }],
+      nextCursor: null,
+    })
+
+    try {
+      const state = useDesktopState()
+      await state.refreshAll({ includeSelectedThreadMessages: false })
+      const callsBeforeNotification = gatewayMocks.getThreadGroupsPage.mock.calls.length
+      state.startPolling()
+      expect(notificationHandler).toBeDefined()
+      notificationHandler!({
+        method: 'thread/name/updated',
+        params: {
+          threadId: 'thread-1',
+          threadName: 'Updated title',
+        },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(gatewayMocks.getThreadGroupsPage.mock.calls.length).toBeGreaterThan(callsBeforeNotification)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('surfaces selected thread load failures and still refreshes models', async () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -392,6 +392,21 @@ describe('thread unread state helpers', () => {
 })
 
 describe('collaboration mode selection', () => {
+  it('can prime an empty selected thread without clearing persisted selection', () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'thread-a',
+    })
+
+    const state = useDesktopState()
+
+    expect(state.selectedThreadId.value).toBe('thread-a')
+
+    state.primeSelectedThread('', { persist: false })
+
+    expect(state.selectedThreadId.value).toBe('')
+    expect(window.localStorage.getItem('codex-web-local.selected-thread-id.v1')).toBe('thread-a')
+  })
+
   it('does not carry plan mode from new chats into existing threads', () => {
     installTestWindow({
       'codex-web-local.collaboration-mode.v1': 'plan',

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1517,10 +1517,12 @@ export function useDesktopState() {
   const loadMessagePromiseByThreadId = new Map<string, Promise<void>>()
   let refreshSkillsPromise: Promise<void> | null = null
   let lastThreadListLoadAt = 0
+  let hasLoadedSkills = false
   let lastSkillsLoadAt = 0
   let lastSkillsLoadKey = ''
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
+  let pendingThreadsRefreshForce = false
   const pendingThreadMessageRefresh = new Set<string>()
   const lastMessageLoadAtByThreadId = new Map<string, number>()
   const lastMessageLoadFailureAtByThreadId = new Map<string, number>()
@@ -4011,6 +4013,7 @@ export function useDesktopState() {
 
     if (shouldRefreshThreads) {
       pendingThreadsRefresh = true
+      pendingThreadsRefreshForce = true
     }
 
     if (eventSyncTimer !== null || typeof window === 'undefined') return
@@ -4293,12 +4296,13 @@ export function useDesktopState() {
     }
   }
 
-  async function loadThreads() {
+  async function loadThreads(options: { force?: boolean } = {}) {
     if (loadThreadsPromise) {
       await loadThreadsPromise
       return
     }
     if (
+      options.force !== true &&
       hasLoadedThreads.value &&
       Date.now() - lastThreadListLoadAt < RECENT_THREAD_LIST_LOAD_REUSE_MS
     ) {
@@ -4535,7 +4539,7 @@ export function useDesktopState() {
     await loadMessages(threadId, options)
   }
 
-  async function refreshSkills(): Promise<void> {
+  async function refreshSkills(options: { force?: boolean } = {}): Promise<void> {
     const selectedCwd = selectedThread.value?.cwd?.trim() ?? ''
     const skillsLoadKey = selectedCwd || '__global__'
     if (refreshSkillsPromise) {
@@ -4543,7 +4547,8 @@ export function useDesktopState() {
       return
     }
     if (
-      installedSkills.value.length > 0 &&
+      options.force !== true &&
+      hasLoadedSkills &&
       lastSkillsLoadKey === skillsLoadKey &&
       Date.now() - lastSkillsLoadAt < RECENT_SKILLS_LOAD_REUSE_MS
     ) {
@@ -4553,6 +4558,7 @@ export function useDesktopState() {
     refreshSkillsPromise = (async () => {
       try {
         installedSkills.value = await getSkillsList(selectedCwd ? [selectedCwd] : undefined)
+        hasLoadedSkills = true
         lastSkillsLoadAt = Date.now()
         lastSkillsLoadKey = skillsLoadKey
       } catch {
@@ -5448,13 +5454,15 @@ export function useDesktopState() {
     isPolling.value = true
 
     const shouldRefreshThreads = pendingThreadsRefresh
+    const shouldForceThreadRefresh = pendingThreadsRefreshForce
     const threadIdsToRefresh = new Set(pendingThreadMessageRefresh)
     pendingThreadsRefresh = false
+    pendingThreadsRefreshForce = false
     pendingThreadMessageRefresh.clear()
 
     try {
       if (shouldRefreshThreads) {
-        await loadThreads()
+        await loadThreads({ force: shouldForceThreadRefresh })
       }
 
       const activeThreadId = selectedThreadId.value

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -89,6 +89,8 @@ const BACKGROUND_THREAD_PAGINATION_DELAY_MS = 10_000
 const RATE_LIMIT_REFRESH_DEBOUNCE_MS = 500
 const TURN_START_FOLLOW_UP_SYNC_DELAY_MS = 3000
 const RECENT_THREAD_MESSAGE_LOAD_REUSE_MS = 2000
+const RECENT_THREAD_LIST_LOAD_REUSE_MS = 2000
+const RECENT_SKILLS_LOAD_REUSE_MS = 2000
 const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
 const GLOBAL_SERVER_REQUEST_SCOPE = '__global__'
 const MODEL_FALLBACK_ID = 'gpt-5.4-mini'
@@ -1514,6 +1516,9 @@ export function useDesktopState() {
   let loadThreadsPromise: Promise<void> | null = null
   const loadMessagePromiseByThreadId = new Map<string, Promise<void>>()
   let refreshSkillsPromise: Promise<void> | null = null
+  let lastThreadListLoadAt = 0
+  let lastSkillsLoadAt = 0
+  let lastSkillsLoadKey = ''
   let rateLimitRefreshPromise: Promise<void> | null = null
   let pendingThreadsRefresh = false
   const pendingThreadMessageRefresh = new Set<string>()
@@ -4293,6 +4298,12 @@ export function useDesktopState() {
       await loadThreadsPromise
       return
     }
+    if (
+      hasLoadedThreads.value &&
+      Date.now() - lastThreadListLoadAt < RECENT_THREAD_LIST_LOAD_REUSE_MS
+    ) {
+      return
+    }
 
     loadThreadsPromise = (async () => {
     if (!hasLoadedThreads.value) {
@@ -4319,6 +4330,7 @@ export function useDesktopState() {
 
       applyThreadGroups(loadedThreadListGroups, rootsState)
       hasLoadedThreads.value = true
+      lastThreadListLoadAt = Date.now()
       if (!hasLoadedAllThreadPages) {
         scheduleRemainingThreadPages(rootsState)
       }
@@ -4524,15 +4536,25 @@ export function useDesktopState() {
   }
 
   async function refreshSkills(): Promise<void> {
+    const selectedCwd = selectedThread.value?.cwd?.trim() ?? ''
+    const skillsLoadKey = selectedCwd || '__global__'
     if (refreshSkillsPromise) {
       await refreshSkillsPromise
+      return
+    }
+    if (
+      installedSkills.value.length > 0 &&
+      lastSkillsLoadKey === skillsLoadKey &&
+      Date.now() - lastSkillsLoadAt < RECENT_SKILLS_LOAD_REUSE_MS
+    ) {
       return
     }
 
     refreshSkillsPromise = (async () => {
       try {
-        const selectedCwd = selectedThread.value?.cwd?.trim() ?? ''
         installedSkills.value = await getSkillsList(selectedCwd ? [selectedCwd] : undefined)
+        lastSkillsLoadAt = Date.now()
+        lastSkillsLoadKey = skillsLoadKey
       } catch {
         // keep previous skills on failure
       } finally {

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -1674,10 +1674,12 @@ export function useDesktopState() {
     return availableModelIds.value[0] ?? ''
   }
 
-  function setSelectedThreadId(nextThreadId: string): void {
+  function setSelectedThreadId(nextThreadId: string, options: { persist?: boolean } = {}): void {
     if (selectedThreadId.value === nextThreadId) return
     selectedThreadId.value = nextThreadId
-    saveSelectedThreadId(nextThreadId)
+    if (options.persist !== false) {
+      saveSelectedThreadId(nextThreadId)
+    }
     selectedModelId.value = readProviderCompatibleSelectedModel(readModelIdForThread(nextThreadId))
     selectedCollaborationMode.value = readSelectedCollaborationMode(
       selectedCollaborationModeByContext.value,
@@ -5655,8 +5657,8 @@ export function useDesktopState() {
     void sendMessageToSelectedThread(msg.text, msg.imageUrls, msg.skills, 'steer', msg.fileAttachments)
   }
 
-  function primeSelectedThread(threadId: string): void {
-    setSelectedThreadId(threadId)
+  function primeSelectedThread(threadId: string, options: { persist?: boolean } = {}): void {
+    setSelectedThreadId(threadId, options)
   }
 
   return {

--- a/tests.md
+++ b/tests.md
@@ -5872,7 +5872,35 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
-- Remove the temporary isolated `CODEX_HOME` if it is no longer needed.
+
+---
+
+### Startup profiler request dedupe
+
+#### Feature/Change Name
+Startup thread-list and skills-list refreshes reuse fresh in-memory results, and the profiler distinguishes pinned-thread summary hydration from duplicate full thread reads.
+
+#### Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. Ensure the browser profiler is available from this repository.
+
+#### Steps
+1. In light theme, run `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser`.
+2. Open the generated `output/playwright/browser-runtime-profile-home-*.json`.
+3. Confirm `duplicateCounts.threadListFirstPage` is `1`, `duplicateCounts.skillsList` is `1`, and `warnings` is empty.
+4. Run `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:thread`.
+5. Open the generated `output/playwright/browser-runtime-profile-thread-*.json`.
+6. Confirm `duplicateCounts.threadReadWithTurns` is `0` or `1`, `duplicateCounts.threadReadDuplicateKeys` is `0`, and `warnings` is empty.
+7. Repeat the home route in dark theme and confirm the page finishes loading without `pageState.stillLoadingThreads`.
+
+#### Expected Results
+- Startup event bursts do not issue duplicate first-page `thread/list` requests.
+- Startup event bursts do not issue duplicate same-cwd `skills/list` requests.
+- Pinned-thread summaries may appear as `thread/read:*:summary` rows, but they do not trigger duplicate full-read warnings.
+- Light and dark themes both complete thread loading.
+
+#### Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -5872,6 +5872,7 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
+- Remove the temporary isolated `CODEX_HOME` if it is no longer needed.
 
 ---
 
@@ -5890,7 +5891,7 @@ Startup thread-list and skills-list refreshes reuse fresh in-memory results, and
 3. Confirm `duplicateCounts.threadListFirstPage` is `1`, `duplicateCounts.skillsList` is `1`, and `warnings` is empty.
 4. Run `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:thread`.
 5. Open the generated `output/playwright/browser-runtime-profile-thread-*.json`.
-6. Confirm `duplicateCounts.threadReadWithTurns` is `0` or `1`, `duplicateCounts.threadReadDuplicateKeys` is `0`, and `warnings` is empty.
+6. Confirm `duplicateCounts.threadReadWithTurns` is `0`, `duplicateCounts.threadReadDuplicateKeys` is `0`, and `warnings` is empty.
 7. Repeat the home route in dark theme and confirm the page finishes loading without `pageState.stillLoadingThreads`.
 
 #### Expected Results

--- a/tests.md
+++ b/tests.md
@@ -5876,6 +5876,32 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 ---
 
+### Non-thread startup selection priming
+
+#### Feature/Change Name
+Home, skills, and automations startup priming clears the active in-memory selected thread without erasing the persisted selected thread id.
+
+#### Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. Have at least one existing thread available in the sidebar.
+
+#### Steps
+1. In light theme, open a thread route and confirm the thread is selected.
+2. Navigate to `http://127.0.0.1:4173/#/`.
+3. Refresh the page and confirm the home route does not load skills for the previously selected thread context.
+4. Navigate back to the prior thread route and confirm it can still be selected normally.
+5. Repeat the home-route refresh in dark theme and confirm no thread-loading overlay remains stuck.
+
+#### Expected Results
+- Non-thread routes clear the active selected thread for startup request scoping.
+- The persisted selected thread id is not removed by the non-thread startup priming path.
+- Light and dark themes both finish loading without duplicate startup warnings.
+
+#### Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.
+
+---
+
 ### Startup profiler request dedupe
 
 #### Feature/Change Name


### PR DESCRIPTION
## Summary
- reuse freshly loaded thread-list results during startup refresh bursts
- reuse freshly loaded same-cwd skills-list results
- update browser profiler to distinguish pinned-thread summary hydration from duplicate full thread reads

## Verification
- pnpm run test:unit -- src/composables/useDesktopState.test.ts (13 files, 126 tests passed)
- pnpm run build:frontend
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser: home profile warnings=[], threadListFirstPage=1, skillsList=1, stillLoadingThreads=false
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:thread: thread profile warnings=[], threadReadWithTurns=0, threadReadDuplicateKeys=0, stillLoadingThreads=false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reuse/throttle recent thread-list and skills loads to reduce redundant requests; event-driven updates still force fresh thread data.

* **Bug Fixes**
  * Skills reliably refresh when changed; initial route priming improved and can prime an empty thread selection without overwriting persisted choice.

* **Testing**
  * Added tests for startup deduplication, cache reuse, and event-driven refresh behavior.

* **Documentation**
  * Added manual verifications and enhanced profiling diagnostics to detect duplicate thread-read requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->