### PR TITLE
Fix Codex CLI resolution on Windows

### DIFF
--- a/src/commandResolution.ts
+++ b/src/commandResolution.ts
@@ -1,7 +1,7 @@
-import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, join } from 'node:path'
+import { spawnSyncCommand } from './utils/commandInvocation.js'
 
 export type CommandInvocation = {
   command: string
@@ -61,7 +61,7 @@ function getPotentialCodexExecutables(prefix: string): string[] {
           'codex-win32-x64',
           'vendor',
           'x86_64-pc-windows-msvc',
-          'codex',
+          'bin',
           'codex.exe',
         )
       : join(packageDir, 'bin', 'codex')
@@ -86,7 +86,7 @@ function getPotentialRipgrepExecutables(prefix: string): string[] {
 }
 
 export function canRunCommand(command: string, args: string[] = []): boolean {
-  const result = spawnSync(command, args, {
+  const result = spawnSyncCommand(command, args, {
     stdio: 'ignore',
     windowsHide: true,
   })

--- a/src/server/accountRoutes.ts
+++ b/src/server/accountRoutes.ts
@@ -4,6 +4,8 @@ import { mkdtemp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from '
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { resolveCodexCommand } from '../commandResolution.js'
+import { getSpawnInvocation } from '../utils/commandInvocation.js'
 import { buildAppServerArgs } from './appServerRuntimeConfig.js'
 import { callRpcWithRateLimitDecodeRecovery } from './rateLimitDecodeRecovery.js'
 
@@ -650,7 +652,13 @@ async function withTemporaryCodexAppServer<T>(
   const authPath = join(tempCodexHome, 'auth.json')
   await writeFile(authPath, authRaw, { encoding: 'utf8', mode: 0o600 })
 
-  const proc = spawn('codex', buildAppServerArgs(), {
+  const codexCommand = resolveCodexCommand()
+  if (!codexCommand) {
+    throw new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
+  }
+
+  const invocation = getSpawnInvocation(codexCommand, buildAppServerArgs())
+  const proc = spawn(invocation.command, invocation.args, {
     env: { ...process.env, CODEX_HOME: tempCodexHome },
     stdio: ['pipe', 'pipe', 'pipe'],
   })
@@ -1027,7 +1035,13 @@ async function startCodexLogin(): Promise<string> {
     return await waitForLoginUrl()
   }
 
-  const proc = spawn('codex', ['login'], {
+  const codexCommand = resolveCodexCommand()
+  if (!codexCommand) {
+    throw new Error('Codex CLI is not available. Install @openai/codex or set CODEXUI_CODEX_COMMAND.')
+  }
+
+  const invocation = getSpawnInvocation(codexCommand, ['login'])
+  const proc = spawn(invocation.command, invocation.args, {
     env: process.env,
     stdio: ['pipe', 'pipe', 'pipe'],
   })


### PR DESCRIPTION
This fixes a Windows-specific regression where `codexui`/`codexapp` reports that the Codex CLI is not in PATH even when `codex` is installed and works from PowerShell.

What changed:
- fix the bundled Windows Codex executable path to `vendor/x86_64-pc-windows-msvc/bin/codex.exe`
- reuse `spawnSyncCommand()` in `canRunCommand()` so Windows command probing goes through the existing `cmd.exe` wrapper logic
- stop hardcoding `spawn('codex', ...)` in account login / temporary app-server flows and instead use `resolveCodexCommand()` + `getSpawnInvocation()`

Why this was failing on Windows:
- Node `spawnSync('codex', ...)` does not resolve the npm shim the same way PowerShell does
- the fallback native executable path pointed at `.../codex/codex.exe`, but the package currently ships `.../bin/codex.exe`
- even if detection succeeded, the login and temporary app-server paths still bypassed the Windows wrapper and could fail separately

Validation:
- rebuilt the CLI bundle with `tsup`
- confirmed the generated bundle now points at `.../bin/codex.exe`
- confirmed the generated bundle uses `getSpawnInvocation(codexCommand, ...)` for the login and temporary app-server paths

This keeps the change small and only touches the Windows command resolution/call sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Codex CLI detection and resolution across various system configurations, particularly improving Windows compatibility with better executable path discovery
  * More informative error messages when the Codex CLI is unavailable, including helpful guidance on installation procedures and environment variable configuration
  * Improved command availability validation for better system reliability and user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->