### PR TITLE
Replace native dropdown controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@
 ## UI Rules
 
 - For shared route surfaces and large feature UIs, put decisive dark-theme overrides in `src/style.css` instead of relying only on component-scoped `:global(:root.dark)` blocks.
+- Do not introduce native browser dropdowns (`<select>`) for app controls such as provider, model, branch, runtime, folder, language, or settings pickers. Use the app's custom dropdown/menu components so styling, search, dark theme, and option layout stay consistent.
 - Browser assertions must inspect the real changed UI, not sidebar previews or base page load.
 - For refresh-persistence fixes, include post-refresh evidence that the state persisted.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -233,13 +233,14 @@
               </button>
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the interface language for the app.')">
                 <span class="sidebar-settings-label">{{ t('UI language') }}</span>
-                <select
-                  class="sidebar-settings-provider-select"
-                  :value="uiLanguage"
-                  @change="setUiLanguage(($event.target as HTMLSelectElement).value as 'en' | 'zh-CN')"
-                >
-                  <option v-for="option in uiLanguageOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
-                </select>
+                <ComposerDropdown
+                  class="sidebar-settings-provider-dropdown"
+                  :model-value="uiLanguage"
+                  :options="uiLanguageOptions"
+                  :placeholder="t('UI language')"
+                  menu-align="end"
+                  @update:model-value="setUiLanguage($event as 'en' | 'zh-CN')"
+                />
               </div>
               <button class="sidebar-settings-row" type="button" :title="SETTINGS_HELP.chatWidth" @click="cycleChatWidth">
                 <span class="sidebar-settings-label">{{ t('Chat width') }}</span>
@@ -265,17 +266,15 @@
 
               <div class="sidebar-settings-row sidebar-settings-row--select" :title="t('Choose the API provider for the Codex backend')">
                 <span class="sidebar-settings-label">{{ t('Provider') }}</span>
-                <select
-                  class="sidebar-settings-provider-select"
-                  :value="selectedProvider"
+                <ComposerDropdown
+                  class="sidebar-settings-provider-dropdown"
+                  :model-value="selectedProvider"
+                  :options="providerDropdownOptions"
+                  :placeholder="t('Provider')"
                   :disabled="freeModeLoading"
-                  @change="onProviderChange(($event.target as HTMLSelectElement).value)"
-                >
-                  <option value="codex">Codex</option>
-                  <option value="openrouter">OpenRouter</option>
-                  <option value="opencode-zen">OpenCode Zen</option>
-                  <option value="custom">Custom endpoint</option>
-                </select>
+                  menu-align="end"
+                  @update:model-value="onProviderChange"
+                />
               </div>
               <div v-if="providerError" class="sidebar-settings-row sidebar-settings-error">
                 <span>{{ providerError }}</span>
@@ -1570,6 +1569,12 @@ const freeModeCustomKeyMasked = ref<string | null>(null)
 const freeModeCustomKeySaving = ref(false)
 const providerError = ref('')
 const selectedProvider = ref<'codex' | 'openrouter' | 'opencode-zen' | 'custom'>('codex')
+const providerDropdownOptions = computed(() => [
+  { value: 'codex', label: t('Codex') },
+  { value: 'openrouter', label: t('OpenRouter') },
+  { value: 'opencode-zen', label: t('OpenCode Zen') },
+  { value: 'custom', label: t('Custom endpoint') },
+])
 const customEndpointUrl = ref('')
 const customEndpointKey = ref('')
 const customEndpointWireApi = ref<'responses' | 'chat'>('responses')
@@ -5678,12 +5683,16 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
   @apply shrink-0 w-6 h-6 flex items-center justify-center rounded-full border border-zinc-200 text-xs text-zinc-400 transition-colors hover:text-zinc-600 hover:border-zinc-300 disabled:opacity-40;
 }
 
-.sidebar-settings-provider-select {
-  @apply min-w-0 max-w-40 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700 outline-none transition-colors cursor-pointer;
+.sidebar-settings-provider-dropdown {
+  @apply min-w-0 max-w-44;
 }
 
-.sidebar-settings-provider-select:focus {
-  @apply border-zinc-400 ring-2 ring-zinc-200;
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-trigger) {
+  @apply h-auto rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700;
+}
+
+.sidebar-settings-provider-dropdown :deep(.composer-dropdown-value) {
+  @apply max-w-36;
 }
 
 .sidebar-settings-segmented {
@@ -5704,14 +5713,6 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .sidebar-settings-provider-link {
   @apply text-xs text-blue-600 hover:text-blue-700 underline shrink-0;
-}
-
-:root.dark .sidebar-settings-provider-select {
-  @apply border-zinc-600 bg-zinc-800 text-zinc-200;
-}
-
-:root.dark .sidebar-settings-provider-select:focus {
-  @apply border-zinc-500 ring-zinc-700;
 }
 
 :root.dark .sidebar-settings-segmented {

--- a/src/components/content/ReviewPane.vue
+++ b/src/components/content/ReviewPane.vue
@@ -47,20 +47,14 @@
 
         <div v-if="!isCommitReview && activeScope === 'baseBranch' && snapshot?.baseBranchOptions.length" class="review-pane-control-cluster">
           <span class="review-pane-control-label">{{ t('Branch') }}</span>
-          <label class="review-pane-branch-select-wrap">
-            <select
-              v-model="selectedBaseBranch"
-              class="review-pane-branch-select"
-            >
-              <option
-                v-for="branch in snapshot.baseBranchOptions"
-                :key="branch"
-                :value="branch"
-              >
-                {{ branch }}
-              </option>
-            </select>
-          </label>
+          <ComposerDropdown
+            v-model="selectedBaseBranch"
+            class="review-pane-branch-dropdown"
+            :options="baseBranchDropdownOptions"
+            :placeholder="t('Branch')"
+            enable-search
+            :search-placeholder="t('Search branches...')"
+          />
         </div>
 
         <div v-if="!isCommitReview && activeScope === 'workspace'" class="review-pane-control-cluster">
@@ -356,6 +350,7 @@ import type {
   UiReviewHunk,
 } from '../../types/codex'
 import IconTablerX from '../icons/IconTablerX.vue'
+import ComposerDropdown from './ComposerDropdown.vue'
 
 const props = defineProps<{
   threadId: string
@@ -426,6 +421,9 @@ type MutableReviewTreeFolder = {
 const selectedFile = computed(() => snapshot.value?.files.find((file) => file.id === selectedFileId.value) ?? snapshot.value?.files[0] ?? null)
 const folderExpansionState = ref<Record<string, boolean>>({})
 const isCommitReview = computed(() => Boolean(props.commitSha?.trim()))
+const baseBranchDropdownOptions = computed(() => {
+  return (snapshot.value?.baseBranchOptions ?? []).map((branch) => ({ value: branch, label: branch }))
+})
 const emptyReviewMessage = computed(() => {
   if (snapshot.value?.scope === 'commit' || isCommitReview.value) {
     return t('No file changes in this commit.')
@@ -987,12 +985,16 @@ onBeforeUnmount(() => {
   @apply shrink-0 text-[10px] font-medium uppercase tracking-[0.08em] text-zinc-400;
 }
 
-.review-pane-branch-select-wrap {
-  @apply inline-flex min-w-[9rem] items-center rounded-full border border-zinc-200 bg-white px-2.5 py-1 shadow-sm;
+.review-pane-branch-dropdown {
+  @apply min-w-[9rem];
 }
 
-.review-pane-branch-select {
-  @apply w-full appearance-none bg-transparent text-[11px] font-medium text-zinc-700 outline-none;
+.review-pane-branch-dropdown :deep(.composer-dropdown-trigger) {
+  @apply min-h-7 rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-medium text-zinc-700 shadow-sm;
+}
+
+.review-pane-branch-dropdown :deep(.composer-dropdown-value) {
+  @apply max-w-36;
 }
 
 .review-pane-segmented {
@@ -1389,12 +1391,12 @@ onBeforeUnmount(() => {
     @apply text-[9px];
   }
 
-  .review-pane-branch-select-wrap {
-    @apply min-w-0 flex-1 px-2 py-0.75;
+  .review-pane-branch-dropdown {
+    @apply min-w-0 flex-1;
   }
 
-  .review-pane-branch-select {
-    @apply text-[12px];
+  .review-pane-branch-dropdown :deep(.composer-dropdown-trigger) {
+    @apply px-2 py-0.75 text-[12px];
   }
 
   .review-pane-segmented {

--- a/src/components/content/ThreadConversation.vue
+++ b/src/components/content/ThreadConversation.vue
@@ -4008,13 +4008,11 @@ function readQuestionOtherAnswer(requestId: number, questionId: string): string 
   return toolQuestionOtherAnswers.value[key] ?? ''
 }
 
-function onQuestionAnswerChange(requestId: number, questionId: string, event: Event): void {
-  const target = event.target
-  if (!(target instanceof HTMLSelectElement)) return
+function onQuestionAnswerChange(requestId: number, questionId: string, value: string): void {
   const key = toolQuestionKey(requestId, questionId)
   toolQuestionAnswers.value = {
     ...toolQuestionAnswers.value,
-    [key]: target.value,
+    [key]: value,
   }
 }
 
@@ -4030,7 +4028,7 @@ function onQuestionOtherAnswerInput(requestId: number, questionId: string, event
 
 function onMcpElicitationFieldInput(requestId: number, field: McpElicitationField, event: Event): void {
   const target = event.target
-  if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLSelectElement)) return
+  if (!(target instanceof HTMLInputElement)) return
   mcpElicitationAnswers.value = {
     ...mcpElicitationAnswers.value,
     [mcpElicitationAnswerKey(requestId, field.key)]: target.value,

--- a/src/components/content/ThreadPendingRequestPanel.vue
+++ b/src/components/content/ThreadPendingRequestPanel.vue
@@ -105,36 +105,29 @@
               />
             </label>
 
-            <label v-else-if="field.kind === 'boolean'" class="thread-pending-request-select-wrap">
+            <div v-else-if="field.kind === 'boolean'" class="thread-pending-request-select-wrap">
               <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-              <select
-                class="thread-pending-request-select"
-                :value="serializeMcpBooleanValue(readMcpElicitationFieldValue(request.id, field))"
-                @change="onMcpElicitationBooleanChange(request.id, field, $event)"
-              >
-                <option v-if="!field.hasExplicitDefault" value="">{{ t('Select true or false') }}</option>
-                <option value="true">{{ t('True') }}</option>
-                <option value="false">{{ t('False') }}</option>
-              </select>
-            </label>
+              <ComposerDropdown
+                class="thread-pending-request-dropdown"
+                :model-value="serializeMcpBooleanValue(readMcpElicitationFieldValue(request.id, field))"
+                :options="mcpBooleanOptions(field)"
+                :placeholder="t('Select true or false')"
+                @update:model-value="onMcpElicitationBooleanChange(request.id, field, $event)"
+              />
+            </div>
 
-            <label v-else-if="field.kind === 'singleEnum'" class="thread-pending-request-select-wrap">
+            <div v-else-if="field.kind === 'singleEnum'" class="thread-pending-request-select-wrap">
               <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-              <select
-                class="thread-pending-request-select"
-                :value="String(readMcpElicitationFieldValue(request.id, field) ?? '')"
-                @change="onMcpElicitationFieldInput(request.id, field, $event)"
-              >
-                <option v-if="!field.hasExplicitDefault" value="">{{ t('Select an option') }}</option>
-                <option
-                  v-for="option in field.options"
-                  :key="`${request.id}:${field.key}:${option.value}`"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </option>
-              </select>
-            </label>
+              <ComposerDropdown
+                class="thread-pending-request-dropdown"
+                :model-value="String(readMcpElicitationFieldValue(request.id, field) ?? '')"
+                :options="mcpSingleEnumOptions(field)"
+                :placeholder="t('Select an option')"
+                enable-search
+                :search-placeholder="t('Search options...')"
+                @update:model-value="onMcpElicitationFieldValueChange(request.id, field, $event)"
+              />
+            </div>
 
             <div v-else class="thread-pending-request-question-options">
               <label
@@ -180,22 +173,16 @@
             <p v-if="question.question" class="thread-pending-request-question-text">{{ question.question }}</p>
 
             <div v-if="question.options.length > 0" class="thread-pending-request-question-options">
-              <label class="thread-pending-request-select-wrap">
+              <div class="thread-pending-request-select-wrap">
                 <span class="thread-pending-request-select-label">{{ t('Choice') }}</span>
-                <select
-                  class="thread-pending-request-select"
-                  :value="readQuestionAnswer(request.id, question.id, question.options[0]?.label || '')"
-                  @change="onQuestionAnswerChange(request.id, question.id, $event)"
-                >
-                  <option
-                    v-for="option in question.options"
-                    :key="`${request.id}:${question.id}:${option.label}`"
-                    :value="option.label"
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </label>
+                <ComposerDropdown
+                  class="thread-pending-request-dropdown"
+                  :model-value="readQuestionAnswer(request.id, question.id, question.options[0]?.label || '')"
+                  :options="toolQuestionOptions(question)"
+                  :placeholder="t('Choice')"
+                  @update:model-value="onQuestionAnswerChange(request.id, question.id, $event)"
+                />
+              </div>
 
               <p
                 v-if="selectedOptionDescription(request.id, question.id, question.options)"
@@ -250,6 +237,7 @@
 import { computed, ref, watch } from 'vue'
 import type { UiServerRequest, UiServerRequestReply } from '../../types/codex'
 import { useUiLanguage } from '../../composables/useUiLanguage'
+import ComposerDropdown from './ComposerDropdown.vue'
 
 type ApprovalDecision = 'accept' | 'acceptForSession' | 'decline' | 'cancel'
 
@@ -532,14 +520,16 @@ function readQuestionOtherAnswer(requestId: number, questionId: string): string 
   return toolQuestionOtherAnswers.value[toolQuestionKey(requestId, questionId)] ?? ''
 }
 
-function onQuestionAnswerChange(requestId: number, questionId: string, event: Event): void {
-  const target = event.target
-  if (!(target instanceof HTMLSelectElement)) return
+function onQuestionAnswerChange(requestId: number, questionId: string, value: string): void {
   const key = toolQuestionKey(requestId, questionId)
   toolQuestionAnswers.value = {
     ...toolQuestionAnswers.value,
-    [key]: target.value,
+    [key]: value,
   }
+}
+
+function toolQuestionOptions(question: ParsedToolQuestion): Array<{ value: string; label: string }> {
+  return question.options.map((option) => ({ value: option.label, label: option.label }))
 }
 
 function onQuestionOtherAnswerInput(requestId: number, questionId: string, event: Event): void {
@@ -727,9 +717,12 @@ function readMcpElicitationMultiValue(requestId: number, field: McpElicitationFi
 
 function onMcpElicitationFieldInput(requestId: number, field: McpElicitationField, event: Event): void {
   const target = event.target
-  if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLSelectElement)) return
+  if (!(target instanceof HTMLInputElement)) return
 
-  const rawValue = target.value
+  onMcpElicitationFieldValueChange(requestId, field, target.value)
+}
+
+function onMcpElicitationFieldValueChange(requestId: number, field: McpElicitationField, rawValue: string): void {
   const nextValue =
     field.kind === 'number'
       ? rawValue
@@ -742,13 +735,10 @@ function onMcpElicitationFieldInput(requestId: number, field: McpElicitationFiel
   mcpElicitationValidationError.value = ''
 }
 
-function onMcpElicitationBooleanChange(requestId: number, field: McpElicitationField, event: Event): void {
-  const target = event.target
-  if (!(target instanceof HTMLSelectElement)) return
-
+function onMcpElicitationBooleanChange(requestId: number, field: McpElicitationField, value: string): void {
   let nextValue: boolean | null = null
-  if (target.value === 'true') nextValue = true
-  else if (target.value === 'false') nextValue = false
+  if (value === 'true') nextValue = true
+  else if (value === 'false') nextValue = false
 
   mcpElicitationAnswers.value = {
     ...mcpElicitationAnswers.value,
@@ -779,6 +769,25 @@ function serializeMcpBooleanValue(value: string | number | boolean | string[] | 
   if (value === true) return 'true'
   if (value === false) return 'false'
   return ''
+}
+
+function mcpBooleanOptions(field: McpElicitationField): Array<{ value: string; label: string }> {
+  const options = [
+    { value: 'true', label: t('True') },
+    { value: 'false', label: t('False') },
+  ]
+  if (!field.hasExplicitDefault) {
+    options.unshift({ value: '', label: t('Select true or false') })
+  }
+  return options
+}
+
+function mcpSingleEnumOptions(field: McpElicitationField): Array<{ value: string; label: string }> {
+  const options = field.options.map((option) => ({ value: option.value, label: option.label }))
+  if (!field.hasExplicitDefault) {
+    options.unshift({ value: '', label: t('Select an option') })
+  }
+  return options
 }
 
 function isMcpElicitationFieldAnswered(requestId: number, field: McpElicitationField): boolean {
@@ -1088,15 +1097,21 @@ function onRejectUnknownRequest(request: UiServerRequest): void {
   @apply text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500;
 }
 
-.thread-pending-request-select,
 .thread-pending-request-input {
   @apply h-11 rounded-xl border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100 outline-none;
 }
 
-.thread-pending-request-select:focus,
 .thread-pending-request-input:focus {
   @apply border-zinc-500;
   box-shadow: 0 0 0 1px rgba(244, 244, 245, 0.18);
+}
+
+.thread-pending-request-dropdown :deep(.composer-dropdown-trigger) {
+  @apply h-11 w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 text-sm text-zinc-100;
+}
+
+.thread-pending-request-dropdown :deep(.composer-dropdown-value) {
+  @apply min-w-0 flex-1 text-left;
 }
 
 .thread-pending-request-input::placeholder {

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -714,21 +714,14 @@
             </div>
 
             <div class="automation-target-dropdown">
-              <input
-                v-model="automationTargetSearch"
-                class="rename-thread-input"
-                type="search"
-                :placeholder="automationTargetMode === 'project' ? 'Search projects' : 'Search chats'"
+              <ComposerDropdown
+                v-model="automationTargetValue"
+                class="automation-thread-dropdown"
+                :options="automationTargetDropdownOptions"
+                :placeholder="automationTargetMode === 'project' ? 'Select project' : 'Select chat'"
+                enable-search
+                :search-placeholder="automationTargetMode === 'project' ? 'Search projects' : 'Search chats'"
               />
-              <select v-model="automationTargetValue" class="automation-thread-select" size="5">
-                <option
-                  v-for="option in filteredAutomationTargetOptions"
-                  :key="option.value"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </option>
-              </select>
             </div>
           </div>
 
@@ -808,15 +801,13 @@
                 step="1"
                 @input="syncAutomationRruleFromScheduleDraft"
               />
-              <select
-                v-model="automationScheduleDraft.intervalUnit"
-                class="automation-schedule-unit"
-                @change="syncAutomationRruleFromScheduleDraft"
-              >
-                <option value="minutes">minutes</option>
-                <option value="hours">hours</option>
-                <option value="days">days</option>
-              </select>
+              <ComposerDropdown
+                class="automation-schedule-unit-dropdown"
+                :model-value="automationScheduleDraft.intervalUnit"
+                :options="automationIntervalUnitOptions"
+                placeholder="Unit"
+                @update:model-value="onAutomationIntervalUnitChange"
+              />
             </div>
 
             <input
@@ -830,13 +821,16 @@
             <p class="automation-schedule-preview">{{ automationSchedulePreview }}</p>
           </div>
 
-          <label class="automation-thread-field">
+          <div class="automation-thread-field">
             <span class="automation-thread-label">Status</span>
-            <select v-model="automationDraft.status" class="automation-thread-select">
-              <option value="ACTIVE">{{ t('Active') }}</option>
-              <option value="PAUSED">{{ t('Paused') }}</option>
-            </select>
-          </label>
+            <ComposerDropdown
+              class="automation-thread-dropdown"
+              :model-value="automationDraft.status"
+              :options="automationStatusOptions"
+              :placeholder="t('Status')"
+              @update:model-value="onAutomationStatusChange"
+            />
+          </div>
 
           <p v-if="automationDialogError" class="rename-thread-subtitle automation-thread-error">{{ automationDialogError }}</p>
           <p v-else-if="automationDialogNotice" class="rename-thread-subtitle automation-thread-notice">{{ automationDialogNotice }}</p>
@@ -901,6 +895,7 @@ import IconTablerTrash from '../icons/IconTablerTrash.vue'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import { useFeedbackDiagnostics } from '../../composables/useFeedbackDiagnostics'
 import { getPathLeafName, getPathParent, isAbsoluteLikePath, isProjectlessChatPath } from '../../pathUtils.js'
+import ComposerDropdown from '../content/ComposerDropdown.vue'
 import SidebarMenuRow from './SidebarMenuRow.vue'
 import { reconcilePinnedThreadIds } from './pinnedThreadUtils'
 
@@ -1021,7 +1016,6 @@ const automationDialogAutomationId = ref('')
 const automationDialogMode = ref<'create' | 'edit'>('create')
 const automationTargetPickerVisible = ref(false)
 const automationTargetMode = ref<AutomationTargetMode>('thread')
-const automationTargetSearch = ref('')
 const automationTargetValue = ref('')
 const automationDialogError = ref('')
 const automationDialogNotice = ref('')
@@ -1092,14 +1086,22 @@ const automationProjectTargetOptions = computed(() => {
   }
   return rows
 })
-const filteredAutomationTargetOptions = computed(() => {
-  const query = automationTargetSearch.value.trim().toLowerCase()
+const automationTargetDropdownOptions = computed(() => {
   const source = automationTargetMode.value === 'project'
     ? automationProjectTargetOptions.value
     : automationThreadTargetOptions.value
-  return query ? source.filter((option) => option.searchText.includes(query)) : source
+  return source.map((option) => ({ value: option.value, label: option.label }))
 })
-watch(filteredAutomationTargetOptions, (options) => {
+const automationIntervalUnitOptions = [
+  { value: 'minutes', label: 'minutes' },
+  { value: 'hours', label: 'hours' },
+  { value: 'days', label: 'days' },
+]
+const automationStatusOptions = computed(() => [
+  { value: 'ACTIVE', label: t('Active') },
+  { value: 'PAUSED', label: t('Paused') },
+])
+watch(automationTargetDropdownOptions, (options) => {
   if (!automationTargetPickerVisible.value) return
   if (options.some((option) => option.value === automationTargetValue.value)) return
   automationTargetValue.value = options[0]?.value ?? ''
@@ -1672,6 +1674,23 @@ function syncAutomationRruleFromScheduleDraft(): void {
   }
 }
 
+function onAutomationIntervalUnitChange(value: string): void {
+  if (value !== 'minutes' && value !== 'hours' && value !== 'days') return
+  automationScheduleDraft.value = {
+    ...automationScheduleDraft.value,
+    intervalUnit: value,
+  }
+  syncAutomationRruleFromScheduleDraft()
+}
+
+function onAutomationStatusChange(value: string): void {
+  if (value !== 'ACTIVE' && value !== 'PAUSED') return
+  automationDraft.value = {
+    ...automationDraft.value,
+    status: value,
+  }
+}
+
 function syncAutomationScheduleDraftFromRrule(): void {
   automationScheduleDraft.value = createScheduleDraftFromRrule(automationDraft.value.rrule)
 }
@@ -1906,7 +1925,6 @@ function openAutomationEditorFromPanel(payload: {
 function openAutomationCreatorFromPanel(): void {
   automationTargetPickerVisible.value = true
   automationTargetMode.value = 'thread'
-  automationTargetSearch.value = ''
   automationTargetValue.value = automationThreadTargetOptions.value[0]?.value ?? ''
   automationDialogScope.value = 'thread'
   automationDialogThreadId.value = ''
@@ -1921,14 +1939,9 @@ function openAutomationCreatorFromPanel(): void {
 
 function setAutomationTargetMode(mode: AutomationTargetMode): void {
   automationTargetMode.value = mode
-  automationTargetSearch.value = ''
   automationTargetValue.value = ''
   automationDialogScope.value = mode === 'project' ? 'project' : 'thread'
-  if (mode === 'thread') {
-    automationTargetValue.value = filteredAutomationTargetOptions.value[0]?.value ?? ''
-  } else if (mode === 'project') {
-    automationTargetValue.value = filteredAutomationTargetOptions.value[0]?.value ?? ''
-  }
+  automationTargetValue.value = automationTargetDropdownOptions.value[0]?.value ?? ''
 }
 
 function startNewAutomationDraft(): void {
@@ -3447,9 +3460,16 @@ onBeforeUnmount(() => {
   @apply text-xs font-medium uppercase tracking-wide text-zinc-500;
 }
 
-.automation-thread-textarea,
-.automation-thread-select {
+.automation-thread-textarea {
   @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-thread-dropdown :deep(.composer-dropdown-trigger) {
+  @apply w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900;
+}
+
+.automation-thread-dropdown :deep(.composer-dropdown-value) {
+  @apply min-w-0 flex-1 text-left;
 }
 
 .automation-schedule-mode-group {
@@ -3476,6 +3496,10 @@ onBeforeUnmount(() => {
 .automation-schedule-number,
 .automation-schedule-unit {
   @apply rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-900 outline-none focus:border-zinc-500;
+}
+
+.automation-schedule-unit-dropdown :deep(.composer-dropdown-trigger) {
+  @apply min-h-8 rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm text-zinc-900;
 }
 
 .automation-schedule-number {

--- a/tests/providers-models/provider-dropdown-in-settings-replaces-free-mode-toggle.md
+++ b/tests/providers-models/provider-dropdown-in-settings-replaces-free-mode-toggle.md
@@ -8,18 +8,21 @@
 2. Verify the settings panel is scrollable when content overflows.
 3. Verify the Accounts section does NOT have its own scrollbar — it flows naturally within the settings panel scroll.
 4. Locate the **Provider** dropdown (default: "Codex").
-5. Change provider to **OpenRouter**.
-6. Verify a "Get API key" link appears next to the OpenRouter API key label, pointing to `https://openrouter.ai/keys`.
-7. Verify the API key input field is shown with placeholder `sk-or-v1-... (optional, uses free keys if empty)`.
-8. Optionally enter an OpenRouter API key and click Set.
-9. Change provider to **Custom endpoint**.
-10. Verify URL and API key input fields appear.
-11. Enter a valid endpoint URL and click Save.
-12. Change provider back to **Codex**.
-13. Verify the config is reset and no provider-specific fields are shown.
+5. Open the Provider dropdown and verify it renders as the app custom menu, not a native browser `<select>` control.
+6. Change provider to **OpenRouter**.
+7. Verify a "Get API key" link appears next to the OpenRouter API key label, pointing to `https://openrouter.ai/keys`.
+8. Verify the API key input field is shown with placeholder `sk-or-v1-... (optional, uses free keys if empty)`.
+9. Optionally enter an OpenRouter API key and click Set.
+10. Change provider to **Custom endpoint**.
+11. Verify URL and API key input fields appear.
+12. Enter a valid endpoint URL and click Save.
+13. Change provider back to **Codex**.
+14. Verify the config is reset and no provider-specific fields are shown.
+15. Repeat the Provider dropdown open/selection check in dark theme and confirm the trigger, menu, options, and selected state are readable.
 
 #### Expected Results
-- Provider dropdown shows three options: Codex, OpenRouter, Custom endpoint.
+- Provider dropdown shows Codex, OpenRouter, OpenCode Zen, and Custom endpoint.
+- Provider dropdown uses the shared custom dropdown/menu component with consistent styling and dark-theme behavior.
 - Selecting OpenRouter enables free mode with community keys (or custom key if provided).
 - Selecting Custom endpoint allows setting a custom API base URL and bearer token.
 - Selecting Codex disables external provider mode and uses the default Codex backend.
@@ -28,3 +31,4 @@
 
 #### Rollback/Cleanup
 - Switch provider back to Codex to restore default behavior.
+- Restore the preferred appearance setting if dark theme was only enabled for this check.


### PR DESCRIPTION
## Summary
- Replace remaining native Vue `<select>` controls with the shared `ComposerDropdown` menu pattern.
- Cover settings provider/UI language, review base branch, pending request choices, and automation target/status/schedule controls.
- Add a durable AGENTS rule and update the provider dropdown manual test with custom-menu and dark-theme checks.

## Verification
- `rg -n "<select|</select>|HTMLSelectElement" src -g "*.vue"` returns no matches.
- `pnpm run build:frontend`
- Local UI check at `http://127.0.0.1:4173/`: provider menu renders as custom dropdown and live DOM had `select count 0` in light and dark themes.
- `PROFILE_BASE_URL=http://127.0.0.1:4173 PROFILE_WAIT_MS=7000 pnpm run profile:browser` passed with no warnings; duplicate counts stayed bounded (`threadList: 1`, `skillsList: 1`, `providerModels: 1`), `totalApiKB: 494.9`.

## Notes
- Codex.app CDP launched on `127.0.0.1:9229`, but `/json/list` exposed no page targets, so no reference screenshot was available from that run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified dropdown controls across the app by replacing native browser select elements with custom dropdown components in settings (language, provider selection), review pane (base branch), conversation UI (tool questions and MCP fields), and automation dialogs for improved consistency and theming.

* **Tests**
  * Updated dropdown control test procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->