### PR TITLE
Reduce startup profiler request fanout

### DIFF
--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -720,6 +720,26 @@ describe('live error overlay', () => {
   })
 })
 
+describe('startup refresh coalescing', () => {
+  it('clears selected thread without refreshing models, messages, or skills', async () => {
+    installTestWindow({
+      'codex-web-local.selected-thread-id.v1': 'previous-thread',
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(['gpt-5.5'])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+
+    const state = useDesktopState()
+    const result = await state.selectThread('')
+
+    expect(result).toBe('ok')
+    expect(state.selectedThreadId.value).toBe('')
+    expect(gatewayMocks.resumeThread).not.toHaveBeenCalled()
+    expect(gatewayMocks.getThreadDetail).not.toHaveBeenCalled()
+    expect(gatewayMocks.getAvailableModelIds).not.toHaveBeenCalled()
+    expect(gatewayMocks.getSkillsList).not.toHaveBeenCalled()
+  })
+})
+
 describe('provider model selection', () => {
   it('ignores global selected-model localStorage when OpenCode Zen is the active provider', async () => {
     installTestWindow({

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4643,6 +4643,7 @@ export function useDesktopState() {
 
   async function selectThread(threadId: string): Promise<SelectThreadResult> {
     setSelectedThreadId(threadId)
+    if (!threadId.trim()) return 'ok'
 
     try {
       await loadMessages(threadId)

--- a/tests/accounts-feedback-observability/startup-profiler-request-dedupe.md
+++ b/tests/accounts-feedback-observability/startup-profiler-request-dedupe.md
@@ -1,7 +1,7 @@
 ### Startup profiler request dedupe
 
 #### Feature/Change Name
-Startup thread-list and skills-list refreshes reuse fresh in-memory results, and the profiler distinguishes pinned-thread summary hydration from duplicate full thread reads.
+Startup thread-list and skills-list refresh paths avoid duplicate profiler diagnostics.
 
 #### Prerequisites/Setup
 1. Start local Vite: `pnpm run dev --host 127.0.0.1 --port 4173`.
@@ -19,6 +19,7 @@ Startup thread-list and skills-list refreshes reuse fresh in-memory results, and
 #### Expected Results
 - Startup event bursts do not issue duplicate first-page `thread/list` requests.
 - Startup event bursts do not issue duplicate same-cwd `skills/list` requests.
+- Home startup does not clear a remembered selected thread through the full selected-thread load path.
 - Pinned-thread summaries may appear as `thread/read:*:summary` rows, but they do not trigger duplicate full-read warnings.
 - Light and dark themes both complete thread loading.
 


### PR DESCRIPTION
## Summary
- Avoid running the full selected-thread load/model/skills refresh path when home-route sync clears a remembered selected thread.
- Add regression coverage for empty thread selection not refreshing messages, models, or skills.
- Update startup profiler manual test notes for the route-clear behavior.

## Verification
- `pnpm exec vitest run src/composables/useDesktopState.test.ts src/components/sidebar/pinnedThreadUtils.test.ts`
- `pnpm run build:frontend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated unnecessary API calls when clearing the selected thread, improving startup performance and application responsiveness.

* **Tests**
  * Added test coverage for thread selection clearing to verify no redundant gateway requests are triggered during this operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->