### PR TITLE
Support Codex catalog provider model payloads

### DIFF
--- a/src/server/codexAppServerBridge.providerModels.test.ts
+++ b/src/server/codexAppServerBridge.providerModels.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeProviderModelsData } from './codexAppServerBridge'
+
+describe('provider model discovery payload normalization', () => {
+  it('reads OpenAI-compatible model ids from data rows', () => {
+    expect(normalizeProviderModelsData({
+      data: [
+        { id: 'gpt-5.4' },
+        { id: 'gpt-5.4-mini' },
+      ],
+    })).toEqual(['gpt-5.4', 'gpt-5.4-mini'])
+  })
+
+  it('reads Codex catalog model slugs from models rows', () => {
+    expect(normalizeProviderModelsData({
+      models: [
+        { slug: 'gpt-5.4' },
+        { slug: 'gpt-5.3-codex' },
+      ],
+    })).toEqual(['gpt-5.4', 'gpt-5.3-codex'])
+  })
+
+  it('accepts string rows and common model fields while preserving first-seen order', () => {
+    expect(normalizeProviderModelsData({
+      models: [
+        'gpt-5.5',
+        { model: 'gpt-5.4' },
+        { id: 'gpt-5.5' },
+        { slug: 'gpt-5.3-codex' },
+      ],
+    })).toEqual(['gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex'])
+  })
+
+  it('rejects payloads without a supported models array', () => {
+    expect(() => normalizeProviderModelsData({ object: 'list' }))
+      .toThrow('provider /models payload is missing a data/models array')
+  })
+})

--- a/src/server/codexAppServerBridge.providerModels.test.ts
+++ b/src/server/codexAppServerBridge.providerModels.test.ts
@@ -20,6 +20,16 @@ describe('provider model discovery payload normalization', () => {
     })).toEqual(['gpt-5.4', 'gpt-5.3-codex'])
   })
 
+  it('falls back to models rows when data rows are empty', () => {
+    expect(normalizeProviderModelsData({
+      data: [],
+      models: [
+        { slug: 'gpt-5.4' },
+        { slug: 'gpt-5.3-codex' },
+      ],
+    })).toEqual(['gpt-5.4', 'gpt-5.3-codex'])
+  })
+
   it('accepts string rows and common model fields while preserving first-seen order', () => {
     expect(normalizeProviderModelsData({
       models: [

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1226,17 +1226,25 @@ function buildProviderModelsUrl(baseUrl: string, queryParams: unknown): URL {
   return url
 }
 
-function normalizeProviderModelsData(payload: unknown): string[] {
+export function normalizeProviderModelsData(payload: unknown): string[] {
   const record = asRecord(payload)
-  const rows = Array.isArray(record?.data) ? record.data : null
+  const rows = Array.isArray(record?.data)
+    ? record.data
+    : Array.isArray(record?.models)
+      ? record.models
+      : null
   if (!rows) {
-    throw new Error('provider /models payload is missing a data array')
+    throw new Error('provider /models payload is missing a data/models array')
   }
 
   const ids: string[] = []
   for (const row of rows) {
+    const candidateFromString = readNonEmptyString(row)
     const entry = asRecord(row)
-    const candidate = readNonEmptyString(entry?.id)
+    const candidate = candidateFromString
+      || readNonEmptyString(entry?.id)
+      || readNonEmptyString(entry?.model)
+      || readNonEmptyString(entry?.slug)
     if (!candidate || ids.includes(candidate)) continue
     ids.push(candidate)
   }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1228,11 +1228,9 @@ function buildProviderModelsUrl(baseUrl: string, queryParams: unknown): URL {
 
 export function normalizeProviderModelsData(payload: unknown): string[] {
   const record = asRecord(payload)
-  const rows = Array.isArray(record?.data)
-    ? record.data
-    : Array.isArray(record?.models)
-      ? record.models
-      : null
+  const dataRows = Array.isArray(record?.data) ? record.data : null
+  const modelRows = Array.isArray(record?.models) ? record.models : null
+  const rows = dataRows?.length ? dataRows : modelRows?.length ? modelRows : dataRows ?? modelRows
   if (!rows) {
     throw new Error('provider /models payload is missing a data/models array')
   }

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -1236,6 +1236,7 @@ export function normalizeProviderModelsData(payload: unknown): string[] {
   }
 
   const ids: string[] = []
+  const seen = new Set<string>()
   for (const row of rows) {
     const candidateFromString = readNonEmptyString(row)
     const entry = asRecord(row)
@@ -1243,7 +1244,8 @@ export function normalizeProviderModelsData(payload: unknown): string[] {
       || readNonEmptyString(entry?.id)
       || readNonEmptyString(entry?.model)
       || readNonEmptyString(entry?.slug)
-    if (!candidate || ids.includes(candidate)) continue
+    if (!candidate || seen.has(candidate)) continue
+    seen.add(candidate)
     ids.push(candidate)
   }
   return ids

--- a/tests/providers-models/index.md
+++ b/tests/providers-models/index.md
@@ -29,6 +29,7 @@ Return to the [manual test index](../../tests.md).
 | [Android published CLI loads Codex app-server models through local proxy](android-published-cli-loads-codex-app-server-models-through-local-proxy.md) |
 | [OpenCode Zen status returns current provider models](opencode-zen-status-returns-current-provider-models.md) |
 | [Provider models load without Codex model-list dependency](provider-models-load-without-codex-model-list-dependency.md) |
+| [Provider models accept Codex catalog payloads](provider-models-accepts-codex-catalog-payload.md) |
 | [Thread-locked providers across Zen, Codex, and OpenRouter](thread-locked-providers-across-zen-codex-and-openrouter.md) |
 | [Selected thread loads do not refetch provider models](selected-thread-loads-do-not-refetch-provider-models.md) |
 | [Provider-backed scheduled refreshes keep model menus populated](provider-backed-scheduled-refreshes-keep-model-menus-populated.md) |

--- a/tests/providers-models/provider-models-accepts-codex-catalog-payload.md
+++ b/tests/providers-models/provider-models-accepts-codex-catalog-payload.md
@@ -1,0 +1,24 @@
+### Provider models accept Codex catalog payloads
+
+#### Feature/Change Name
+Provider-backed model discovery accepts both OpenAI-compatible and Codex catalog `/models` payloads.
+
+#### Prerequisites/Setup
+1. Build the project with `pnpm run build`.
+2. Configure Codex with a `responses` provider whose `/models` endpoint returns `{"models":[{"slug":"..."}]}`.
+3. Start the app and open it in the browser.
+
+#### Steps
+1. Open the model selector for the provider-backed thread or new-chat composer.
+2. Confirm the selector includes model ids from the provider `models[].slug` payload.
+3. Select one of the discovered models and start a new thread.
+
+#### Expected Results
+- `/codex-api/provider-models` returns model ids from either `data[].id` or `models[].slug`.
+- The model selector is not reduced to only the configured fallback model when the provider returns a Codex catalog payload.
+- Starting a thread passes the selected model id through to Codex.
+
+#### Rollback/Cleanup
+- Switch the provider back to the preferred default.
+
+---

--- a/tests/providers-models/provider-models-accepts-codex-catalog-payload.md
+++ b/tests/providers-models/provider-models-accepts-codex-catalog-payload.md
@@ -5,8 +5,9 @@ Provider-backed model discovery accepts both OpenAI-compatible and Codex catalog
 
 #### Prerequisites/Setup
 1. Build the project with `pnpm run build`.
-2. Configure Codex with a `responses` provider whose `/models` endpoint returns `{"models":[{"slug":"..."}]}`.
-3. Start the app and open it in the browser.
+2. Start the app and open it in the browser.
+3. In Settings, choose `Custom endpoint`, set API format to `Responses`, and point the endpoint URL at a test provider base URL such as `http://127.0.0.1:8666/v1`.
+4. Have that provider return `{"models":[{"slug":"gpt-5.4"}]}` from `GET /v1/models`.
 
 #### Steps
 1. Open the model selector for the provider-backed thread or new-chat composer.


### PR DESCRIPTION
## Summary
- accept Codex catalog-shaped provider `/models` payloads in provider model discovery
- keep existing OpenAI-compatible `data[].id` handling while also reading `models[].slug`, `models[].model`, `models[].id`, and string rows
- add focused parser coverage and provider-model manual test documentation

## Root Cause
Provider model discovery currently expects OpenAI-compatible `/models` responses shaped like `{"data":[{"id":"..."}]}`.

Some Responses-compatible providers expose a Codex catalog-shaped model response instead, for example `{"models":[{"slug":"gpt-5.4"}]}`. In that case discovery treats the payload as invalid, returns an empty provider model list, and the model selector falls back to only the configured model even though the provider exposes more models.

## Reproduction
Configure a `responses` provider whose `<base_url>/models` endpoint returns:

```json
{"models":[{"slug":"gpt-5.4"},{"slug":"gpt-5.3-codex"}]}
```

Open the model selector. Before this change, only the configured fallback model is available; after this change, the provider models appear.

## Verification
- `pnpm run test:unit`
- `pnpm run build`

## Performance
Parser-only change on the existing provider-model discovery response. It adds no new requests, polling, cache invalidation path, or UI render work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider model discovery accepts Codex-style catalog payloads and derives model IDs from multiple common fields, preserving discovered order.
  * Improved handling and clearer error reporting when a provider returns no supported models/data.

* **Tests**
  * Added automated tests covering varied provider payload shapes, ordering, deduplication, and error handling when no models/data are present.

* **Documentation**
  * Added a manual test/spec describing expected discovery behavior and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->