### PR TITLE
feat: containerize codexapp with Docker + CODEXAPP_PORT env support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.git
+dist
+dist-cli
+.env
+.env.*
+output
+tests
+test
+docs
+documentation
+.github
+llm-wiki
+.cert
+.cursor
+.agents

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:22-alpine AS build
+
+RUN apk add --no-cache g++ make python3 \
+  && corepack enable \
+  && corepack prepare pnpm@10.15.1 --activate
+
+WORKDIR /app
+
+COPY package.json .npmrc ./
+COPY scripts/fix-pty-native-build.cjs scripts/fix-pty-native-build.cjs
+RUN pnpm install
+
+COPY . .
+RUN pnpm run build \
+  && pnpm prune --prod
+
+FROM node:22-alpine AS runtime
+
+RUN apk add --no-cache git openssh-client \
+  && npm install --global @openai/codex \
+  && npm cache clean --force
+
+ENV NODE_ENV=production \
+  CODEX_HOME=/home/node/.codex \
+  CODEXAPP_PORT=18923
+
+WORKDIR /app
+
+RUN mkdir -p /home/node/.codex /workspace \
+  && chown -R node:node /home/node/.codex /workspace
+
+COPY --from=build --chown=node:node /app/dist ./dist
+COPY --from=build --chown=node:node /app/dist-cli ./dist-cli
+COPY --from=build --chown=node:node /app/package.json ./package.json
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+
+USER node
+
+EXPOSE 18923
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget --quiet --output-document=- http://localhost:18923/ >/dev/null || exit 1
+
+CMD ["node", "dist-cli/index.js"]

--- a/README.md
+++ b/README.md
@@ -260,6 +260,43 @@ Outgoing assistant messages are sent with Telegram `parse_mode=HTML` for formatt
 
 ---
 
+## 🐳 Docker
+
+Build and start `codexapp`, then open [http://localhost:18923](http://localhost:18923):
+
+```bash
+docker compose up --build -d
+docker compose logs -f codexapp
+```
+
+Stop the service with `docker compose down`. The image runs `node dist-cli/index.js` as the non-root `node` user and includes the Codex CLI.
+
+### Environment
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | Optional API key passed to Codex |
+| `TELEGRAM_BOT_TOKEN` | Optional Telegram bot token |
+| `TELEGRAM_ALLOWED_USER_IDS` | Comma-separated Telegram user ID allowlist |
+| `CODEXAPP_PORT` | CLI default listening port; the Compose service sets it to `18923` |
+| `CODEX_HOME` | Codex state directory; the Compose service sets it to `/home/node/.codex` |
+| `CODEXAPP_WORKSPACE` | Host directory mounted at `/workspace`; defaults to the current directory |
+
+The Compose service mounts host `~/.codex` at `/home/node/.codex` so authentication, threads, and Codex state survive container replacement. It mounts `${CODEXAPP_WORKSPACE:-.}` at `/workspace` so projects remain on the host. If you change the container listening port, update the Compose port mapping and Docker healthcheck to match.
+
+### Telegram Example
+
+```bash
+export TELEGRAM_BOT_TOKEN="<your-telegram-bot-token>"
+export TELEGRAM_ALLOWED_USER_IDS="<your-telegram-user-id>"
+export CODEXAPP_WORKSPACE="/absolute/path/to/your/project"
+docker compose up --build -d
+```
+
+Telegram messages use `/workspace` as their default working directory in the Compose service.
+
+---
+
 ## 🤝 Contributing
 Issues and PRs are welcome.  
 Bring bug reports, platform notes, and setup improvements.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  codexapp:
+    build: .
+    ports:
+      - "18923:18923"
+    environment:
+      CODEX_HOME: /home/node/.codex
+      CODEXAPP_PORT: 18923
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+      TELEGRAM_ALLOWED_USER_IDS: ${TELEGRAM_ALLOWED_USER_IDS:-}
+      TELEGRAM_DEFAULT_CWD: /workspace
+    volumes:
+      - ${HOME}/.codex:/home/node/.codex
+      - ${CODEXAPP_WORKSPACE:-.}:/workspace
+    restart: unless-stopped

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ import { spawnSyncCommand } from '../utils/commandInvocation.js'
 
 const program = new Command().name('codexui').description('Web interface for Codex app-server')
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const defaultPort = process.env.CODEXAPP_PORT?.trim() || '5900'
 let hasPromptedCloudflaredInstall = false
 
 function getCodexHomePath(): string {
@@ -629,7 +630,7 @@ async function runLogin() {
 program
   .argument('[projectPath]', 'project directory to open on launch')
   .option('--open-project <path>', 'open project directory on launch (Codex desktop parity)')
-  .option('-p, --port <port>', 'port to listen on', '5900')
+  .option('-p, --port <port>', 'port to listen on', defaultPort)
   .option('--password <pass>', 'set a specific password')
   .option('--no-password', 'disable password protection')
   .option('--tunnel', 'start cloudflared tunnel (default is auto by Tailscale detection)', true)

--- a/tests/cli-network-platform/docker-containerization-and-codexapp-port-env.md
+++ b/tests/cli-network-platform/docker-containerization-and-codexapp-port-env.md
@@ -1,0 +1,26 @@
+### Feature: Docker containerization and CODEXAPP_PORT default
+
+#### Prerequisites
+- Docker is running.
+- Port `18923` is available.
+- A disposable host directory is available for `CODEX_HOME` and workspace mounts.
+
+#### Steps
+1. Run `docker build -t codexapp-local .`.
+2. Start the image with `docker run --rm -d --name codexapp-local -p 18923:18923 -v <codex-home>:/home/node/.codex -v <workspace>:/workspace codexapp-local`.
+3. Run `docker inspect --format '{{.State.Health.Status}}' codexapp-local` until it reports `healthy`.
+4. Open `http://localhost:18923/` and verify the app loads.
+5. Run `docker exec codexapp-local sh -lc 'id -u; printf "%s\n" "$CODEX_HOME" "$CODEXAPP_PORT"'`.
+6. Stop the container, then start the built CLI outside Docker with `CODEXAPP_PORT=5997 node dist-cli/index.js --no-open --no-tunnel --no-login --no-password`.
+7. Start it again with `CODEXAPP_PORT=5997 node dist-cli/index.js --port 5998 --no-open --no-tunnel --no-login --no-password`.
+
+#### Expected Results
+- The image builds, the healthcheck becomes healthy, and the app responds on port `18923`.
+- The container process runs with a non-zero user ID.
+- `CODEX_HOME` is `/home/node/.codex` and `CODEXAPP_PORT` is `18923`.
+- The CLI uses port `5997` when only `CODEXAPP_PORT` is set.
+- Explicit `--port 5998` overrides `CODEXAPP_PORT`.
+
+#### Rollback/Cleanup
+- Run `docker rm -f codexapp-local` if it is still running.
+- Remove the disposable Codex home/workspace directories and image with `docker image rm codexapp-local`.

--- a/tests/cli-network-platform/index.md
+++ b/tests/cli-network-platform/index.md
@@ -26,3 +26,4 @@ Return to the [manual test index](../../tests.md).
 | [Feature: CLI auto-stars friuns2/codexui on startup (best-effort)](cli-auto-stars-friuns2-codexui-on-startup-best-effort.md) |
 | [Startup welcome log uses repository GitHub URL](startup-welcome-log-uses-repository-github-url.md) |
 | [Home route no longer crashes on dev startup](home-route-no-longer-crashes-on-dev-startup.md) |
+| [Feature: Docker containerization and CODEXAPP_PORT default](docker-containerization-and-codexapp-port-env.md) |


### PR DESCRIPTION
- Dockerfile: multi-stage build (node:22-alpine), pnpm build, non-root user, HEALTHCHECK
- docker-compose.yml: codexapp service with volumes, env vars, restart policy
- .dockerignore: exclude build/dev artifacts from image context
- README: add 🐳 Docker section with quick start, env reference, Telegram example
- src/cli/index.ts: CODEXAPP_PORT env var as default port (overridable by --port)
- tests: manual test doc for Docker containerization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containerization support with multi-stage build and Alpine-based runtime.
  * Docker Compose configuration for streamlined deployment and service management.
  * Environment variable support for configurable application port via `CODEXAPP_PORT`.

* **Documentation**
  * Added Docker setup, usage guide, and environment variables documentation to README.

* **Tests**
  * Added Docker containerization test documentation.

* **Chores**
  * Added `.dockerignore` file for optimized Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->