### PR TITLE
Fix mobile sidebar and dropdown state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -547,6 +547,7 @@
               :placeholder="terminalCommandPlaceholder"
               :selected-prefix-icon="IconTablerTerminal"
               :icon-only="true"
+              menu-align="end"
               :empty-label="t('No commands')"
               @update:model-value="onSelectHeaderTerminalCommand"
             />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1494,6 +1494,8 @@ const serverMatchedThreadIds = ref<string[] | null>(null)
 let threadSearchTimer: ReturnType<typeof setTimeout> | null = null
 let terminalKeyboardFocusFallbackTimer: ReturnType<typeof setTimeout> | null = null
 let sidebarScrollTop = 0
+let sidebarScrollRestoreRequestId = 0
+let isRestoringSidebarScroll = false
 let threadBranchesRequestId = 0
 let threadBranchCommitsRequestId = 0
 let threadCommitFilesRequestId = 0
@@ -2266,9 +2268,55 @@ function clearSidebarSearch(): void {
   sidebarSearchInputRef.value?.focus()
 }
 
-function onSidebarScroll(): void {
+function getSidebarScrollableElement(): HTMLElement | null {
+  if (sidebarScrollableRef.value) return sidebarScrollableRef.value
+  if (typeof document === 'undefined') return null
+  return document.querySelector<HTMLElement>('.mobile-drawer .sidebar-scrollable, .sidebar-scrollable')
+}
+
+function onSidebarScroll(event?: Event): void {
   if (isSidebarCollapsed.value) return
-  sidebarScrollTop = sidebarScrollableRef.value?.scrollTop ?? 0
+  if (isRestoringSidebarScroll) return
+  const target = event?.currentTarget
+  const container = target instanceof HTMLElement ? target : getSidebarScrollableElement()
+  sidebarScrollTop = container?.scrollTop ?? sidebarScrollTop
+}
+
+function restoreSidebarScrollPosition(): void {
+  const requestId = ++sidebarScrollRestoreRequestId
+  const targetScrollTop = sidebarScrollTop
+  const maxRestoreAttempts = 90
+  isRestoringSidebarScroll = true
+  const finishRestore = () => {
+    if (requestId === sidebarScrollRestoreRequestId) {
+      sidebarScrollTop = targetScrollTop
+      isRestoringSidebarScroll = false
+    }
+  }
+  const restore = (attempt: number) => {
+    if (requestId !== sidebarScrollRestoreRequestId) return
+    if (isSidebarCollapsed.value) {
+      finishRestore()
+      return
+    }
+
+    const container = getSidebarScrollableElement()
+    if (container) {
+      container.scrollTop = targetScrollTop
+      if (Math.abs(container.scrollTop - targetScrollTop) <= 1 || attempt >= maxRestoreAttempts) {
+        finishRestore()
+        return
+      }
+    }
+
+    if (attempt >= maxRestoreAttempts || typeof window === 'undefined') {
+      finishRestore()
+      return
+    }
+    window.requestAnimationFrame(() => restore(attempt + 1))
+  }
+
+  void nextTick(() => restore(0))
 }
 
 function onSidebarSearchKeydown(event: KeyboardEvent): void {
@@ -2834,16 +2882,15 @@ async function onForkThreadFromMessage(payload: { threadId: string; turnIndex: n
 function setSidebarCollapsed(nextValue: boolean): void {
   if (isSidebarCollapsed.value === nextValue) return
   if (nextValue) {
-    sidebarScrollTop = sidebarScrollableRef.value?.scrollTop ?? sidebarScrollTop
+    const currentScrollTop = getSidebarScrollableElement()?.scrollTop
+    if (typeof currentScrollTop === 'number' && (currentScrollTop > 0 || sidebarScrollTop === 0)) {
+      sidebarScrollTop = currentScrollTop
+    }
   }
   isSidebarCollapsed.value = nextValue
   saveSidebarCollapsed(nextValue)
   if (!nextValue) {
-    void nextTick(() => {
-      if (isSidebarCollapsed.value) return
-      if (!sidebarScrollableRef.value) return
-      sidebarScrollableRef.value.scrollTop = sidebarScrollTop
-    })
+    restoreSidebarScrollPosition()
   }
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2267,6 +2267,7 @@ function clearSidebarSearch(): void {
 }
 
 function onSidebarScroll(): void {
+  if (isSidebarCollapsed.value) return
   sidebarScrollTop = sidebarScrollableRef.value?.scrollTop ?? 0
 }
 
@@ -2738,7 +2739,10 @@ function resolveSelectedThreadProjectCwd(): string {
 }
 
 function onStartNewThreadFromToolbar(): void {
-  newThreadCwd.value = resolveSelectedThreadProjectCwd()
+  const resolvedCwd = resolveSelectedThreadProjectCwd()
+  if (resolvedCwd) {
+    newThreadCwd.value = resolvedCwd
+  }
   newThreadRuntime.value = 'local'
   if (isMobile.value) setSidebarCollapsed(true)
   if (isHomeRoute.value) return
@@ -2836,6 +2840,7 @@ function setSidebarCollapsed(nextValue: boolean): void {
   saveSidebarCollapsed(nextValue)
   if (!nextValue) {
     void nextTick(() => {
+      if (isSidebarCollapsed.value) return
       if (!sidebarScrollableRef.value) return
       sidebarScrollableRef.value.scrollTop = sidebarScrollTop
     })

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,11 @@
   <DesktopLayout :is-sidebar-collapsed="isSidebarCollapsed" @close-sidebar="setSidebarCollapsed(true)">
     <template #sidebar>
       <section class="sidebar-root">
-        <div class="sidebar-scrollable">
+        <div
+          ref="sidebarScrollableRef"
+          class="sidebar-scrollable"
+          @scroll="onSidebarScroll"
+        >
           <SidebarThreadControls
             v-if="!isSidebarCollapsed"
             class="sidebar-thread-controls-host"
@@ -1480,6 +1484,7 @@ const worktreeInitStatus = ref<{ phase: 'idle' | 'running' | 'error'; title: str
 const isSidebarCollapsed = ref(loadSidebarCollapsed())
 const sidebarSearchQuery = ref('')
 const isSidebarSearchVisible = ref(false)
+const sidebarScrollableRef = ref<HTMLElement | null>(null)
 const sidebarSearchInputRef = ref<HTMLInputElement | null>(null)
 const settingsAreaRef = ref<HTMLElement | null>(null)
 const settingsPanelRef = ref<HTMLElement | null>(null)
@@ -1487,6 +1492,7 @@ const settingsButtonRef = ref<HTMLElement | null>(null)
 const serverMatchedThreadIds = ref<string[] | null>(null)
 let threadSearchTimer: ReturnType<typeof setTimeout> | null = null
 let terminalKeyboardFocusFallbackTimer: ReturnType<typeof setTimeout> | null = null
+let sidebarScrollTop = 0
 let threadBranchesRequestId = 0
 let threadBranchCommitsRequestId = 0
 let threadCommitFilesRequestId = 0
@@ -2259,6 +2265,10 @@ function clearSidebarSearch(): void {
   sidebarSearchInputRef.value?.focus()
 }
 
+function onSidebarScroll(): void {
+  sidebarScrollTop = sidebarScrollableRef.value?.scrollTop ?? 0
+}
+
 function onSidebarSearchKeydown(event: KeyboardEvent): void {
   if (event.key === 'Escape') {
     isSidebarSearchVisible.value = false
@@ -2810,8 +2820,17 @@ async function onForkThreadFromMessage(payload: { threadId: string; turnIndex: n
 
 function setSidebarCollapsed(nextValue: boolean): void {
   if (isSidebarCollapsed.value === nextValue) return
+  if (nextValue) {
+    sidebarScrollTop = sidebarScrollableRef.value?.scrollTop ?? sidebarScrollTop
+  }
   isSidebarCollapsed.value = nextValue
   saveSidebarCollapsed(nextValue)
+  if (!nextValue) {
+    void nextTick(() => {
+      if (!sidebarScrollableRef.value) return
+      sidebarScrollableRef.value.scrollTop = sidebarScrollTop
+    })
+  }
 }
 
 function onWindowKeyDown(event: KeyboardEvent): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2728,8 +2728,16 @@ async function onCreateProjectWorktree(projectName: string): Promise<void> {
   }
 }
 
+function resolveSelectedThreadProjectCwd(): string {
+  const thread = selectedThread.value
+  if (!thread) return ''
+  const projectName = thread.projectName?.trim() ?? ''
+  if (!projectName) return thread.cwd?.trim() ?? ''
+  return resolvePreferredLocalCwd(projectName, thread.cwd?.trim() ?? '')
+}
+
 function onStartNewThreadFromToolbar(): void {
-  newThreadCwd.value = ''
+  newThreadCwd.value = resolveSelectedThreadProjectCwd()
   newThreadRuntime.value = 'local'
   if (isMobile.value) setSidebarCollapsed(true)
   if (isHomeRoute.value) return

--- a/src/components/content/ComposerDropdown.vue
+++ b/src/components/content/ComposerDropdown.vue
@@ -15,13 +15,15 @@
 
     <div
       v-if="isOpen"
+      ref="menuWrapRef"
       class="composer-dropdown-menu-wrap"
       :class="{
         'composer-dropdown-menu-wrap-up': openDirection === 'up',
         'composer-dropdown-menu-wrap-down': openDirection === 'down',
       }"
+      :style="menuWrapStyle"
     >
-      <div class="composer-dropdown-menu">
+      <div ref="menuRef" class="composer-dropdown-menu">
         <div v-if="enableSearch" class="composer-dropdown-search-wrap">
           <input
             ref="searchInputRef"
@@ -71,6 +73,7 @@ const props = defineProps<{
   selectedPrefixIcon?: Component | null
   iconOnly?: boolean
   openDirection?: 'up' | 'down'
+  menuAlign?: 'start' | 'end'
   enableSearch?: boolean
   searchPlaceholder?: string
   emptyLabel?: string
@@ -81,9 +84,12 @@ const emit = defineEmits<{
 }>()
 
 const rootRef = ref<HTMLElement | null>(null)
+const menuWrapRef = ref<HTMLElement | null>(null)
+const menuRef = ref<HTMLElement | null>(null)
 const searchInputRef = ref<HTMLInputElement | null>(null)
 const isOpen = ref(false)
 const searchQuery = ref('')
+const menuWrapStyle = ref<Record<string, string>>({})
 
 const selectedLabel = computed(() => {
   const selected = props.options.find((option) => option.value === props.modelValue)
@@ -92,6 +98,7 @@ const selectedLabel = computed(() => {
 })
 
 const openDirection = computed(() => props.openDirection ?? 'down')
+const menuAlign = computed(() => props.menuAlign ?? 'start')
 const iconOnly = computed(() => props.iconOnly === true)
 const enableSearch = computed(() => props.enableSearch === true)
 const searchPlaceholderText = computed(() => props.searchPlaceholder?.trim() || 'Quick search projects')
@@ -108,6 +115,46 @@ const filteredOptions = computed(() => {
 function onToggle(): void {
   if (props.disabled) return
   isOpen.value = !isOpen.value
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function updateMenuPosition(): void {
+  if (!isOpen.value) return
+  const root = rootRef.value
+  if (!root || typeof window === 'undefined') return
+
+  const rect = root.getBoundingClientRect()
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const viewportPadding = 8
+  const gap = 8
+  const maxMenuWidth = Math.max(0, viewportWidth - viewportPadding * 2)
+  const measuredWidth = menuRef.value?.offsetWidth ?? menuWrapRef.value?.offsetWidth ?? 224
+  const measuredHeight = menuRef.value?.offsetHeight ?? menuWrapRef.value?.offsetHeight ?? 0
+  const menuWidth = Math.min(measuredWidth, maxMenuWidth)
+  const maxLeft = Math.max(viewportPadding, viewportWidth - menuWidth - viewportPadding)
+  const desiredLeft = menuAlign.value === 'end' ? rect.right - menuWidth : rect.left
+  const left = clamp(desiredLeft, viewportPadding, maxLeft)
+
+  let top = openDirection.value === 'up'
+    ? rect.top - measuredHeight - gap
+    : rect.bottom + gap
+  if (measuredHeight > 0 && top + measuredHeight > viewportHeight - viewportPadding) {
+    top = viewportHeight - measuredHeight - viewportPadding
+  }
+  top = Math.max(viewportPadding, top)
+
+  menuWrapStyle.value = {
+    position: 'fixed',
+    left: `${left}px`,
+    right: 'auto',
+    top: `${top}px`,
+    bottom: 'auto',
+    width: `${menuWidth}px`,
+  }
 }
 
 function onSelect(value: string): void {
@@ -137,17 +184,27 @@ function onDocumentPointerDown(event: PointerEvent): void {
 }
 
 watch(isOpen, (open) => {
-  if (!open) return
-  if (!enableSearch.value) return
-  nextTick(() => searchInputRef.value?.focus())
+  if (!open) {
+    menuWrapStyle.value = {}
+    return
+  }
+  nextTick(() => {
+    updateMenuPosition()
+    window.requestAnimationFrame(updateMenuPosition)
+    if (enableSearch.value) searchInputRef.value?.focus()
+  })
 })
 
 onMounted(() => {
   window.addEventListener('pointerdown', onDocumentPointerDown)
+  window.addEventListener('resize', updateMenuPosition)
+  window.addEventListener('scroll', updateMenuPosition, true)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onDocumentPointerDown)
+  window.removeEventListener('resize', updateMenuPosition)
+  window.removeEventListener('scroll', updateMenuPosition, true)
 })
 </script>
 

--- a/src/components/content/ComposerDropdown.vue
+++ b/src/components/content/ComposerDropdown.vue
@@ -90,6 +90,7 @@ const searchInputRef = ref<HTMLInputElement | null>(null)
 const isOpen = ref(false)
 const searchQuery = ref('')
 const menuWrapStyle = ref<Record<string, string>>({})
+let isLayoutListenerAttached = false
 
 const selectedLabel = computed(() => {
   const selected = props.options.find((option) => option.value === props.modelValue)
@@ -157,6 +158,20 @@ function updateMenuPosition(): void {
   }
 }
 
+function addLayoutListeners(): void {
+  if (isLayoutListenerAttached || typeof window === 'undefined') return
+  window.addEventListener('resize', updateMenuPosition)
+  window.addEventListener('scroll', updateMenuPosition, true)
+  isLayoutListenerAttached = true
+}
+
+function removeLayoutListeners(): void {
+  if (!isLayoutListenerAttached || typeof window === 'undefined') return
+  window.removeEventListener('resize', updateMenuPosition)
+  window.removeEventListener('scroll', updateMenuPosition, true)
+  isLayoutListenerAttached = false
+}
+
 function onSelect(value: string): void {
   emit('update:modelValue', value)
   isOpen.value = false
@@ -185,9 +200,11 @@ function onDocumentPointerDown(event: PointerEvent): void {
 
 watch(isOpen, (open) => {
   if (!open) {
+    removeLayoutListeners()
     menuWrapStyle.value = {}
     return
   }
+  addLayoutListeners()
   nextTick(() => {
     updateMenuPosition()
     window.requestAnimationFrame(updateMenuPosition)
@@ -197,14 +214,11 @@ watch(isOpen, (open) => {
 
 onMounted(() => {
   window.addEventListener('pointerdown', onDocumentPointerDown)
-  window.addEventListener('resize', updateMenuPosition)
-  window.addEventListener('scroll', updateMenuPosition, true)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onDocumentPointerDown)
-  window.removeEventListener('resize', updateMenuPosition)
-  window.removeEventListener('scroll', updateMenuPosition, true)
+  removeLayoutListeners()
 })
 </script>
 

--- a/tests.md
+++ b/tests.md
@@ -15,7 +15,7 @@ This file is the manual test index. Detailed regression and feature verification
 
 | Folder | Sections | Scope |
 | --- | ---: | --- |
-| [Projects, Sidebar, and New Chat](tests/projects-sidebar-new-chat/index.md) | 12 | Home route, project picker, sidebar organization, new-chat setup, projectless folders, and project/worktree shell behavior. |
+| [Projects, Sidebar, and New Chat](tests/projects-sidebar-new-chat/index.md) | 14 | Home route, project picker, sidebar organization, new-chat setup, projectless folders, and project/worktree shell behavior. |
 | [Automations](tests/automations/index.md) | 4 | Thread heartbeat automations, project cron automations, dialogs, action rows, and automation panel behavior. |
 | [Skills, Plugins, and Integrations](tests/skills-plugins-integrations/index.md) | 27 | Skills Hub, skill sync, plugin/app directory surfaces, prompts, Composio, Telegram, and installed skill behavior. |
 | [Chat Composer and Message Rendering](tests/chat-composer-rendering/index.md) | 33 | Composer controls, queued messages, plan mode, markdown parsing, file links, attachments, generated images, and visible message rows. |
@@ -25,7 +25,7 @@ This file is the manual test index. Detailed regression and feature verification
 | [CLI, Network, and Platform](tests/cli-network-platform/index.md) | 17 | CLI startup, dev scripts, npx, Tailscale, Cloudflare tunnels, Windows, Android, Termux, and platform packaging behavior. |
 | [Git, Worktrees, and Rollback](tests/git-worktrees-rollback/index.md) | 25 | Branch controls, worktree creation, rollback commits, changed-files panels, file browser links, and rollback debug behavior. |
 | [Accounts, Feedback, and Observability](tests/accounts-feedback-observability/index.md) | 14 | Account panels, quota refresh, feedback diagnostics, Sentry, browser profiling, API perf logs, and Qodo diagnostic fixes. |
-| [Theme, Layout, and Terminal](tests/theme-layout-terminal/index.md) | 15 | Light/dark theme regressions, responsive layout, terminal UI, mobile keyboard behavior, dialog sizing, and visual alignment. |
+| [Theme, Layout, and Terminal](tests/theme-layout-terminal/index.md) | 16 | Light/dark theme regressions, responsive layout, terminal UI, mobile keyboard behavior, dialog sizing, and visual alignment. |
 | [Website, Docs, and Miscellaneous](tests/website-docs-misc/index.md) | 3 | Static website checks and small compatibility checks that do not yet fit a narrower product area. |
 
 ## Template

--- a/tests/projects-sidebar-new-chat/index.md
+++ b/tests/projects-sidebar-new-chat/index.md
@@ -20,3 +20,5 @@ Return to the [manual test index](../../tests.md).
 | [Expandable Projects, Pinned, and Chats sidebar sections](expandable-projects-pinned-and-chats-sidebar-sections.md) |
 | [Sidebar chats show more projectless chats](sidebar-chats-show-more-projectless-chats.md) |
 | [Projectless new chat folder collisions](projectless-new-chat-folder-collisions.md) |
+| [Sidebar scroll position survives collapse](sidebar-scroll-position-survives-collapse.md) |
+| [Toolbar new thread keeps active project](toolbar-new-thread-keeps-active-project.md) |

--- a/tests/projects-sidebar-new-chat/sidebar-scroll-position-survives-collapse.md
+++ b/tests/projects-sidebar-new-chat/sidebar-scroll-position-survives-collapse.md
@@ -1,0 +1,27 @@
+# Sidebar scroll position survives collapse
+
+## Feature/Change Name
+Sidebar scroll position is restored after closing and reopening the sidebar.
+
+## Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. Use a workspace with enough sidebar projects or threads for the sidebar list to scroll.
+
+## Steps
+1. In light theme, open `http://127.0.0.1:4173/#/`.
+2. Scroll the sidebar list downward until a lower project or thread row is near the top of the sidebar.
+3. Collapse the sidebar with the sidebar toggle or `Command+B`.
+4. Reopen the sidebar with the header/sidebar toggle or `Command+B`.
+5. Confirm the same lower project or thread row is still near the top and the sidebar did not jump back to the top.
+6. Repeat collapse/reopen twice quickly and confirm the restored position is not clobbered to the top while collapsed.
+7. Repeat the collapse and reopen flow in dark theme.
+
+## Expected Results
+- Closing and reopening the sidebar restores the previous vertical scroll offset.
+- The remembered scroll position remains stable while the sidebar content is remounted.
+- Mobile drawer restore retries after reopen until the full list height is available, so transition/teleport timing does not leave the sidebar at the top or a partial intermediate offset.
+- Scroll events emitted after collapse do not overwrite the saved offset.
+- Light and dark theme sidebar rows remain readable after restore.
+
+## Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.

--- a/tests/projects-sidebar-new-chat/toolbar-new-thread-keeps-active-project.md
+++ b/tests/projects-sidebar-new-chat/toolbar-new-thread-keeps-active-project.md
@@ -1,0 +1,27 @@
+# Toolbar new thread keeps active project
+
+## Feature/Change Name
+The global Start new thread action opens the new-thread composer with the active thread's project selected.
+
+## Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
+2. Use a workspace with at least one project-backed thread.
+
+## Steps
+1. In light theme, open `http://127.0.0.1:4173/#/`.
+2. Select a thread inside a project from the sidebar.
+3. Click the toolbar Start new thread button.
+4. Confirm the home/new-thread composer opens with the same project folder selected, not an empty or projectless selection.
+5. Send a first message and confirm the new thread appears under the same project in the sidebar.
+6. While already on the home/new-thread route with a folder selected, click Start new thread again and confirm the selected folder is not cleared.
+7. Repeat the selection and Start new thread flow in dark theme.
+
+## Expected Results
+- The toolbar Start new thread action preserves the active thread's project context.
+- The new-thread folder dropdown shows the project folder immediately after navigation.
+- Existing home-route folder selection is preserved when no active thread project resolves.
+- New threads created from that composer are grouped under the same project.
+- Light and dark theme controls remain readable.
+
+## Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.

--- a/tests/theme-layout-terminal/index.md
+++ b/tests/theme-layout-terminal/index.md
@@ -23,3 +23,4 @@ Return to the [manual test index](../../tests.md).
 | [Dark theme plan card contrast](dark-theme-plan-card-contrast.md) |
 | [Terminal focus does not fullscreen panel](terminal-focus-does-not-fullscreen-panel.md) |
 | [Terminal quick commands from project files](terminal-quick-commands-from-project-files.md) |
+| [Mobile terminal command dropdown stays on screen](mobile-terminal-command-dropdown-stays-on-screen.md) |

--- a/tests/theme-layout-terminal/mobile-terminal-command-dropdown-stays-on-screen.md
+++ b/tests/theme-layout-terminal/mobile-terminal-command-dropdown-stays-on-screen.md
@@ -1,0 +1,25 @@
+# Mobile terminal command dropdown stays on screen
+
+## Feature/Change Name
+Composer dropdown menus are viewport-clamped so the terminal command dropdown remains visible on mobile.
+
+## Prerequisites/Setup
+1. Start local Vite: `pnpm run dev --host 0.0.0.0 --port 4173`.
+2. Open the app on a mobile viewport or mobile browser with a thread whose project exposes terminal quick commands.
+
+## Steps
+1. In light theme, open a thread at mobile width.
+2. Tap the terminal command dropdown in the content header.
+3. Confirm the menu is fully visible within the left and right viewport edges.
+4. Confirm long command labels truncate inside the menu instead of pushing the menu off-screen.
+5. Scroll or rotate the viewport while the menu is open and confirm it remains clamped to the visible viewport.
+6. Repeat the dropdown check in dark theme.
+
+## Expected Results
+- The terminal command dropdown does not render off the left or right edge on mobile.
+- Command rows remain tappable and readable.
+- Resize and scroll repositioning only runs while the dropdown is open.
+- Light and dark theme dropdown surfaces remain readable.
+
+## Rollback/Cleanup
+- Stop the temporary Vite server if it was only used for this check.


### PR DESCRIPTION
## Summary
- preserve sidebar scroll position across collapse/reopen
- start toolbar-created threads in the active project instead of clearing the project selection
- clamp composer dropdown menus to the viewport so terminal commands stay on-screen on mobile

## Verification
- pnpm run build:frontend
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser
  - report: output/playwright/browser-runtime-profile-home-2026-05-18T21-41-09-813Z.json
  - warnings: []
  - threadListFirstPage=1, threadListCursor=0, totalApiKB=338.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New threads started from the toolbar now preselect the active thread’s project folder.

* **Bug Fixes**
  * Sidebar scroll position is preserved when collapsing and expanding (including rapid toggles).
  * Terminal/command dropdown is right-aligned and dynamically positioned to remain fully visible on resize/scroll.

* **Tests**
  * Added manual checks for sidebar scroll persistence, new-thread context selection, and mobile dropdown positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->