### PR TITLE
Clear folder from Chats new chat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@
             @remove-project="onRemoveProject" @reorder-project="onReorderProject"
             @copy-thread-chat="onCopyThreadChat"
             @automations-changed="onAutomationsChanged"
-            @start-new-chat="onStartNewThreadFromToolbar" />
+            @start-new-chat="onStartProjectlessNewChat" />
         </div>
 
         <div
@@ -2788,6 +2788,14 @@ function onStartNewThreadFromToolbar(): void {
   if (resolvedCwd) {
     newThreadCwd.value = resolvedCwd
   }
+  newThreadRuntime.value = 'local'
+  if (isMobile.value) setSidebarCollapsed(true)
+  if (isHomeRoute.value) return
+  void router.push({ name: 'home' })
+}
+
+function onStartProjectlessNewChat(): void {
+  newThreadCwd.value = ''
   newThreadRuntime.value = 'local'
   if (isMobile.value) setSidebarCollapsed(true)
   if (isHomeRoute.value) return

--- a/tests/projects-sidebar-new-chat/projectless-new-chat-folders.md
+++ b/tests/projects-sidebar-new-chat/projectless-new-chat-folders.md
@@ -6,15 +6,17 @@
 - Light and dark themes are both available from Settings.
 
 #### Steps
-1. Open the app in light theme and click the sidebar `New chat` action while an existing thread is selected.
-2. Confirm the home composer does not inherit the selected thread folder.
-3. Send a first message with a unique prompt such as `Projectless folder smoke test`.
-4. Confirm the new thread starts in `~/Documents/Codex/<YYYY-MM-DD>/projectless-folder-smoke-test`.
-5. Start another new chat with the same prompt and confirm the folder receives a numeric suffix.
-6. Switch to dark theme and repeat steps 1-3 with a different unique prompt.
+1. Open the app in light theme and select a project-backed thread so the new-thread composer would normally have a folder context.
+2. Expand the sidebar `Chats` section and click its `New chat` action.
+3. Confirm the home composer does not inherit the selected thread folder and the selected-folder line is absent.
+4. Send a first message with a unique prompt such as `Projectless folder smoke test`.
+5. Confirm the new thread starts in `~/Documents/Codex/<YYYY-MM-DD>/projectless-folder-smoke-test`.
+6. Start another new chat with the same prompt and confirm the folder receives a numeric suffix.
+7. Switch to dark theme and repeat steps 1-4 with a different unique prompt.
 
 #### Expected Results
 - `New chat` starts as a projectless chat instead of reusing the current thread cwd.
+- The `Chats` section `New chat` action clears any selected folder even when a project-backed thread is selected.
 - Sending the first message creates a real directory under `~/Documents/Codex/<YYYY-MM-DD>/`.
 - Folder names are derived from the prompt using lowercase alphanumeric tokens, with suffixes for duplicates.
 - Projectless chat rows appear in the `Chats` section and do not create a separate project group from the generated folder name.


### PR DESCRIPTION
## Summary
- route the Chats section New chat action through a projectless handler
- clear the selected new-thread folder while preserving toolbar/project new-thread behavior
- update the projectless new chat manual test steps

## Verification
- pnpm run build:frontend
- Playwright focused check at 599x941 in light and dark before rebase
- PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser before rebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projectless new chat functionality now properly clears folder selection and resets chat state.
  * Sidebar automatically collapses on mobile when initiating a new chat.

* **Tests**
  * Updated test documentation for projectless new chat behavior and folder handling verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->