### PR TITLE
Replace chat export with clipboard copy

### DIFF
--- a/.agents/skills/codex-app-parity/SKILL.md
+++ b/.agents/skills/codex-app-parity/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: "codex-app-parity"
-description: "Use when implementing or changing user-visible behavior/UI in this repository and parity with the installed Codex desktop app must be validated before coding."
+description: "Use only when the user explicitly mentions Codex parity, codex-app-parity, Codex.app parity, or asks to compare against the installed Codex desktop app."
 ---
 
 # Codex App Parity Skill
 
-Use this skill for any feature work or user-visible behavior/UI change in this repository.
-Do not use it for purely internal refactors that do not affect behavior.
+Use this skill only when the user explicitly asks for Codex parity work, names `codex-app-parity`, mentions Codex.app parity, or asks to compare behavior against the installed Codex desktop app.
+Do not auto-trigger this skill for ordinary feature work, UI changes, or user-visible behavior changes unless the user explicitly requests that parity workflow.
 
 ## Objective
 
@@ -173,6 +173,13 @@ The script:
 - auto-picks free CDP and Node inspector ports
 - verifies the endpoints after launch
 - prepares the required native Sparkle shim for external-Electron runs
+
+If the helper script fails, treat the failure as a skill maintenance signal, not just a one-off launch error:
+
+- Inspect the failing shell script and its nearby helper scripts before using a manual fallback.
+- Fix durable launcher bugs in the `.sh` scripts when the cause is clear and local to the script.
+- Re-run the helper after the fix and update this skill with any new reliable launch finding.
+- Use a manual launch fallback only when the script cannot be repaired safely in the current task.
 
 Use `--verify-only` when you only need to confirm whether the current endpoints are still alive.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1175,6 +1175,7 @@ import type { ComposerDraftPayload, ThreadComposerExposed } from './components/c
 import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, TelegramStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, isProjectlessChatPath, normalizePathForUi } from './pathUtils.js'
+import { copyTextToClipboard } from './utils/clipboard'
 
 const ThreadConversation = defineAsyncComponent(() => import('./components/content/ThreadConversation.vue'))
 const ThreadTerminalPanel = defineAsyncComponent(() => import('./components/content/ThreadTerminalPanel.vue'))
@@ -2362,11 +2363,7 @@ function onAutomationsChanged(): void {
 
 async function onCopyThreadChat(threadId: string): Promise<void> {
   if (!threadId) return
-  if (selectedThreadId.value !== threadId) {
-    await selectThread(threadId)
-    await router.push({ name: 'thread', params: { threadId } })
-  }
-  await nextTick()
+  if (selectedThreadId.value !== threadId) return
   await copySelectedThreadChat()
 }
 
@@ -4029,33 +4026,6 @@ function buildThreadMarkdown(): string {
 
 function escapeMarkdownText(value: string): string {
   return value.replace(/([\\`*_{}\[\]()#+\-.!])/g, '\\$1')
-}
-
-function copyTextWithSelectionFallback(text: string): boolean {
-  if (typeof document === 'undefined') return false
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.setAttribute('readonly', '')
-  textarea.style.position = 'fixed'
-  textarea.style.left = '-9999px'
-  textarea.style.top = '0'
-  document.body.appendChild(textarea)
-  textarea.select()
-  try {
-    return document.execCommand('copy')
-  } finally {
-    document.body.removeChild(textarea)
-  }
-}
-
-async function copyTextToClipboard(text: string): Promise<void> {
-  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text)
-    return
-  }
-  if (!copyTextWithSelectionFallback(text)) {
-    throw new Error('Clipboard write failed')
-  }
 }
 
 function loadBoolPref(key: string, fallback: boolean): boolean {

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,7 @@
             @rename-thread="onRenameThread"
             @fork-thread="onForkThread"
             @remove-project="onRemoveProject" @reorder-project="onReorderProject"
-            @export-thread="onExportThread"
+            @copy-thread-chat="onCopyThreadChat"
             @automations-changed="onAutomationsChanged"
             @start-new-chat="onStartNewThreadFromToolbar" />
         </div>
@@ -2360,14 +2360,14 @@ function onAutomationsChanged(): void {
   void automationsPanelRef.value?.loadAutomations()
 }
 
-async function onExportThread(threadId: string): Promise<void> {
+async function onCopyThreadChat(threadId: string): Promise<void> {
   if (!threadId) return
   if (selectedThreadId.value !== threadId) {
     await selectThread(threadId)
     await router.push({ name: 'thread', params: { threadId } })
   }
   await nextTick()
-  onExportChat()
+  await copySelectedThreadChat()
 }
 
 function shortAccountId(accountId: string): string {
@@ -3959,20 +3959,15 @@ function onImplementPlan(payload: { turnId: string }): void {
 }
 
 
-function onExportChat(): void {
-  if (isHomeRoute.value || isSkillsRoute.value || isAutomationsRoute.value || typeof document === 'undefined') return
+async function copySelectedThreadChat(): Promise<void> {
+  if (isHomeRoute.value || isSkillsRoute.value || isAutomationsRoute.value) return
   if (!selectedThread.value || filteredMessages.value.length === 0) return
   const markdown = buildThreadMarkdown()
-  const fileName = buildExportFileName()
-  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
-  const objectUrl = URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = objectUrl
-  link.download = fileName
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
+  try {
+    await copyTextToClipboard(markdown)
+  } catch {
+    // Clipboard writes can be blocked by browser permissions; keep the menu action best-effort.
+  }
 }
 
 function buildThreadMarkdown(): string {
@@ -4032,19 +4027,35 @@ function buildThreadMarkdown(): string {
   return `${lines.join('\n').trimEnd()}\n`
 }
 
-function buildExportFileName(): string {
-  const threadTitle = selectedThread.value?.title?.trim() || 'chat'
-  const sanitized = threadTitle
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  const base = sanitized || 'chat'
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-  return `${base}-${stamp}.md`
-}
-
 function escapeMarkdownText(value: string): string {
   return value.replace(/([\\`*_{}\[\]()#+\-.!])/g, '\\$1')
+}
+
+function copyTextWithSelectionFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  textarea.style.top = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  try {
+    return document.execCommand('copy')
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+  if (!copyTextWithSelectionFallback(text)) {
+    throw new Error('Clipboard write failed')
+  }
 }
 
 function loadBoolPref(key: string, fallback: boolean): boolean {

--- a/src/components/content/HeaderGitBranchDropdown.vue
+++ b/src/components/content/HeaderGitBranchDropdown.vue
@@ -194,6 +194,7 @@ import IconTablerChevronDown from '../icons/IconTablerChevronDown.vue'
 import IconTablerFilePencil from '../icons/IconTablerFilePencil.vue'
 import IconTablerGitFork from '../icons/IconTablerGitFork.vue'
 import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 const props = defineProps<{
   currentBranch: string | null
@@ -340,28 +341,6 @@ function copyCommitRef(commit: GitCommitOption): void {
   void copyTextToClipboard(value).catch(() => {
     copiedCommitSha.value = ''
   })
-}
-
-async function copyTextToClipboard(value: string): Promise<void> {
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(value)
-      return
-    }
-  } catch {
-    // Fall back for embedded browser contexts without clipboard permission.
-  }
-  const textarea = document.createElement('textarea')
-  textarea.value = value
-  textarea.setAttribute('readonly', 'true')
-  textarea.style.position = 'fixed'
-  textarea.style.top = '-9999px'
-  textarea.style.left = '-9999px'
-  document.body.appendChild(textarea)
-  textarea.select()
-  const copied = document.execCommand('copy')
-  textarea.remove()
-  if (!copied) throw new Error('Copy failed')
 }
 
 function resetSelectedCommit(): void {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -922,6 +922,7 @@ import type { UiFileChange, UiLiveOverlay, UiMessage, UiPlanStep, UiServerReques
 import { updateThreadFileChanges } from '../../api/codexGateway'
 import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { useMobile } from '../../composables/useMobile'
+import { copyTextToClipboard, copyTextWithSelectionFallback } from '../../utils/clipboard'
 
 import IconTablerArrowBackUp from '../icons/IconTablerArrowBackUp.vue'
 import IconTablerArrowUp from '../icons/IconTablerArrowUp.vue'
@@ -2340,42 +2341,16 @@ function diffViewerMarker(line: DiffViewerLine): string {
   return ''
 }
 
-function copyTextWithSelectionFallback(text: string): boolean {
-  if (typeof document === 'undefined') return false
-
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  textarea.setAttribute('readonly', 'true')
-  textarea.style.position = 'fixed'
-  textarea.style.left = '-9999px'
-  textarea.style.opacity = '0'
-  textarea.style.pointerEvents = 'none'
-  document.body.appendChild(textarea)
-  textarea.focus()
-  textarea.select()
-  textarea.setSelectionRange(0, text.length)
-
-  try {
-    return document.execCommand('copy')
-  } catch {
-    return false
-  } finally {
-    document.body.removeChild(textarea)
-  }
-}
-
 async function copyResponse(anchorMessageId: string): Promise<void> {
   const content = copyableResponseContentByAnchorId.value[anchorMessageId] ?? ''
   if (!content) return
 
   let copied = false
-  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(content)
-      copied = true
-    } catch {
-      copied = false
-    }
+  try {
+    await copyTextToClipboard(content)
+    copied = true
+  } catch {
+    copied = false
   }
 
   if (!copied) {
@@ -2971,17 +2946,9 @@ async function copyFileLinkContextLink(): Promise<void> {
   if (!href || href === '#') return
 
   try {
-    await navigator.clipboard.writeText(href)
+    await copyTextToClipboard(href)
   } catch {
-    const textarea = document.createElement('textarea')
-    textarea.value = href
-    textarea.setAttribute('readonly', 'true')
-    textarea.style.position = 'fixed'
-    textarea.style.opacity = '0'
-    document.body.appendChild(textarea)
-    textarea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textarea)
+    // Clipboard writes can be blocked by browser permissions; keep the context action best-effort.
   }
 }
 

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -618,7 +618,13 @@
         <button class="thread-menu-item" type="button" @click="onCopyThreadPath(openThreadMenuThread.id)">
           Copy path
         </button>
-        <button class="thread-menu-item" type="button" @click="onCopyThreadChat(openThreadMenuThread.id)">
+        <button
+          class="thread-menu-item"
+          type="button"
+          :disabled="openThreadMenuThread.id !== selectedThreadId"
+          :title="openThreadMenuThread.id === selectedThreadId ? 'Copy chat' : 'Open this chat before copying'"
+          @click="onCopyThreadChat(openThreadMenuThread.id)"
+        >
           Copy chat
         </button>
         <button class="thread-menu-item" type="button" @click="onForkThread(openThreadMenuThread.id)">
@@ -1679,6 +1685,7 @@ function setAutomationScheduleMode(mode: AutomationScheduleMode): void {
 }
 
 function onCopyThreadChat(threadId: string): void {
+  if (threadId !== props.selectedThreadId) return
   emit('copy-thread-chat', threadId)
   closeThreadMenu()
 }
@@ -3252,6 +3259,10 @@ onBeforeUnmount(() => {
 
 .thread-menu-item {
   @apply rounded px-2 py-1 text-left text-sm text-zinc-700 hover:bg-zinc-100;
+}
+
+.thread-menu-item:disabled {
+  @apply cursor-not-allowed text-zinc-400 hover:bg-transparent;
 }
 
 .thread-menu-item-danger {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -618,8 +618,8 @@
         <button class="thread-menu-item" type="button" @click="onCopyThreadPath(openThreadMenuThread.id)">
           Copy path
         </button>
-        <button class="thread-menu-item" type="button" @click="onExportThread(openThreadMenuThread.id)">
-          Export chat
+        <button class="thread-menu-item" type="button" @click="onCopyThreadChat(openThreadMenuThread.id)">
+          Copy chat
         </button>
         <button class="thread-menu-item" type="button" @click="onForkThread(openThreadMenuThread.id)">
           Create chat fork
@@ -925,7 +925,7 @@ const emit = defineEmits<{
   'rename-thread': [payload: { threadId: string; title: string }]
   'remove-project': [projectName: string]
   'reorder-project': [payload: { projectName: string; toIndex: number }]
-  'export-thread': [threadId: string]
+  'copy-thread-chat': [threadId: string]
   'fork-thread': [threadId: string]
   'start-new-chat': []
   'automations-changed': []
@@ -1678,8 +1678,8 @@ function setAutomationScheduleMode(mode: AutomationScheduleMode): void {
   syncAutomationRruleFromScheduleDraft()
 }
 
-function onExportThread(threadId: string): void {
-  emit('export-thread', threadId)
+function onCopyThreadChat(threadId: string): void {
+  emit('copy-thread-chat', threadId)
   closeThreadMenu()
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -477,6 +477,10 @@
   @apply text-zinc-300 hover:bg-zinc-700;
 }
 
+:root.dark .thread-menu-item:disabled {
+  @apply text-zinc-500 hover:bg-transparent;
+}
+
 :root.dark .thread-menu-item-danger {
   @apply text-rose-300 hover:bg-rose-900/40;
 }

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,38 @@
+export function copyTextWithSelectionFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  textarea.setSelectionRange(0, text.length)
+
+  try {
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {
+      // Fall back for embedded browser contexts without clipboard permission.
+    }
+  }
+
+  if (!copyTextWithSelectionFallback(text)) {
+    throw new Error('Copy failed')
+  }
+}

--- a/tests/git-worktrees-rollback/index.md
+++ b/tests/git-worktrees-rollback/index.md
@@ -29,6 +29,7 @@ Return to the [manual test index](../../tests.md).
 | [Fix: Codex.app "New Worktree" Button Missing After Account Switch (CDP Injection)](codex-app-new-worktree-button-missing-after-account-switch-cdp-injection.md) |
 | [User message edit action replaces rollback button](user-message-edit-action-replaces-rollback-button.md) |
 | [Thread menu copy path action](thread-menu-copy-path-action.md) |
+| [Thread menu copy chat action](thread-menu-copy-chat-action.md) |
 | [Project menu permanent worktree action](project-menu-permanent-worktree-action.md) |
 | [Hide worktree controls for non-Git folders](hide-worktree-controls-for-non-git-folders.md) |
 | [Project worktree threads under canonical project](project-worktree-threads-under-canonical-project.md) |

--- a/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
+++ b/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
@@ -10,17 +10,19 @@ The thread overflow menu includes a `Copy chat` item that copies the selected ch
 4. Light theme and dark theme are available from the appearance switcher
 
 #### Steps
-1. In light theme, hover a thread row in the sidebar and open its overflow menu
+1. In light theme, hover the selected thread row in the sidebar and open its overflow menu
 2. Verify `Copy chat` appears after `Copy path`
 3. Click `Copy chat`
 4. Paste the clipboard contents into a text field or clipboard inspector
-5. Reopen the same menu in dark theme and verify the item remains readable and in the same position
+5. Open a different, non-selected thread row menu and verify `Copy chat` is disabled
+6. Reopen the selected thread menu in dark theme and verify the item remains readable and in the same position
 
 #### Expected Results
 - The menu closes after clicking `Copy chat`
 - No Markdown file is downloaded
 - Clipboard contents start with the thread title as a Markdown heading and include `Thread ID:`
 - The copied body includes the visible chat messages in Markdown
+- `Copy chat` is disabled for non-selected threads so clipboard writes keep the original click activation
 - Light theme and dark theme both keep the menu item readable
 
 #### Rollback/Cleanup

--- a/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
+++ b/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
@@ -1,25 +1,26 @@
-### Thread menu copy path action
+### Thread menu copy chat action
 
 #### Feature/Change Name
-The thread overflow menu includes a `Copy path` item that copies the selected thread's working directory path.
+The thread overflow menu includes a `Copy chat` item that copies the selected chat as Markdown instead of downloading an export file.
 
 #### Prerequisites/Setup
 1. Dev server running at `http://127.0.0.1:5174` or the active Vite dev URL
-2. Open any existing thread with a known project path
+2. Open any existing thread with at least one visible message
 3. Browser clipboard access is available
 4. Light theme and dark theme are available from the appearance switcher
 
 #### Steps
 1. In light theme, hover a thread row in the sidebar and open its overflow menu
-2. Verify `Copy path` appears after `Browse files`
-3. Click `Copy path`
+2. Verify `Copy chat` appears after `Copy path`
+3. Click `Copy chat`
 4. Paste the clipboard contents into a text field or clipboard inspector
 5. Reopen the same menu in dark theme and verify the item remains readable and in the same position
 
 #### Expected Results
-- The menu order is `Add automation...` or `Manage automations...`, `Browse files`, `Copy path`, `Copy chat`, `Create chat fork`, `Pin thread` or `Unpin thread`, `Rename thread`, `Delete thread`
-- Clicking `Copy path` closes the menu
-- Clipboard contents equal the thread's `cwd` path
+- The menu closes after clicking `Copy chat`
+- No Markdown file is downloaded
+- Clipboard contents start with the thread title as a Markdown heading and include `Thread ID:`
+- The copied body includes the visible chat messages in Markdown
 - Light theme and dark theme both keep the menu item readable
 
 #### Rollback/Cleanup


### PR DESCRIPTION
## Summary
- replace the thread menu Export chat action with Copy chat
- copy the existing Markdown chat export content to the clipboard instead of downloading a file
- keep Copy chat enabled only for the selected thread so clipboard writes retain the original click activation
- extract shared clipboard utilities and reuse them across chat copy, response copy, file-link copy, and commit-ref copy paths
- narrow the codex-app-parity skill trigger to explicit user requests and document debug-launch script repair behavior
- add/update manual test coverage for the thread menu copy actions

## Verification
- pnpm run build
- Playwright on http://127.0.0.1:4173 verified Copy chat in light and dark menus, no Export chat label, selected-thread clipboard Markdown containing Thread ID plus message sections, and disabled Copy chat for non-selected thread rows

## Performance audit
- Reuses the existing Markdown serialization path and replaces blob/object URL download work with one clipboard write.
- Shared clipboard utility removes duplicated fallback code without adding runtime fanout.
- No new requests, polling, cache invalidation, or unbounded fanout added.
- Live verification confirmed the changed menu interaction without duplicate API behavior introduced by the feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread menu now offers "Copy chat" (copies thread as Markdown to clipboard) instead of downloading files; action is disabled for non-selected threads and keeps readable formatting across themes.
  * File/link "Copy" actions use the clipboard for quick copying with best-effort handling.

* **Tests & Documentation**
  * Added documentation and manual test steps for the thread menu "Copy chat" behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->