### PR TITLE
Persist fallback titles for attachment-only threads

### DIFF
--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -4107,10 +4107,35 @@ export function useDesktopState() {
     }
   }
 
-  async function requestThreadTitleGeneration(threadId: string, prompt: string, cwd: string | null): Promise<void> {
+  function resolveFallbackThreadTitle(prompt: string, imageUrls: string[], fileAttachments: FileAttachment[]): string {
+    const trimmed = prompt.trim()
+    if (trimmed) return toOptimisticThreadTitle(trimmed)
+
+    const firstAttachmentLabel = fileAttachments
+      .map((attachment) => attachment.label.trim())
+      .find((label) => label.length > 0)
+    if (firstAttachmentLabel) return toOptimisticThreadTitle(firstAttachmentLabel)
+
+    if (imageUrls.length > 0) return toOptimisticThreadTitle('[Image]')
+    return 'Untitled thread'
+  }
+
+  async function requestThreadTitleGeneration(
+    threadId: string,
+    prompt: string,
+    cwd: string | null,
+    imageUrls: string[] = [],
+    fileAttachments: FileAttachment[] = [],
+  ): Promise<void> {
     if (threadTitleById.value[threadId]) return
     const trimmed = prompt.trim()
-    if (!trimmed) return
+    if (!trimmed) {
+      const fallbackTitle = resolveFallbackThreadTitle(prompt, imageUrls, fileAttachments)
+      threadTitleById.value = { ...threadTitleById.value, [threadId]: fallbackTitle }
+      applyThreadFlags()
+      void persistThreadTitle(threadId, fallbackTitle)
+      return
+    }
     const truncated = trimmed.length > 300 ? trimmed.slice(0, 300) : trimmed
     try {
       const title = await generateThreadTitle(truncated, cwd)
@@ -5021,7 +5046,7 @@ export function useDesktopState() {
         .finally(() => {
           isSendingMessage.value = false
         })
-      void requestThreadTitleGeneration(capturedThreadId, capturedPrompt, capturedCwd)
+      void requestThreadTitleGeneration(capturedThreadId, capturedPrompt, capturedCwd, imageUrls, fileAttachments)
       return threadId
     } catch (unknownError) {
       shouldAutoScrollOnNextAgentEvent = false


### PR DESCRIPTION
## Summary
- persist a fallback title when a new thread starts with attachments/images but no text prompt
- use the first file attachment label when available, otherwise fall back to `[Image]` or `Untitled thread`
- pass attachment context into thread title generation so file-only pastes do not disappear from the sidebar after reload

## Validation
- `corepack pnpm install --ignore-scripts`
- `corepack pnpm run build:frontend`

## Root cause
`requestThreadTitleGeneration()` returned early on `prompt.trim() === ""`, while file-only pastes create a thread with attachments and an empty text prompt. That meant no persisted title was written, and after reload the sidebar could lose the thread because the cache/index had no title to render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced thread title generation to handle empty prompts gracefully, with fallback titles derived from attachment names or image placeholders
* Thread titles now display and persist immediately
* Improved handling of attachments in title generation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/friuns2/codex-mobile/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->