### PR TITLE
Fix inline code marker rendering

### DIFF
--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -2544,7 +2544,7 @@ function splitTextByFileUrls(
 
     const markdownToken = parseMarkdownLinkToken(token)
     if (!markdownToken) {
-      segments.push(...splitPlainTextByLinks(text.slice(segmentStart, segmentEnd)))
+      segments.push(...splitPlainTextByLinks(text.slice(segmentStart, segmentEnd), options))
       cursor = segmentEnd
       scanFrom = segmentEnd
       continue
@@ -2590,7 +2590,7 @@ function parseInlineSegmentsUncached(text: string): InlineSegment[] {
   })
   if (!hasInlineCodeMarker) return linkFirstSegments
   if (!linkFirstSegments.some((segment) => segment.kind === 'text' && segment.value.includes('`'))) {
-    return linkFirstSegments
+    return applyInlineMarkdownMarkers(linkFirstSegments)
   }
 
   const parseCodeAwareTextSegments = (value: string): InlineSegment[] => {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -4795,7 +4795,7 @@ onBeforeUnmount(() => {
 }
 
 .plan-card-markdown :deep(.message-inline-code) {
-  @apply rounded-md bg-slate-200/80 px-1.5 py-0.5 font-mono text-[0.9em] text-slate-900;
+  @apply bg-transparent p-0 font-sans text-[1em] font-semibold text-inherit;
 }
 
 .plan-card-markdown :deep(.message-file-link) {
@@ -4969,7 +4969,8 @@ onBeforeUnmount(() => {
 }
 
 .message-inline-code {
-  @apply rounded-md border border-slate-200 bg-slate-100/60 px-1.5 py-0.5 text-[0.875em] leading-[1.4] text-slate-900 font-mono;
+  @apply bg-transparent p-0 font-sans text-[1em] font-semibold text-inherit;
+  line-height: inherit;
 }
 
 .message-code-block {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -2298,7 +2298,10 @@ function editMessage(messageId: string): void {
   emit('rollback', { turnId })
 }
 
-function splitPlainTextByLinks(text: string): InlineSegment[] {
+function splitPlainTextByLinks(
+  text: string,
+  options: { applyMarkdownMarkers?: boolean } = {},
+): InlineSegment[] {
   const segments: InlineSegment[] = []
   const pattern = /codex:\/\/threads\/[A-Za-z0-9-]+|https?:\/\/[^\s<>"'`，。；：！？、()[\]{}「」『』《》]+|file:\/\/[^\n<>"'`，。；：！？、[\]{}「」『』《》]+|["'](?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^\n"']+["']|`(?:[A-Za-z]:[\\/]|~\/|\.{1,2}\/|\/)[^`\n]+`/gu
   let cursor = 0
@@ -2376,7 +2379,7 @@ function splitPlainTextByLinks(text: string): InlineSegment[] {
     segments.push({ kind: 'text', value: text.slice(cursor) })
   }
 
-  return applyInlineMarkdownMarkers(segments)
+  return options.applyMarkdownMarkers === false ? segments : applyInlineMarkdownMarkers(segments)
 }
 
 function applyDelimitedMarkersAcrossTextSegments(
@@ -2474,7 +2477,10 @@ function applyInlineMarkdownMarkers(segments: InlineSegment[]): InlineSegment[] 
   return next
 }
 
-function splitTextByFileUrls(text: string): InlineSegment[] {
+function splitTextByFileUrls(
+  text: string,
+  options: { applyMarkdownMarkers?: boolean } = {},
+): InlineSegment[] {
   const segments: InlineSegment[] = []
   let cursor = 0
   let scanFrom = 0
@@ -2533,7 +2539,7 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
     const segmentEnd = asteriskWrapper?.segmentEnd ?? end
 
     if (segmentStart > cursor) {
-      segments.push(...splitPlainTextByLinks(text.slice(cursor, segmentStart)))
+      segments.push(...splitPlainTextByLinks(text.slice(cursor, segmentStart), options))
     }
 
     const markdownToken = parseMarkdownLinkToken(token)
@@ -2571,15 +2577,18 @@ function splitTextByFileUrls(text: string): InlineSegment[] {
   }
 
   if (cursor < text.length) {
-    segments.push(...splitPlainTextByLinks(text.slice(cursor)))
+    segments.push(...splitPlainTextByLinks(text.slice(cursor), options))
   }
 
   return segments
 }
 
 function parseInlineSegmentsUncached(text: string): InlineSegment[] {
-  const linkFirstSegments = splitTextByFileUrls(text)
-  if (!text.includes('`')) return linkFirstSegments
+  const hasInlineCodeMarker = text.includes('`')
+  const linkFirstSegments = splitTextByFileUrls(text, {
+    applyMarkdownMarkers: !hasInlineCodeMarker,
+  })
+  if (!hasInlineCodeMarker) return linkFirstSegments
   if (!linkFirstSegments.some((segment) => segment.kind === 'text' && segment.value.includes('`'))) {
     return linkFirstSegments
   }

--- a/src/style.css
+++ b/src/style.css
@@ -674,7 +674,7 @@
 }
 
 :root.dark .message-inline-code {
-  @apply border-zinc-600 bg-zinc-700/60 text-zinc-200;
+  @apply bg-transparent text-inherit;
 }
 
 :root.dark .message-table {
@@ -1321,7 +1321,7 @@
 }
 
 :root.dark .plan-card-markdown .message-inline-code {
-  @apply bg-zinc-800 text-zinc-100;
+  @apply bg-transparent text-inherit;
 }
 
 :root.dark .plan-card-markdown .message-file-link {

--- a/tests.md
+++ b/tests.md
@@ -5872,6 +5872,7 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
+- Remove the temporary isolated `CODEX_HOME` and unset or restore `CODEX_HOME` if it was exported.
 
 ---
 

--- a/tests.md
+++ b/tests.md
@@ -5886,13 +5886,13 @@ Inline code parsing preserves asterisks inside code spans without affecting late
 
 #### Steps
 1. In light theme, render or send a message containing: ``generated `composio-*.md` connector documentation and starts the thread without attaching `composio-cli` as a skill``.
-2. Confirm only `composio-*.md` and `composio-cli` render with inline-code styling.
+2. Confirm only `composio-*.md` and `composio-cli` render as bold inline text without a grey box.
 3. Confirm `connector documentation and starts the thread without attaching` remains normal prose.
-4. Repeat in dark theme and confirm the same two inline-code spans are styled with readable dark contrast.
+4. Repeat in dark theme and confirm the same two inline-code spans are bold inline text with readable dark contrast.
 
 #### Expected Results
 - Asterisks inside inline code do not open italic parsing.
-- Inline code backgrounds do not spill over later prose when wrapping on a mobile-width viewport.
+- Inline code does not show a grey box or spill styling over later prose when wrapping on a mobile-width viewport.
 - Light and dark themes both keep normal prose and inline code visually distinct.
 
 #### Rollback/Cleanup

--- a/tests.md
+++ b/tests.md
@@ -5872,6 +5872,31 @@ Message loads for an already selected thread do not trigger redundant model pref
 
 #### Rollback/Cleanup
 - Stop the temporary Vite server if it was only used for this check.
+
+---
+
+### Inline code with asterisks does not leak formatting
+
+#### Feature/Change Name
+Inline code parsing preserves asterisks inside code spans without affecting later prose.
+
+#### Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. Open a thread that can display a rendered assistant or user message.
+
+#### Steps
+1. In light theme, render or send a message containing: ``generated `composio-*.md` connector documentation and starts the thread without attaching `composio-cli` as a skill``.
+2. Confirm only `composio-*.md` and `composio-cli` render with inline-code styling.
+3. Confirm `connector documentation and starts the thread without attaching` remains normal prose.
+4. Repeat in dark theme and confirm the same two inline-code spans are styled with readable dark contrast.
+
+#### Expected Results
+- Asterisks inside inline code do not open italic parsing.
+- Inline code backgrounds do not spill over later prose when wrapping on a mobile-width viewport.
+- Light and dark themes both keep normal prose and inline code visually distinct.
+
+#### Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.
 - Remove the temporary isolated `CODEX_HOME` if it is no longer needed.
 
 ---


### PR DESCRIPTION
## Summary
- preserve inline code spans before applying emphasis markers when a message contains backticks
- prevents `*` inside code like `composio-*.md` from styling later prose on mobile wrapping
- adds manual light/dark rendering coverage to tests.md

## Verification
- pnpm run test:unit src/api/normalizers/v2.test.ts src/api/codexGateway.test.ts
- pnpm run build
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser

Performance profile: no warnings; duplicateCounts threadList=1, threadRead=3, skillsList=1, providerModels=1; totalApiKB=338.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented asterisks inside inline code from being parsed as emphasis by making emphasis parsing optional during initial link/code segmentation.
  * Ensured inline-code formatting no longer leaks into surrounding text when lines wrap.

* **Style**
  * Updated inline-code appearance in dark mode to use a transparent background, inherited text color, sans/semibold styling and preserved line-height.

* **Documentation**
  * Added a manual regression test for inline-code with asterisks and updated cleanup/rollback steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->