### PR TITLE
Add Feishu and Lark platform support for thread bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Notes:
 - ⚡ No global install required for quick experimentation
 - 🎙️ Built-in hold-to-dictate voice input with transcription to composer draft
 - 🤖 Optional Telegram bot bridge: send messages to bot, forward into mapped thread, send assistant reply back to Telegram
+- 🐦 Optional Feishu bot bridge: same bidirectional messaging via Feishu using WebSocket long connection (no public IP needed)
 - 💾 Project portability: export a project as a ZIP from project or thread menus, including matching Codex chat JSONL history under `.codex-project/chats/`
 - 📦 Project import: restore exported project ZIPs from the browser via `Import Project`
 - 🔁 Imported chats are rewritten for the destination `CODEX_HOME`, project path, and currently selected provider/model so they can be resumed in the new environment
@@ -173,6 +174,41 @@ Bot commands:
 - `/help` show command reference
 
 Outgoing assistant messages are sent with Telegram `parse_mode=HTML` for formatting, with automatic plain-text fallback if HTML delivery fails.
+
+### Feishu Bot Bridge (Optional)
+
+Same bidirectional messaging as Telegram, using Feishu's WebSocket long connection mode (no public IP or domain required).
+
+**Setup:**
+
+1. Create a self-built app at [Feishu Open Platform](https://open.feishu.cn)
+2. Enable bot capability
+3. Under Event Subscription, select **Long Connection** mode
+4. Subscribe to `im.message.receive_v1` event
+5. Add permission `im:message:send_as_bot`
+6. Configure in the codexapp sidebar settings (App ID, App Secret, allowed user open_ids), or use environment variables:
+
+```bash
+export FEISHU_APP_ID="<your-feishu-app-id>"
+export FEISHU_APP_SECRET="<your-feishu-app-secret>"
+export FEISHU_ALLOWED_USER_IDS="<your-open-id>,<optional-second-id>"
+export FEISHU_DEFAULT_CWD="$PWD" # optional, defaults to current working directory
+npx codexapp
+```
+
+`FEISHU_ALLOWED_USER_IDS` is required for safe access. Use `*` to allow all users. To find your open_id, send a message to the bot — it will show in the rejection message.
+
+Bot commands (same as Telegram):
+
+- `/start` show quick help and thread picker
+- `/threads` list recent threads grouped by project
+- `/newthread` create and map a new Codex thread
+- `/thread <threadId>` map current chat to an existing thread
+- `/current` show currently connected thread
+- `/history` show full history for current thread
+- `/status` show bridge/mapping status
+- `/whoami` show your Feishu IDs and authorization state
+- `/help` show command reference
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@composio/client": "0.1.0-alpha.66",
+    "@larksuiteoapi/node-sdk": "^1.70.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "commander": "^13.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -480,6 +480,29 @@
                 <span class="sidebar-settings-value">{{ feishuStatusText }}</span>
               </button>
               <div v-if="isFeishuConfigOpen" class="sidebar-settings-telegram-panel">
+                <div class="sidebar-settings-row sidebar-settings-row--select" style="padding: 0">
+                  <span class="sidebar-settings-label">{{ t('Platform') }}</span>
+                  <div class="sidebar-settings-segmented" role="group" :aria-label="t('Feishu platform')">
+                    <button
+                      type="button"
+                      class="sidebar-settings-segmented-option"
+                      :class="{ 'is-active': feishuDomainDraft === 'feishu' }"
+                      :disabled="isFeishuSaving"
+                      @click="feishuDomainDraft = 'feishu'"
+                    >
+                      Feishu
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-settings-segmented-option"
+                      :class="{ 'is-active': feishuDomainDraft === 'lark' }"
+                      :disabled="isFeishuSaving"
+                      @click="feishuDomainDraft = 'lark'"
+                    >
+                      Lark
+                    </button>
+                  </div>
+                </div>
                 <label class="sidebar-settings-field">
                   <span class="sidebar-settings-field-label">{{ t('App ID') }}</span>
                   <input
@@ -1285,7 +1308,7 @@ import {
 } from './api/codexGateway'
 import type { ReasoningEffort, SpeedMode, UiAccountEntry, UiRateLimitWindow, UiServerRequest, UiServerRequestReply, UiThreadAutomation, UiThreadTokenUsage } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
-import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, TelegramStatus, FeishuStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
+import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, TelegramStatus, FeishuStatus, FeishuDomain, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, isProjectlessChatPath, normalizePathForUi } from './pathUtils.js'
 import { copyTextToClipboard } from './utils/clipboard'
@@ -1722,6 +1745,7 @@ const telegramAllowedUserIdsDraft = ref('')
 const telegramConfigError = ref('')
 const isTelegramSaving = ref(false)
 const isFeishuConfigOpen = ref(false)
+const feishuDomainDraft = ref<FeishuDomain>('feishu')
 const feishuAppIdDraft = ref('')
 const feishuAppSecretDraft = ref('')
 const feishuAllowedUserIdsDraft = ref('')
@@ -1778,6 +1802,7 @@ const telegramStatus = ref<TelegramStatus>({
 const feishuStatus = ref<FeishuStatus>({
   configured: false,
   active: false,
+  domain: 'feishu',
   mappedChats: 0,
   mappedThreads: 0,
   allowedUsers: 0,
@@ -2197,12 +2222,13 @@ const telegramStatusText = computed(() => {
 const feishuStatusText = computed(() => {
   if (!feishuStatus.value.configured) return t('Not configured')
   const base = feishuStatus.value.active ? t('Online') : t('Configured (offline)')
+  const platform = feishuStatus.value.domain === 'lark' ? 'Lark' : 'Feishu'
   const allowlist = feishuStatus.value.allowAllUsers
     ? t('allow all users')
     : `${feishuStatus.value.allowedUsers} ${t('allowed user(s)')}`
   const mapped = `${feishuStatus.value.mappedChats} ${t('chat(s)')}, ${feishuStatus.value.mappedThreads} ${t('thread(s)')}, ${allowlist}`
   const error = feishuStatus.value.lastError ? `, ${t('error')}: ${feishuStatus.value.lastError}` : ''
-  return `${base}, ${mapped}${error}`
+  return `${base}, ${platform}, ${mapped}${error}`
 })
 
 onMounted(() => {
@@ -2439,6 +2465,7 @@ async function refreshFeishuStatus(): Promise<void> {
       mappedThreads: 0,
       allowedUsers: 0,
       allowAllUsers: false,
+      domain: 'feishu',
       lastError: message,
     }
   }
@@ -2447,6 +2474,7 @@ async function refreshFeishuStatus(): Promise<void> {
 async function refreshFeishuConfig(): Promise<void> {
   try {
     const config = await getFeishuConfig()
+    feishuDomainDraft.value = config.domain
     feishuAppIdDraft.value = config.appId
     feishuAppSecretDraft.value = config.appSecret
     feishuAllowedUserIdsDraft.value = config.allowedUserIds.map((value) => String(value)).join('\n')
@@ -2486,7 +2514,7 @@ async function saveFeishuConfig(): Promise<void> {
   isFeishuSaving.value = true
   feishuConfigError.value = ''
   try {
-    await configureFeishuBot(appId, appSecret, allowedUserIds)
+    await configureFeishuBot(appId, appSecret, feishuDomainDraft.value, allowedUserIds)
     feishuAllowedUserIdsDraft.value = allowedUserIds.map((value) => String(value)).join('\n')
     await Promise.all([
       refreshFeishuConfig(),

--- a/src/App.vue
+++ b/src/App.vue
@@ -475,6 +475,61 @@
                   </button>
                 </div>
               </div>
+              <button class="sidebar-settings-row" type="button" aria-live="polite" @click="isFeishuConfigOpen = !isFeishuConfigOpen">
+                <span class="sidebar-settings-label">{{ t('Feishu') }}</span>
+                <span class="sidebar-settings-value">{{ feishuStatusText }}</span>
+              </button>
+              <div v-if="isFeishuConfigOpen" class="sidebar-settings-telegram-panel">
+                <label class="sidebar-settings-field">
+                  <span class="sidebar-settings-field-label">{{ t('App ID') }}</span>
+                  <input
+                    v-model="feishuAppIdDraft"
+                    class="sidebar-settings-input"
+                    type="text"
+                    placeholder="cli_xxxxxxxxxx"
+                    autocomplete="off"
+                    spellcheck="false"
+                  >
+                </label>
+                <label class="sidebar-settings-field">
+                  <span class="sidebar-settings-field-label">{{ t('App Secret') }}</span>
+                  <input
+                    v-model="feishuAppSecretDraft"
+                    class="sidebar-settings-input"
+                    type="password"
+                    placeholder="xxxxxxxxxxxxxxxxxxxxxxxx"
+                    autocomplete="off"
+                    spellcheck="false"
+                  >
+                </label>
+                <label class="sidebar-settings-field">
+                  <span class="sidebar-settings-field-label">{{ t('Allowed Feishu user open_ids') }}</span>
+                  <textarea
+                    v-model="feishuAllowedUserIdsDraft"
+                    class="sidebar-settings-textarea"
+                    rows="3"
+                    placeholder="ou_xxxxxxxxxx&#10;ou_yyyyyyyyyy"
+                    spellcheck="false"
+                  />
+                </label>
+                <div class="sidebar-settings-field-help">
+                  {{ t('Put one Feishu open_id per line or separate them with commas. Use `*` to allow all Feishu users. You can find open_id in the bot rejection message.') }}
+                </div>
+                <div v-if="feishuConfigError" class="sidebar-settings-telegram-error">
+                  <span>{{ feishuConfigError }}</span>
+                  <a class="visible-error-feedback" :href="feedbackMailto" @click="prepareFeedbackLink($event, feishuConfigError)">{{ t('Send feedback') }}</a>
+                </div>
+                <div class="sidebar-settings-telegram-actions">
+                  <button
+                    class="sidebar-settings-telegram-save"
+                    type="button"
+                    :disabled="isFeishuSaving"
+                    @click="saveFeishuConfig"
+                  >
+                    {{ isFeishuSaving ? t('Saving…') : t('Save Feishu config') }}
+                  </button>
+                </div>
+              </div>
               <div
                 v-if="showThreadContextBadge"
                 class="sidebar-settings-row sidebar-settings-context-row"
@@ -1193,6 +1248,7 @@ import {
   checkoutGitBranch,
   cloneGithubRepository,
   configureTelegramBot,
+  configureFeishuBot,
   createPermanentWorktree,
   createWorktree,
   createProjectlessThreadDirectory,
@@ -1209,8 +1265,10 @@ import {
   getFirstLaunchPluginsCardPreference,
   getHomeDirectory,
   getTelegramConfig,
+  getFeishuConfig,
   getProjectRootSuggestion,
   getTelegramStatus,
+  getFeishuStatus,
   getThreadTerminalQuickCommands,
   getThreadTerminalStatus,
   getWorkspaceRootsState,
@@ -1227,7 +1285,7 @@ import {
 } from './api/codexGateway'
 import type { ReasoningEffort, SpeedMode, UiAccountEntry, UiRateLimitWindow, UiServerRequest, UiServerRequestReply, UiThreadAutomation, UiThreadTokenUsage } from './types/codex'
 import type { ComposerDraftPayload, ThreadComposerExposed } from './components/content/ThreadComposer.vue'
-import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, TelegramStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
+import type { GitCommitFileChange, GitCommitOption, LocalDirectoryEntry, TelegramStatus, FeishuStatus, ThreadTerminalQuickCommand, WorktreeBranchOption } from './api/codexGateway'
 import { getFreeModeStatus, setFreeMode, setFreeModeCustomKey, setCustomProvider } from './api/codexGateway'
 import { getPathLeafName, getPathParent, isProjectlessChatPath, normalizePathForUi } from './pathUtils.js'
 import { copyTextToClipboard } from './utils/clipboard'
@@ -1663,6 +1721,12 @@ const telegramBotTokenDraft = ref('')
 const telegramAllowedUserIdsDraft = ref('')
 const telegramConfigError = ref('')
 const isTelegramSaving = ref(false)
+const isFeishuConfigOpen = ref(false)
+const feishuAppIdDraft = ref('')
+const feishuAppSecretDraft = ref('')
+const feishuAllowedUserIdsDraft = ref('')
+const feishuConfigError = ref('')
+const isFeishuSaving = ref(false)
 const isCreateFolderOpen = ref(false)
 const createFolderDraft = ref('')
 const createFolderError = ref('')
@@ -1703,6 +1767,15 @@ const visibleFeedbackErrors = [
 ]
 const hasVisibleFeedbackError = computed(() => visibleFeedbackErrors.some((entry) => entry.value.trim().length > 0))
 const telegramStatus = ref<TelegramStatus>({
+  configured: false,
+  active: false,
+  mappedChats: 0,
+  mappedThreads: 0,
+  allowedUsers: 0,
+  allowAllUsers: false,
+  lastError: '',
+})
+const feishuStatus = ref<FeishuStatus>({
   configured: false,
   active: false,
   mappedChats: 0,
@@ -2121,6 +2194,16 @@ const telegramStatusText = computed(() => {
   const error = telegramStatus.value.lastError ? `, ${t('error')}: ${telegramStatus.value.lastError}` : ''
   return `${base}, ${mapped}${error}`
 })
+const feishuStatusText = computed(() => {
+  if (!feishuStatus.value.configured) return t('Not configured')
+  const base = feishuStatus.value.active ? t('Online') : t('Configured (offline)')
+  const allowlist = feishuStatus.value.allowAllUsers
+    ? t('allow all users')
+    : `${feishuStatus.value.allowedUsers} ${t('allowed user(s)')}`
+  const mapped = `${feishuStatus.value.mappedChats} ${t('chat(s)')}, ${feishuStatus.value.mappedThreads} ${t('thread(s)')}, ${allowlist}`
+  const error = feishuStatus.value.lastError ? `, ${t('error')}: ${feishuStatus.value.lastError}` : ''
+  return `${base}, ${mapped}${error}`
+})
 
 onMounted(() => {
   document.addEventListener('pointerdown', onDocumentPointerDown)
@@ -2141,6 +2224,8 @@ onMounted(() => {
   void refreshDefaultProjectName()
   void refreshTelegramConfig()
   void refreshTelegramStatus()
+  void refreshFeishuConfig()
+  void refreshFeishuStatus()
   void loadFreeModeStatus()
   void refreshThreadTerminalStatus()
   void refreshTerminalQuickCommands()
@@ -2339,6 +2424,80 @@ async function saveTelegramConfig(): Promise<void> {
     void refreshTelegramStatus()
   } finally {
     isTelegramSaving.value = false
+  }
+}
+
+async function refreshFeishuStatus(): Promise<void> {
+  try {
+    feishuStatus.value = await getFeishuStatus()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load Feishu status'
+    feishuStatus.value = {
+      configured: false,
+      active: false,
+      mappedChats: 0,
+      mappedThreads: 0,
+      allowedUsers: 0,
+      allowAllUsers: false,
+      lastError: message,
+    }
+  }
+}
+
+async function refreshFeishuConfig(): Promise<void> {
+  try {
+    const config = await getFeishuConfig()
+    feishuAppIdDraft.value = config.appId
+    feishuAppSecretDraft.value = config.appSecret
+    feishuAllowedUserIdsDraft.value = config.allowedUserIds.map((value) => String(value)).join('\n')
+    feishuConfigError.value = ''
+  } catch (error) {
+    feishuConfigError.value = error instanceof Error ? error.message : 'Failed to load Feishu configuration'
+  }
+}
+
+function parseFeishuAllowedUserIdsInput(value: string): Array<string | '*'> {
+  const rawEntries = value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const allowAllUsers = rawEntries.includes('*')
+  const normalizedUserIds = Array.from(new Set(rawEntries.filter((entry) => entry !== '*')))
+  return allowAllUsers ? ['*', ...normalizedUserIds] : normalizedUserIds
+}
+
+async function saveFeishuConfig(): Promise<void> {
+  const appId = feishuAppIdDraft.value.trim()
+  const appSecret = feishuAppSecretDraft.value.trim()
+  const allowedUserIds = parseFeishuAllowedUserIdsInput(feishuAllowedUserIdsDraft.value)
+  if (!appId) {
+    feishuConfigError.value = t('Feishu App ID is required.')
+    return
+  }
+  if (!appSecret) {
+    feishuConfigError.value = t('Feishu App Secret is required.')
+    return
+  }
+  if (allowedUserIds.length === 0) {
+    feishuConfigError.value = t('At least one allowed Feishu user open_id or * is required.')
+    return
+  }
+
+  isFeishuSaving.value = true
+  feishuConfigError.value = ''
+  try {
+    await configureFeishuBot(appId, appSecret, allowedUserIds)
+    feishuAllowedUserIdsDraft.value = allowedUserIds.map((value) => String(value)).join('\n')
+    await Promise.all([
+      refreshFeishuConfig(),
+      refreshFeishuStatus(),
+    ])
+    window.alert(t('Feishu bot configured. Only allowlisted Feishu users can use the bridge.'))
+  } catch (error) {
+    feishuConfigError.value = error instanceof Error ? error.message : t('Failed to connect Feishu bot')
+    void refreshFeishuStatus()
+  } finally {
+    isFeishuSaving.value = false
   }
 }
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -370,9 +370,12 @@ export type TelegramConfig = {
   allowedUserIds: Array<number | '*'>
 }
 
+export type FeishuDomain = 'feishu' | 'lark'
+
 export type FeishuStatus = {
   configured: boolean
   active: boolean
+  domain: FeishuDomain
   mappedChats: number
   mappedThreads: number
   allowedUsers: number
@@ -383,6 +386,7 @@ export type FeishuStatus = {
 export type FeishuConfig = {
   appId: string
   appSecret: string
+  domain: FeishuDomain
   allowedUserIds: Array<string | '*'>
 }
 
@@ -3420,6 +3424,7 @@ export async function getTelegramStatus(): Promise<TelegramStatus> {
 export async function configureFeishuBot(
   appId: string,
   appSecret: string,
+  domain: FeishuDomain,
   allowedUserIds: Array<string | '*'>,
 ): Promise<void> {
   const response = await fetch('/codex-api/feishu/configure-bot', {
@@ -3428,6 +3433,7 @@ export async function configureFeishuBot(
     body: JSON.stringify({
       appId,
       appSecret,
+      domain,
       allowedUserIds,
     }),
   })
@@ -3463,6 +3469,7 @@ export async function getFeishuConfig(): Promise<FeishuConfig> {
   return {
     appId: typeof data.appId === 'string' ? data.appId : '',
     appSecret: typeof data.appSecret === 'string' ? data.appSecret : '',
+    domain: data.domain === 'lark' ? 'lark' : 'feishu',
     allowedUserIds,
   }
 }
@@ -3485,6 +3492,7 @@ export async function getFeishuStatus(): Promise<FeishuStatus> {
   return {
     configured: data.configured === true,
     active: data.active === true,
+    domain: data.domain === 'lark' ? 'lark' : 'feishu',
     mappedChats: typeof data.mappedChats === 'number' ? data.mappedChats : 0,
     mappedThreads: typeof data.mappedThreads === 'number' ? data.mappedThreads : 0,
     allowedUsers: typeof data.allowedUsers === 'number' ? data.allowedUsers : 0,

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -370,6 +370,22 @@ export type TelegramConfig = {
   allowedUserIds: Array<number | '*'>
 }
 
+export type FeishuStatus = {
+  configured: boolean
+  active: boolean
+  mappedChats: number
+  mappedThreads: number
+  allowedUsers: number
+  allowAllUsers: boolean
+  lastError: string
+}
+
+export type FeishuConfig = {
+  appId: string
+  appSecret: string
+  allowedUserIds: Array<string | '*'>
+}
+
 export type LocalDirectoryEntry = {
   name: string
   path: string
@@ -3380,6 +3396,82 @@ export async function getTelegramStatus(): Promise<TelegramStatus> {
   const payload = await response.json()
   if (!response.ok) {
     const message = getErrorMessageFromPayload(payload, 'Failed to load Telegram status')
+    throw new Error(message)
+  }
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  return {
+    configured: data.configured === true,
+    active: data.active === true,
+    mappedChats: typeof data.mappedChats === 'number' ? data.mappedChats : 0,
+    mappedThreads: typeof data.mappedThreads === 'number' ? data.mappedThreads : 0,
+    allowedUsers: typeof data.allowedUsers === 'number' ? data.allowedUsers : 0,
+    allowAllUsers: data.allowAllUsers === true,
+    lastError: typeof data.lastError === 'string' ? data.lastError : '',
+  }
+}
+
+export async function configureFeishuBot(
+  appId: string,
+  appSecret: string,
+  allowedUserIds: Array<string | '*'>,
+): Promise<void> {
+  const response = await fetch('/codex-api/feishu/configure-bot', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      appId,
+      appSecret,
+      allowedUserIds,
+    }),
+  })
+  const payload = await response.json()
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to connect Feishu bot')
+    throw new Error(message)
+  }
+}
+
+export async function getFeishuConfig(): Promise<FeishuConfig> {
+  const response = await fetch('/codex-api/feishu/config')
+  const payload = await response.json()
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to load Feishu configuration')
+    throw new Error(message)
+  }
+  const record =
+    payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {}
+  const data =
+    record.data && typeof record.data === 'object' && !Array.isArray(record.data)
+      ? (record.data as Record<string, unknown>)
+      : {}
+  const rawAllowedUserIds = Array.isArray(data.allowedUserIds) ? data.allowedUserIds : []
+  const allowedUserIds: Array<string | '*'> = []
+  for (const value of rawAllowedUserIds) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      allowedUserIds.push(value.trim())
+    }
+  }
+  return {
+    appId: typeof data.appId === 'string' ? data.appId : '',
+    appSecret: typeof data.appSecret === 'string' ? data.appSecret : '',
+    allowedUserIds,
+  }
+}
+
+export async function getFeishuStatus(): Promise<FeishuStatus> {
+  const response = await fetch('/codex-api/feishu/status')
+  const payload = await response.json()
+  if (!response.ok) {
+    const message = getErrorMessageFromPayload(payload, 'Failed to load Feishu status')
     throw new Error(message)
   }
   const record =

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -17,6 +17,7 @@ import { callRpcWithRateLimitDecodeRecovery } from './rateLimitDecodeRecovery.js
 import { handleReviewRoutes } from './reviewGit.js'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
 import { TelegramThreadBridge } from './telegramThreadBridge.js'
+import { FeishuThreadBridge } from './feishuThreadBridge.js'
 import {
   getRandomFreeKey,
   getFreeKeyCount,
@@ -6133,6 +6134,80 @@ function rememberTelegramChatId(chatId: number): Promise<void> {
   return telegramBridgeConfigMutation
 }
 
+type FeishuBridgeConfigState = {
+  appId: string
+  appSecret: string
+  chatIds: string[]
+  allowedUserIds: Array<string | '*'>
+}
+
+function getFeishuBridgeConfigPath(): string {
+  return join(getCodexHomeDir(), 'feishu-bridge.json')
+}
+
+function normalizeFeishuBridgeConfig(value: unknown): FeishuBridgeConfigState {
+  const record = asRecord(value)
+  if (!record) return { appId: '', appSecret: '', chatIds: [], allowedUserIds: [] }
+  const appId = typeof record.appId === 'string' ? record.appId.trim() : ''
+  const appSecret = typeof record.appSecret === 'string' ? record.appSecret.trim() : ''
+  const rawChatIds = Array.isArray(record.chatIds) ? record.chatIds : []
+  const chatIds = Array.from(new Set(rawChatIds
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim()))).slice(0, 50)
+  const rawAllowedUserIds = Array.isArray(record.allowedUserIds) ? record.allowedUserIds : []
+  const normalizedAllowedUserIds = rawAllowedUserIds
+    .map((value) => {
+      if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+      return ''
+    })
+    .filter((value) => value.length > 0)
+  const allowAllUsers = normalizedAllowedUserIds.some((value) => value === '*')
+  const allowedUserIds = allowAllUsers
+    ? ['*']
+    : Array.from(new Set(normalizedAllowedUserIds)).slice(0, 100)
+  return { appId, appSecret, chatIds, allowedUserIds }
+}
+
+async function readFeishuBridgeConfig(): Promise<FeishuBridgeConfigState> {
+  const configPath = getFeishuBridgeConfigPath()
+  try {
+    const raw = await readFile(configPath, 'utf8')
+    const payload = asRecord(JSON.parse(raw)) ?? {}
+    return normalizeFeishuBridgeConfig(payload)
+  } catch {
+    return { appId: '', appSecret: '', chatIds: [], allowedUserIds: [] }
+  }
+}
+
+async function writeFeishuBridgeConfig(nextState: FeishuBridgeConfigState): Promise<void> {
+  const normalized = normalizeFeishuBridgeConfig(nextState)
+  const configPath = getFeishuBridgeConfigPath()
+  await writeFile(configPath, JSON.stringify({
+    appId: normalized.appId,
+    appSecret: normalized.appSecret,
+    chatIds: normalized.chatIds,
+    allowedUserIds: normalized.allowedUserIds,
+  }), 'utf8')
+}
+
+let feishuBridgeConfigMutation: Promise<void> = Promise.resolve()
+
+function rememberFeishuChatId(chatId: string): Promise<void> {
+  const normalizedChatId = chatId.trim()
+  if (!normalizedChatId) return Promise.resolve()
+
+  feishuBridgeConfigMutation = feishuBridgeConfigMutation.then(async () => {
+    const current = await readFeishuBridgeConfig()
+    if (current.chatIds.includes(normalizedChatId)) return
+    const next = {
+      ...current,
+      chatIds: [normalizedChatId, ...current.chatIds].slice(0, 50),
+    }
+    await writeFeishuBridgeConfig(next)
+  })
+  return feishuBridgeConfigMutation
+}
+
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   const raw = await readRawBody(req)
   if (raw.length === 0) return null
@@ -7322,6 +7397,7 @@ type SharedBridgeState = {
   terminalManager: ThreadTerminalManager
   methodCatalog: MethodCatalog
   telegramBridge: TelegramThreadBridge
+  feishuBridge: FeishuThreadBridge
   backendQueueProcessor: BackendQueueProcessor
 }
 
@@ -7355,6 +7431,11 @@ function getSharedBridgeState(): SharedBridgeState {
     telegramBridge: new TelegramThreadBridge(appServer, {
       onChatSeen: (chatId) => {
         void rememberTelegramChatId(chatId).catch(() => {})
+      },
+    }),
+    feishuBridge: new FeishuThreadBridge(appServer, {
+      onChatSeen: (chatId) => {
+        void rememberFeishuChatId(chatId).catch(() => {})
       },
     }),
   }
@@ -7439,7 +7520,7 @@ async function buildThreadSearchIndex(appServer: AppServerProcess): Promise<Thre
 }
 
 export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
-  const { appServer, terminalManager, methodCatalog, telegramBridge, backendQueueProcessor } = getSharedBridgeState()
+  const { appServer, terminalManager, methodCatalog, telegramBridge, feishuBridge, backendQueueProcessor } = getSharedBridgeState()
   let threadSearchIndex: ThreadSearchIndex | null = null
   let threadSearchIndexPromise: Promise<ThreadSearchIndex> | null = null
 
@@ -7464,6 +7545,15 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
       telegramBridge.configureToken(config.botToken)
       telegramBridge.configureAllowedUserIds(config.allowedUserIds)
       telegramBridge.start()
+    })
+    .catch(() => {})
+
+  void readFeishuBridgeConfig()
+    .then((config) => {
+      if (!config.appId || !config.appSecret) return
+      feishuBridge.configureApp(config.appId, config.appSecret)
+      feishuBridge.configureAllowedUserIds(config.allowedUserIds)
+      feishuBridge.start()
     })
     .catch(() => {})
 
@@ -9587,6 +9677,60 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         return
       }
 
+      if (req.method === 'POST' && url.pathname === '/codex-api/feishu/configure-bot') {
+        const payload = asRecord(await readJsonBody(req))
+        const appId = typeof payload?.appId === 'string' ? payload.appId.trim() : ''
+        const appSecret = typeof payload?.appSecret === 'string' ? payload.appSecret.trim() : ''
+        const rawAllowedUserIds = Array.isArray(payload?.allowedUserIds) ? payload.allowedUserIds : []
+        if (!appId) {
+          setJson(res, 400, { error: 'Missing appId' })
+          return
+        }
+        if (!appSecret) {
+          setJson(res, 400, { error: 'Missing appSecret' })
+          return
+        }
+        const config = normalizeFeishuBridgeConfig({
+          appId,
+          appSecret,
+          allowedUserIds: rawAllowedUserIds,
+        })
+        if (config.allowedUserIds.length === 0) {
+          setJson(res, 400, { error: 'At least one allowed Feishu user ID is required' })
+          return
+        }
+
+        feishuBridge.configureApp(config.appId, config.appSecret)
+        feishuBridge.configureAllowedUserIds(config.allowedUserIds)
+        feishuBridge.start()
+        const existingConfig = await readFeishuBridgeConfig()
+        await writeFeishuBridgeConfig({
+          appId: config.appId,
+          appSecret: config.appSecret,
+          chatIds: existingConfig.chatIds,
+          allowedUserIds: config.allowedUserIds,
+        })
+        setJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/feishu/config') {
+        const config = await readFeishuBridgeConfig()
+        setJson(res, 200, {
+          data: {
+            appId: config.appId,
+            appSecret: config.appSecret,
+            allowedUserIds: config.allowedUserIds,
+          },
+        })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/codex-api/feishu/status') {
+        setJson(res, 200, { data: feishuBridge.getStatus() })
+        return
+      }
+
       if (req.method === 'GET' && url.pathname === '/codex-api/events') {
         res.statusCode = 200
         res.setHeader('Content-Type', 'text/event-stream; charset=utf-8')
@@ -9627,6 +9771,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
   middleware.dispose = () => {
     threadSearchIndex = null
     telegramBridge.stop()
+    feishuBridge.stop()
     terminalManager.dispose()
     backendQueueProcessor.dispose()
     appServer.dispose()

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -17,7 +17,7 @@ import { callRpcWithRateLimitDecodeRecovery } from './rateLimitDecodeRecovery.js
 import { handleReviewRoutes } from './reviewGit.js'
 import { handleSkillsRoutes, initializeSkillsSyncOnStartup } from './skillsRoutes.js'
 import { TelegramThreadBridge } from './telegramThreadBridge.js'
-import { FeishuThreadBridge } from './feishuThreadBridge.js'
+import { FeishuThreadBridge, normalizeFeishuDomain, type FeishuBridgeDomain } from './feishuThreadBridge.js'
 import {
   getRandomFreeKey,
   getFreeKeyCount,
@@ -6137,6 +6137,7 @@ function rememberTelegramChatId(chatId: number): Promise<void> {
 type FeishuBridgeConfigState = {
   appId: string
   appSecret: string
+  domain: FeishuBridgeDomain
   chatIds: string[]
   allowedUserIds: Array<string | '*'>
 }
@@ -6147,9 +6148,10 @@ function getFeishuBridgeConfigPath(): string {
 
 function normalizeFeishuBridgeConfig(value: unknown): FeishuBridgeConfigState {
   const record = asRecord(value)
-  if (!record) return { appId: '', appSecret: '', chatIds: [], allowedUserIds: [] }
+  if (!record) return { appId: '', appSecret: '', domain: 'feishu', chatIds: [], allowedUserIds: [] }
   const appId = typeof record.appId === 'string' ? record.appId.trim() : ''
   const appSecret = typeof record.appSecret === 'string' ? record.appSecret.trim() : ''
+  const domain = normalizeFeishuDomain(record.domain)
   const rawChatIds = Array.isArray(record.chatIds) ? record.chatIds : []
   const chatIds = Array.from(new Set(rawChatIds
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
@@ -6165,7 +6167,7 @@ function normalizeFeishuBridgeConfig(value: unknown): FeishuBridgeConfigState {
   const allowedUserIds = allowAllUsers
     ? ['*']
     : Array.from(new Set(normalizedAllowedUserIds)).slice(0, 100)
-  return { appId, appSecret, chatIds, allowedUserIds }
+  return { appId, appSecret, domain, chatIds, allowedUserIds }
 }
 
 async function readFeishuBridgeConfig(): Promise<FeishuBridgeConfigState> {
@@ -6175,7 +6177,7 @@ async function readFeishuBridgeConfig(): Promise<FeishuBridgeConfigState> {
     const payload = asRecord(JSON.parse(raw)) ?? {}
     return normalizeFeishuBridgeConfig(payload)
   } catch {
-    return { appId: '', appSecret: '', chatIds: [], allowedUserIds: [] }
+    return { appId: '', appSecret: '', domain: 'feishu', chatIds: [], allowedUserIds: [] }
   }
 }
 
@@ -6185,6 +6187,7 @@ async function writeFeishuBridgeConfig(nextState: FeishuBridgeConfigState): Prom
   await writeFile(configPath, JSON.stringify({
     appId: normalized.appId,
     appSecret: normalized.appSecret,
+    domain: normalized.domain,
     chatIds: normalized.chatIds,
     allowedUserIds: normalized.allowedUserIds,
   }), 'utf8')
@@ -7551,7 +7554,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
   void readFeishuBridgeConfig()
     .then((config) => {
       if (!config.appId || !config.appSecret) return
-      feishuBridge.configureApp(config.appId, config.appSecret)
+      feishuBridge.configureApp(config.appId, config.appSecret, config.domain)
       feishuBridge.configureAllowedUserIds(config.allowedUserIds)
       feishuBridge.start()
     })
@@ -9681,6 +9684,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const payload = asRecord(await readJsonBody(req))
         const appId = typeof payload?.appId === 'string' ? payload.appId.trim() : ''
         const appSecret = typeof payload?.appSecret === 'string' ? payload.appSecret.trim() : ''
+        const domain = normalizeFeishuDomain(payload?.domain)
         const rawAllowedUserIds = Array.isArray(payload?.allowedUserIds) ? payload.allowedUserIds : []
         if (!appId) {
           setJson(res, 400, { error: 'Missing appId' })
@@ -9693,6 +9697,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
         const config = normalizeFeishuBridgeConfig({
           appId,
           appSecret,
+          domain,
           allowedUserIds: rawAllowedUserIds,
         })
         if (config.allowedUserIds.length === 0) {
@@ -9700,13 +9705,14 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           return
         }
 
-        feishuBridge.configureApp(config.appId, config.appSecret)
+        feishuBridge.configureApp(config.appId, config.appSecret, config.domain)
         feishuBridge.configureAllowedUserIds(config.allowedUserIds)
         feishuBridge.start()
         const existingConfig = await readFeishuBridgeConfig()
         await writeFeishuBridgeConfig({
           appId: config.appId,
           appSecret: config.appSecret,
+          domain: config.domain,
           chatIds: existingConfig.chatIds,
           allowedUserIds: config.allowedUserIds,
         })
@@ -9720,6 +9726,7 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
           data: {
             appId: config.appId,
             appSecret: config.appSecret,
+            domain: config.domain,
             allowedUserIds: config.allowedUserIds,
           },
         })

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -118,6 +118,8 @@ export class FeishuThreadBridge {
   private readonly chatIdsByThreadId = new Map<string, Set<string>>()
   private readonly threadCwdByThreadId = new Map<string, string>()
   private readonly lastForwardedTurnByThreadId = new Map<string, string>()
+  private readonly processedMessageIds = new Set<string>()
+  private readonly processedMessageIdOrder: string[] = []
   private active = false
   private lastError = ''
   private readonly onChatSeen?: (chatId: string) => void
@@ -361,6 +363,7 @@ export class FeishuThreadBridge {
       ? (asRecord(sender.sender_id)?.open_id as string ?? '')
       : ''
     const msgType = typeof message.message_type === 'string' ? message.message_type : ''
+    const messageId = typeof message.message_id === 'string' ? message.message_id : ''
 
     if (!chatId) return
 
@@ -382,6 +385,8 @@ export class FeishuThreadBridge {
     }
     if (!text) return
 
+    if (this.hasProcessedMessage(messageId)) return
+
     if (!this.isAllowedSender(senderId)) {
       await this.sendFeishuMessage(chatId, this.unauthorizedMessage(senderId))
       return
@@ -390,25 +395,26 @@ export class FeishuThreadBridge {
 
     const atMentionRegex = /@_user_\d+\s*/g
     text = text.replace(atMentionRegex, '').trim()
+    const commandText = text.toLowerCase()
 
-    if (text === '/start') {
+    if (commandText === '/start') {
       await this.sendFeishuMessage(chatId, this.helpMessage())
       await this.sendThreadPicker(chatId)
       return
     }
 
-    if (text === '/threads') {
+    if (commandText === '/threads') {
       await this.sendThreadPicker(chatId)
       return
     }
 
-    if (text === '/newthread') {
+    if (commandText === '/newthread') {
       const threadId = await this.createThreadForChat(chatId)
       await this.sendFeishuMessage(chatId, `Mapped to new thread: ${threadId}`)
       return
     }
 
-    const threadCommand = text.match(/^\/thread\s+(\S+)$/)
+    const threadCommand = text.match(/^\/thread\s+(\S+)$/i)
     if (threadCommand) {
       const threadId = threadCommand[1]
       this.bindChatToThread(chatId, threadId)
@@ -416,7 +422,7 @@ export class FeishuThreadBridge {
       return
     }
 
-    if (text === '/current') {
+    if (commandText === '/current') {
       const threadId = this.threadIdByChatId.get(chatId)
       await this.sendFeishuMessage(chatId, threadId
         ? `Current thread: ${threadId}`
@@ -424,7 +430,7 @@ export class FeishuThreadBridge {
       return
     }
 
-    if (text === '/history') {
+    if (commandText === '/history') {
       const threadId = this.threadIdByChatId.get(chatId)
       if (!threadId) {
         await this.sendFeishuMessage(chatId, 'No thread is connected for this chat yet. Use /threads or /newthread first.')
@@ -434,7 +440,7 @@ export class FeishuThreadBridge {
       return
     }
 
-    if (text === '/status') {
+    if (commandText === '/status') {
       const status = this.getStatus()
       const mappedThreadId = this.threadIdByChatId.get(chatId) ?? 'none'
       await this.sendFeishuMessage(
@@ -454,7 +460,7 @@ export class FeishuThreadBridge {
       return
     }
 
-    if (text === '/whoami') {
+    if (commandText === '/whoami') {
       const normalizedSenderId = senderId || 'unknown'
       await this.sendFeishuMessage(
         chatId,
@@ -469,7 +475,7 @@ export class FeishuThreadBridge {
       return
     }
 
-    if (text === '/help') {
+    if (commandText === '/help') {
       await this.sendFeishuMessage(chatId, this.helpMessage())
       return
     }
@@ -482,13 +488,9 @@ export class FeishuThreadBridge {
       const thinkingId = await this.sendTextMessage(chatId, '⏳ Thinking...')
       if (thinkingId) this.thinkingMessageIdByChatId.set(chatId, thinkingId)
     }
-    const threadCwd = this.threadCwdByThreadId.get(threadId) || this.defaultCwd
+    const threadCwd = await this.resolveCwdForThread(threadId) || this.defaultCwd
     try {
-      await this.appServer.rpc('turn/start', {
-        threadId,
-        input: [{ type: 'text', text }],
-        cwd: threadCwd,
-      })
+      await this.startTurnWithResumeRetry(threadId, text, threadCwd)
     } catch (error) {
       const message = getErrorMessage(error, 'Failed to forward message to thread')
       const thinkingId = this.getThinkingMessageId(chatId)
@@ -533,6 +535,43 @@ export class FeishuThreadBridge {
     if (!senderId) return false
     if (this.allowAllUsers) return true
     return this.allowedUserIds.has(senderId)
+  }
+
+  private hasProcessedMessage(messageId: string): boolean {
+    if (!messageId) return false
+    if (this.processedMessageIds.has(messageId)) return true
+
+    this.processedMessageIds.add(messageId)
+    this.processedMessageIdOrder.push(messageId)
+
+    const maxRememberedMessages = 500
+    while (this.processedMessageIdOrder.length > maxRememberedMessages) {
+      const oldest = this.processedMessageIdOrder.shift()
+      if (oldest) this.processedMessageIds.delete(oldest)
+    }
+
+    return false
+  }
+
+  private isThreadNotFoundError(error: unknown): boolean {
+    return getErrorMessage(error, '').toLowerCase().includes('not found')
+  }
+
+  private async startTurnWithResumeRetry(threadId: string, text: string, cwd: string): Promise<void> {
+    const params = {
+      threadId,
+      input: [{ type: 'text', text }],
+      cwd,
+    }
+
+    try {
+      await this.appServer.rpc('turn/start', params)
+    } catch (error) {
+      if (!this.isThreadNotFoundError(error)) throw error
+
+      await this.appServer.rpc('thread/resume', { threadId })
+      await this.appServer.rpc('turn/start', params)
+    }
   }
 
   private unauthorizedMessage(senderId: string): string {
@@ -654,13 +693,62 @@ export class FeishuThreadBridge {
     })
   }
 
+  private async resolveCwdForThread(threadId: string): Promise<string> {
+    const cached = this.threadCwdByThreadId.get(threadId)?.trim() ?? ''
+    if (cached) return cached
+
+    try {
+      const response = asRecord(await this.appServer.rpc('thread/read', { threadId, includeTurns: false }))
+      const thread = asRecord(response?.thread)
+      const cwd = typeof thread?.cwd === 'string' ? thread.cwd.trim() : ''
+      if (cwd) {
+        this.threadCwdByThreadId.set(threadId, cwd)
+        return cwd
+      }
+    } catch {
+      // Fall back to the default cwd below.
+    }
+
+    return ''
+  }
+
+  private async resolveRecentThreadCwd(): Promise<string> {
+    try {
+      const payload = asRecord(await this.appServer.rpc('thread/list', {
+        archived: false,
+        limit: 1,
+        sortKey: 'updated_at',
+        modelProviders: [],
+      }))
+      const rows = Array.isArray(payload?.data) ? payload.data : []
+      const first = asRecord(rows[0])
+      const cwd = typeof first?.cwd === 'string' ? first.cwd.trim() : ''
+      return cwd
+    } catch {
+      return ''
+    }
+  }
+
+  private async resolveCwdForChat(chatId: string): Promise<string> {
+    const existingThreadId = this.threadIdByChatId.get(chatId) ?? ''
+    if (existingThreadId) {
+      const existingCwd = await this.resolveCwdForThread(existingThreadId)
+      if (existingCwd) return existingCwd
+    }
+
+    const recentCwd = await this.resolveRecentThreadCwd()
+    return recentCwd || this.defaultCwd
+  }
+
   private async createThreadForChat(chatId: string): Promise<string> {
-    const response = asRecord(await this.appServer.rpc('thread/start', { cwd: this.defaultCwd }))
+    const cwd = await this.resolveCwdForChat(chatId)
+    const response = asRecord(await this.appServer.rpc('thread/start', { cwd }))
     const thread = asRecord(response?.thread)
     const threadId = typeof thread?.id === 'string' ? thread.id : ''
     if (!threadId) {
       throw new Error('thread/start did not return thread id')
     }
+    this.threadCwdByThreadId.set(threadId, cwd)
     this.bindChatToThread(chatId, threadId)
     return threadId
   }

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -537,6 +537,8 @@ export class FeishuThreadBridge {
     if (!this.client) return
     const elements: unknown[] = []
 
+    const MAX_THREADS_PER_GROUP = 6
+
     for (let gi = 0; gi < groups.length; gi += 1) {
       const group = groups[gi]
       if (gi > 0) {
@@ -546,15 +548,24 @@ export class FeishuThreadBridge {
         tag: 'markdown',
         content: `📁 **${group.project}**`,
       })
-      elements.push({
-        tag: 'action',
-        actions: group.threads.map((thread) => ({
-          tag: 'button',
-          text: { content: thread.title, tag: 'plain_text' },
-          type: 'default',
-          value: { threadId: thread.id },
-        })),
-      })
+      const visibleThreads = group.threads.slice(0, MAX_THREADS_PER_GROUP)
+      for (const thread of visibleThreads) {
+        elements.push({
+          tag: 'action',
+          actions: [{
+            tag: 'button',
+            text: { content: thread.title, tag: 'plain_text' },
+            type: 'default',
+            value: { threadId: thread.id },
+          }],
+        })
+      }
+      if (group.threads.length > MAX_THREADS_PER_GROUP) {
+        elements.push({
+          tag: 'markdown',
+          content: `_…and ${group.threads.length - MAX_THREADS_PER_GROUP} more_`,
+        })
+      }
     }
 
     await this.client.im.message.create({

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -116,6 +116,7 @@ export class FeishuThreadBridge {
   private allowedUserIds = new Set<string>()
   private readonly threadIdByChatId = new Map<string, string>()
   private readonly chatIdsByThreadId = new Map<string, Set<string>>()
+  private readonly threadCwdByThreadId = new Map<string, string>()
   private readonly lastForwardedTurnByThreadId = new Map<string, string>()
   private active = false
   private lastError = ''
@@ -481,16 +482,18 @@ export class FeishuThreadBridge {
       const thinkingId = await this.sendTextMessage(chatId, '⏳ Thinking...')
       if (thinkingId) this.thinkingMessageIdByChatId.set(chatId, thinkingId)
     }
+    const threadCwd = this.threadCwdByThreadId.get(threadId) || this.defaultCwd
     try {
       await this.appServer.rpc('turn/start', {
         threadId,
         input: [{ type: 'text', text }],
+        cwd: threadCwd,
       })
     } catch (error) {
       const message = getErrorMessage(error, 'Failed to forward message to thread')
       const thinkingId = this.getThinkingMessageId(chatId)
       const errorMsg = message.includes('not found')
-        ? `Thread belongs to a different project. Use /newthread to create one in the current project, or /threads to pick a local thread.`
+        ? `Thread not found. Use /newthread to create one in the current project, or /threads to pick a local thread.`
         : `Forward failed: ${message}`
       if (thinkingId) {
         await this.updateMessage(thinkingId, errorMsg)
@@ -513,12 +516,14 @@ export class FeishuThreadBridge {
     const value = asRecord(action?.value)
     const threadId = typeof value?.threadId === 'string' ? value.threadId.trim() : ''
     if (!threadId) return
+    const threadCwd = typeof value?.cwd === 'string' ? value.cwd.trim() : ''
 
     const context = asRecord(record.context)
     const chatId = typeof context?.open_chat_id === 'string' ? context.open_chat_id : ''
     if (!chatId) return
 
     this.bindChatToThread(chatId, threadId)
+    if (threadCwd) this.threadCwdByThreadId.set(threadId, threadCwd)
     this.markChatSeen(chatId)
     await this.sendFeishuMessage(chatId, `Connected to thread: ${threadId}`)
     await this.sendHistoryCard(chatId, threadId, 2)
@@ -550,7 +555,7 @@ export class FeishuThreadBridge {
     await this.sendGroupedThreadCard(chatId, groups)
   }
 
-  private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: Array<{ id: string; title: string }> }>> {
+  private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: Array<{ id: string; title: string; cwd: string }> }>> {
     const allRows: unknown[] = []
     let cursor: string | null = null
 
@@ -570,7 +575,7 @@ export class FeishuThreadBridge {
         : null
     } while (cursor)
 
-    const groupMap = new Map<string, Array<{ id: string; title: string }>>()
+    const groupMap = new Map<string, Array<{ id: string; title: string; cwd: string }>>()
     const groupOrder: string[] = []
 
     for (const row of allRows) {
@@ -587,7 +592,7 @@ export class FeishuThreadBridge {
         groupMap.set(projectName, [])
         groupOrder.push(projectName)
       }
-      groupMap.get(projectName)!.push({ id, title: threadTitle.slice(0, 48) })
+      groupMap.get(projectName)!.push({ id, title: threadTitle.slice(0, 48), cwd })
     }
 
     return groupOrder
@@ -597,7 +602,7 @@ export class FeishuThreadBridge {
 
   private async sendGroupedThreadCard(
     chatId: string,
-    groups: Array<{ project: string; threads: Array<{ id: string; title: string }> }>,
+    groups: Array<{ project: string; threads: Array<{ id: string; title: string; cwd: string }> }>,
   ): Promise<void> {
     if (!this.client) return
     const elements: unknown[] = []
@@ -621,7 +626,7 @@ export class FeishuThreadBridge {
             tag: 'button',
             text: { content: thread.title, tag: 'plain_text' },
             type: 'default',
-            value: { threadId: thread.id },
+            value: { threadId: thread.id, cwd: thread.cwd },
           }],
         })
       }

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -12,9 +12,12 @@ type FeishuThreadBridgeOptions = {
   onChatSeen?: (chatId: string) => void
 }
 
+export type FeishuBridgeDomain = 'feishu' | 'lark'
+
 export type FeishuBridgeStatus = {
   configured: boolean
   active: boolean
+  domain: FeishuBridgeDomain
   mappedChats: number
   mappedThreads: number
   allowedUsers: number
@@ -115,6 +118,19 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback
 }
 
+export function normalizeFeishuDomain(value: unknown): FeishuBridgeDomain {
+  if (typeof value !== 'string') return 'feishu'
+  const normalized = value.trim().toLowerCase()
+  if (['lark', 'international', 'intl', 'global', 'open.larksuite.com', 'https://open.larksuite.com'].includes(normalized)) {
+    return 'lark'
+  }
+  return 'feishu'
+}
+
+function getLarkSdkDomain(domain: FeishuBridgeDomain): lark.Domain {
+  return domain === 'lark' ? lark.Domain.Lark : lark.Domain.Feishu
+}
+
 type NormalizedFeishuAllowlist = {
   allowAllUsers: boolean
   allowedUserIds: string[]
@@ -165,6 +181,7 @@ function splitFeishuText(text: string, maxLength = FEISHU_MESSAGE_MAX_LENGTH): s
 export class FeishuThreadBridge {
   private appId: string
   private appSecret: string
+  private domain: FeishuBridgeDomain
   private readonly appServer: AppServerLike
   private readonly defaultCwd: string
   private allowAllUsers = false
@@ -187,6 +204,7 @@ export class FeishuThreadBridge {
     this.appServer = appServer
     this.appId = process.env.FEISHU_APP_ID?.trim() ?? ''
     this.appSecret = process.env.FEISHU_APP_SECRET?.trim() ?? ''
+    this.domain = normalizeFeishuDomain(process.env.FEISHU_DOMAIN)
     this.defaultCwd = process.env.FEISHU_DEFAULT_CWD?.trim() ?? process.cwd()
     this.configureAllowedUserIds(
       (process.env.FEISHU_ALLOWED_USER_IDS ?? '')
@@ -200,12 +218,13 @@ export class FeishuThreadBridge {
   start(): void {
     if (!this.appId || !this.appSecret || this.active) return
     this.active = true
+    const domain = getLarkSdkDomain(this.domain)
 
     this.client = new lark.Client({
       appId: this.appId,
       appSecret: this.appSecret,
       appType: lark.AppType.SelfBuild,
-      domain: lark.Domain.Feishu,
+      domain,
     })
 
     const eventDispatcher = new lark.EventDispatcher({}).register({
@@ -224,6 +243,7 @@ export class FeishuThreadBridge {
     this.wsClient = new lark.WSClient({
       appId: this.appId,
       appSecret: this.appSecret,
+      domain,
       loggerLevel: lark.LoggerLevel.warn,
     })
 
@@ -240,23 +260,33 @@ export class FeishuThreadBridge {
     this.active = false
     this.unsubscribeNotifications?.()
     this.unsubscribeNotifications = null
+    this.wsClient?.close({ force: true })
     this.client = null
     this.wsClient = null
   }
 
-  configureApp(appId: string, appSecret: string): void {
+  configureApp(appId: string, appSecret: string, domain: unknown = this.domain): void {
     const normalizedAppId = appId.trim()
     const normalizedAppSecret = appSecret.trim()
+    const normalizedDomain = normalizeFeishuDomain(domain)
     if (!normalizedAppId) throw new Error('Feishu App ID is required')
     if (!normalizedAppSecret) throw new Error('Feishu App Secret is required')
+    const shouldRestart = this.active
+      && (this.appId !== normalizedAppId
+        || this.appSecret !== normalizedAppSecret
+        || this.domain !== normalizedDomain)
+    if (shouldRestart) this.stop()
     this.appId = normalizedAppId
     this.appSecret = normalizedAppSecret
+    this.domain = normalizedDomain
+    if (shouldRestart) this.start()
   }
 
   getStatus(): FeishuBridgeStatus {
     return {
       configured: this.appId.length > 0 && this.appSecret.length > 0,
       active: this.active,
+      domain: this.domain,
       mappedChats: this.threadIdByChatId.size,
       mappedThreads: this.chatIdsByThreadId.size,
       allowedUsers: this.allowedUserIds.size,

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -489,11 +489,14 @@ export class FeishuThreadBridge {
     } catch (error) {
       const message = getErrorMessage(error, 'Failed to forward message to thread')
       const thinkingId = this.getThinkingMessageId(chatId)
+      const errorMsg = message.includes('not found')
+        ? `Thread belongs to a different project. Use /newthread to create one in the current project, or /threads to pick a local thread.`
+        : `Forward failed: ${message}`
       if (thinkingId) {
-        await this.updateMessage(thinkingId, `Forward failed: ${message}`)
+        await this.updateMessage(thinkingId, errorMsg)
         this.clearThinkingMessage(chatId)
       } else {
-        await this.sendFeishuMessage(chatId, `Forward failed: ${message}`)
+        await this.sendFeishuMessage(chatId, errorMsg)
       }
     }
   }
@@ -557,7 +560,6 @@ export class FeishuThreadBridge {
         limit: 100,
         sortKey: 'updated_at',
         modelProviders: [],
-        cwd: this.defaultCwd,
       }
       if (cursor) params.cursor = cursor
       const payload = asRecord(await this.appServer.rpc('thread/list', params))

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -254,8 +254,16 @@ export class FeishuThreadBridge {
       params: { receive_id_type: 'chat_id' },
       data: {
         receive_id: chatId,
-        content: JSON.stringify({ text }),
-        msg_type: 'text',
+        content: JSON.stringify({
+          header: {
+            template: 'wathet',
+            title: { content: '🤖 Codex', tag: 'plain_text' },
+          },
+          elements: [
+            { tag: 'markdown', content: text },
+          ],
+        }),
+        msg_type: 'interactive',
       },
     })
   }

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -498,17 +498,29 @@ export class FeishuThreadBridge {
   }
 
   private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: Array<{ id: string; title: string }> }>> {
-    const payload = asRecord(await this.appServer.rpc('thread/list', {
-      archived: false,
-      limit: 20,
-      sortKey: 'updated_at',
-      modelProviders: [],
-    }))
-    const rows = Array.isArray(payload?.data) ? payload.data : []
+    const allRows: unknown[] = []
+    let cursor: string | null = null
+
+    do {
+      const params: Record<string, unknown> = {
+        archived: false,
+        limit: 100,
+        sortKey: 'updated_at',
+        modelProviders: [],
+      }
+      if (cursor) params.cursor = cursor
+      const payload = asRecord(await this.appServer.rpc('thread/list', params))
+      const rows = Array.isArray(payload?.data) ? payload.data : []
+      for (const row of rows) allRows.push(row)
+      cursor = typeof payload?.nextCursor === 'string' && payload.nextCursor.length > 0
+        ? payload.nextCursor
+        : null
+    } while (cursor)
+
     const groupMap = new Map<string, Array<{ id: string; title: string }>>()
     const groupOrder: string[] = []
 
-    for (const row of rows) {
+    for (const row of allRows) {
       const record = asRecord(row)
       const id = typeof record?.id === 'string' ? record.id.trim() : ''
       if (!id) continue

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -511,6 +511,7 @@ export class FeishuThreadBridge {
         limit: 100,
         sortKey: 'updated_at',
         modelProviders: [],
+        cwd: this.defaultCwd,
       }
       if (cursor) params.cursor = cursor
       const payload = asRecord(await this.appServer.rpc('thread/list', params))

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -488,21 +488,16 @@ export class FeishuThreadBridge {
   }
 
   private async sendThreadPicker(chatId: string): Promise<void> {
-    const threads = await this.listRecentThreads()
-    if (threads.length === 0) {
+    const groups = await this.listRecentThreadGroups()
+    if (groups.length === 0) {
       await this.sendFeishuMessage(chatId, 'No threads found. Send /newthread to create one.')
       return
     }
 
-    const buttons = threads.map((thread) => ({
-      text: thread.title,
-      value: thread.id,
-    }))
-
-    await this.sendFeishuMessage(chatId, 'Select a thread to connect:', { buttons })
+    await this.sendGroupedThreadCard(chatId, groups)
   }
 
-  private async listRecentThreads(): Promise<Array<{ id: string; title: string }>> {
+  private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: Array<{ id: string; title: string }> }>> {
     const payload = asRecord(await this.appServer.rpc('thread/list', {
       archived: false,
       limit: 20,
@@ -510,7 +505,9 @@ export class FeishuThreadBridge {
       modelProviders: [],
     }))
     const rows = Array.isArray(payload?.data) ? payload.data : []
-    const threads: Array<{ id: string; title: string }> = []
+    const groupMap = new Map<string, Array<{ id: string; title: string }>>()
+    const groupOrder: string[] = []
+
     for (const row of rows) {
       const record = asRecord(row)
       const id = typeof record?.id === 'string' ? record.id.trim() : ''
@@ -520,10 +517,60 @@ export class FeishuThreadBridge {
       const cwd = typeof record?.cwd === 'string' ? record.cwd.trim() : ''
       const projectName = cwd ? basename(cwd) : 'project'
       const threadTitle = (name || preview || id).replace(/\s+/g, ' ').trim()
-      const title = `${projectName}/${threadTitle}`.slice(0, 64)
-      threads.push({ id, title })
+
+      if (!groupMap.has(projectName)) {
+        groupMap.set(projectName, [])
+        groupOrder.push(projectName)
+      }
+      groupMap.get(projectName)!.push({ id, title: threadTitle.slice(0, 48) })
     }
-    return threads
+
+    return groupOrder
+      .map((project) => ({ project, threads: groupMap.get(project) ?? [] }))
+      .filter((group) => group.threads.length > 0)
+  }
+
+  private async sendGroupedThreadCard(
+    chatId: string,
+    groups: Array<{ project: string; threads: Array<{ id: string; title: string }> }>,
+  ): Promise<void> {
+    if (!this.client) return
+    const elements: unknown[] = []
+
+    for (let gi = 0; gi < groups.length; gi += 1) {
+      const group = groups[gi]
+      if (gi > 0) {
+        elements.push({ tag: 'hr' })
+      }
+      elements.push({
+        tag: 'markdown',
+        content: `📁 **${group.project}**`,
+      })
+      elements.push({
+        tag: 'action',
+        actions: group.threads.map((thread) => ({
+          tag: 'button',
+          text: { content: thread.title, tag: 'plain_text' },
+          type: 'default',
+          value: { threadId: thread.id },
+        })),
+      })
+    }
+
+    await this.client.im.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        content: JSON.stringify({
+          header: {
+            template: 'indigo',
+            title: { content: '🧵 Select a thread', tag: 'plain_text' },
+          },
+          elements,
+        }),
+        msg_type: 'interactive',
+      },
+    })
   }
 
   private async createThreadForChat(chatId: string): Promise<string> {

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -396,8 +396,7 @@ export class FeishuThreadBridge {
         await this.sendFeishuMessage(chatId, 'No thread is connected for this chat yet. Use /threads or /newthread first.')
         return
       }
-      const history = await this.readThreadHistorySummary(threadId)
-      await this.sendFeishuMessage(chatId, history)
+      await this.sendHistoryCard(chatId, threadId)
       return
     }
 
@@ -473,10 +472,7 @@ export class FeishuThreadBridge {
     this.bindChatToThread(chatId, threadId)
     this.markChatSeen(chatId)
     await this.sendFeishuMessage(chatId, `Connected to thread: ${threadId}`)
-    const history = await this.readThreadHistorySummary(threadId)
-    if (history) {
-      await this.sendFeishuMessage(chatId, history)
-    }
+    await this.sendHistoryCard(chatId, threadId, 2)
   }
 
   private isAllowedSender(senderId: string): boolean {
@@ -697,11 +693,11 @@ export class FeishuThreadBridge {
     return ''
   }
 
-  private async readThreadHistorySummary(threadId: string): Promise<string> {
+  private async readThreadHistoryMessages(threadId: string): Promise<Array<{ role: 'user' | 'assistant'; text: string }>> {
     const response = asRecord(await this.appServer.rpc('thread/read', { threadId, includeTurns: true }))
     const thread = asRecord(response?.thread)
     const turns = Array.isArray(thread?.turns) ? thread.turns : []
-    const historyRows: string[] = []
+    const messages: Array<{ role: 'user' | 'assistant'; text: string }> = []
 
     for (const turn of turns) {
       const turnRecord = asRecord(turn)
@@ -714,23 +710,75 @@ export class FeishuThreadBridge {
           for (const block of content) {
             const blockRecord = asRecord(block)
             if (blockRecord?.type === 'text' && typeof blockRecord.text === 'string' && blockRecord.text.trim()) {
-              historyRows.push(`User: ${blockRecord.text.trim()}`)
+              messages.push({ role: 'user', text: blockRecord.text.trim() })
             }
           }
         }
         if (type === 'agentMessage' && typeof itemRecord?.text === 'string' && itemRecord.text.trim()) {
-          historyRows.push(`Assistant: ${itemRecord.text.trim()}`)
+          messages.push({ role: 'assistant', text: itemRecord.text.trim() })
         }
       }
     }
 
-    if (historyRows.length === 0) {
-      return 'Thread has no message history yet.'
+    return messages
+  }
+
+  private mergeConsecutiveMessages(messages: Array<{ role: 'user' | 'assistant'; text: string }>): Array<{ role: 'user' | 'assistant'; text: string }> {
+    const merged: Array<{ role: 'user' | 'assistant'; text: string }> = []
+    for (const msg of messages) {
+      const last = merged[merged.length - 1]
+      if (last && last.role === msg.role) {
+        last.text = `${last.text}\n\n${msg.text}`
+      } else {
+        merged.push({ ...msg })
+      }
+    }
+    return merged
+  }
+
+  private async sendHistoryCard(chatId: string, threadId: string, limit?: number): Promise<void> {
+    if (!this.client) return
+    const rawMessages = await this.readThreadHistoryMessages(threadId)
+    if (rawMessages.length === 0) {
+      await this.sendFeishuMessage(chatId, 'Thread has no message history yet.')
+      return
     }
 
-    const tail = historyRows.slice(-12).join('\n\n')
-    const maxLen = 3800
-    const summary = tail.length > maxLen ? tail.slice(tail.length - maxLen) : tail
-    return `Recent history:\n\n${summary}`
+    const merged = this.mergeConsecutiveMessages(rawMessages)
+    const messages = limit ? merged.slice(-limit) : merged
+
+    for (const msg of messages) {
+      if (msg.role === 'user') {
+        await this.client.im.message.create({
+          params: { receive_id_type: 'chat_id' },
+          data: {
+            receive_id: chatId,
+            content: JSON.stringify({
+              header: {
+                template: 'wathet',
+                title: { content: '👤 User', tag: 'plain_text' },
+              },
+              elements: [{ tag: 'markdown', content: msg.text }],
+            }),
+            msg_type: 'interactive',
+          },
+        })
+      } else {
+        await this.client.im.message.create({
+          params: { receive_id_type: 'chat_id' },
+          data: {
+            receive_id: chatId,
+            content: JSON.stringify({
+              header: {
+                template: 'grey',
+                title: { content: '🤖 Assistant', tag: 'plain_text' },
+              },
+              elements: [{ tag: 'markdown', content: msg.text }],
+            }),
+            msg_type: 'interactive',
+          },
+        })
+      }
+    }
   }
 }

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -112,6 +112,7 @@ export class FeishuThreadBridge {
   private readonly appServer: AppServerLike
   private readonly defaultCwd: string
   private allowAllUsers = false
+  private readonly thinkingMessageIdByChatId = new Map<string, string>()
   private allowedUserIds = new Set<string>()
   private readonly threadIdByChatId = new Map<string, string>()
   private readonly chatIdsByThreadId = new Map<string, Set<string>>()
@@ -248,9 +249,9 @@ export class FeishuThreadBridge {
     }
   }
 
-  private async sendTextMessage(chatId: string, text: string): Promise<void> {
-    if (!this.client) return
-    await this.client.im.message.create({
+  private async sendTextMessage(chatId: string, text: string): Promise<string> {
+    if (!this.client) return ''
+    const resp = await this.client.im.message.create({
       params: { receive_id_type: 'chat_id' },
       data: {
         receive_id: chatId,
@@ -266,6 +267,38 @@ export class FeishuThreadBridge {
         msg_type: 'interactive',
       },
     })
+    const data = asRecord(resp?.data)
+    return typeof data?.message_id === 'string' ? data.message_id : ''
+  }
+
+  private async updateMessage(messageId: string, text: string): Promise<void> {
+    if (!this.client || !messageId) return
+    try {
+      await this.client.im.message.patch({
+        path: { message_id: messageId },
+        data: {
+          content: JSON.stringify({
+            header: {
+              template: 'wathet',
+              title: { content: '🤖 Codex', tag: 'plain_text' },
+            },
+            elements: [
+              { tag: 'markdown', content: text },
+            ],
+          }),
+        },
+      })
+    } catch {
+      // ignore update failures
+    }
+  }
+
+  private getThinkingMessageId(chatId: string): string {
+    return this.thinkingMessageIdByChatId.get(chatId) ?? ''
+  }
+
+  private clearThinkingMessage(chatId: string): void {
+    this.thinkingMessageIdByChatId.delete(chatId)
   }
 
   private async sendCardMessage(
@@ -441,6 +474,13 @@ export class FeishuThreadBridge {
     }
 
     const threadId = await this.ensureThreadForChat(chatId)
+    const existingThinkingId = this.getThinkingMessageId(chatId)
+    if (existingThinkingId) {
+      await this.updateMessage(existingThinkingId, '⏳ Thinking...')
+    } else {
+      const thinkingId = await this.sendTextMessage(chatId, '⏳ Thinking...')
+      if (thinkingId) this.thinkingMessageIdByChatId.set(chatId, thinkingId)
+    }
     try {
       await this.appServer.rpc('turn/start', {
         threadId,
@@ -448,7 +488,13 @@ export class FeishuThreadBridge {
       })
     } catch (error) {
       const message = getErrorMessage(error, 'Failed to forward message to thread')
-      await this.sendFeishuMessage(chatId, `Forward failed: ${message}`)
+      const thinkingId = this.getThinkingMessageId(chatId)
+      if (thinkingId) {
+        await this.updateMessage(thinkingId, `Forward failed: ${message}`)
+        this.clearThinkingMessage(chatId)
+      } else {
+        await this.sendFeishuMessage(chatId, `Forward failed: ${message}`)
+      }
     }
   }
 
@@ -668,7 +714,13 @@ export class FeishuThreadBridge {
     if (!assistantReply) return
     const chatIdList = Array.from(chatIds)
     for (const chatId of chatIdList) {
-      await this.sendFeishuMessage(chatId, assistantReply)
+      const thinkingId = this.getThinkingMessageId(chatId)
+      if (thinkingId) {
+        await this.updateMessage(thinkingId, assistantReply)
+        this.clearThinkingMessage(chatId)
+      } else {
+        await this.sendFeishuMessage(chatId, assistantReply)
+      }
     }
     if (turnId) {
       this.lastForwardedTurnByThreadId.set(threadId, turnId)

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -178,6 +178,22 @@ function splitFeishuText(text: string, maxLength = FEISHU_MESSAGE_MAX_LENGTH): s
   return chunks
 }
 
+function formatDurationMs(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return ''
+  if (durationMs < 1000) return `${Math.max(1, Math.round(durationMs))}ms`
+
+  const totalSeconds = Math.round(durationMs / 1000)
+  if (totalSeconds < 60) return `${totalSeconds}s`
+
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
 export class FeishuThreadBridge {
   private appId: string
   private appSecret: string
@@ -186,6 +202,7 @@ export class FeishuThreadBridge {
   private readonly defaultCwd: string
   private allowAllUsers = false
   private readonly thinkingMessageIdByChatId = new Map<string, string>()
+  private readonly thinkingStartedAtMsByChatId = new Map<string, number>()
   private allowedUserIds = new Set<string>()
   private readonly threadIdByChatId = new Map<string, string>()
   private readonly chatIdsByThreadId = new Map<string, Set<string>>()
@@ -388,6 +405,22 @@ export class FeishuThreadBridge {
 
   private clearThinkingMessage(chatId: string): void {
     this.thinkingMessageIdByChatId.delete(chatId)
+    this.thinkingStartedAtMsByChatId.delete(chatId)
+  }
+
+  private markThinkingStarted(chatId: string): void {
+    this.thinkingStartedAtMsByChatId.set(chatId, Date.now())
+  }
+
+  private getThinkingDurationText(chatId: string): string {
+    const startedAtMs = this.thinkingStartedAtMsByChatId.get(chatId)
+    if (typeof startedAtMs !== 'number') return ''
+    return formatDurationMs(Date.now() - startedAtMs)
+  }
+
+  private getCompletedMessage(chatId: string): string {
+    const durationText = this.getThinkingDurationText(chatId)
+    return durationText ? `✅ Completed in ${durationText}` : '✅ Completed'
   }
 
   private async sendCardMessage(
@@ -568,6 +601,7 @@ export class FeishuThreadBridge {
 
     const threadId = await this.ensureThreadForChat(chatId)
     const existingThinkingId = this.getThinkingMessageId(chatId)
+    this.markThinkingStarted(chatId)
     if (existingThinkingId) {
       await this.updateMessage(existingThinkingId, '⏳ Thinking...')
     } else {
@@ -899,14 +933,14 @@ export class FeishuThreadBridge {
     if (turnId && lastForwardedTurnId === turnId) return
 
     const assistantReply = await this.readLatestAssistantMessage(threadId)
-    if (!assistantReply) return
     const chatIdList = Array.from(chatIds)
     for (const chatId of chatIdList) {
       const thinkingId = this.getThinkingMessageId(chatId)
       if (thinkingId) {
-        await this.updateMessage(thinkingId, assistantReply)
+        await this.updateMessage(thinkingId, this.getCompletedMessage(chatId))
         this.clearThinkingMessage(chatId)
-      } else {
+      }
+      if (assistantReply) {
         await this.sendFeishuMessage(chatId, assistantReply)
       }
     }

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -1,4 +1,6 @@
-import { basename } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import * as lark from '@larksuiteoapi/node-sdk'
 
 type AppServerLike = {
@@ -25,6 +27,12 @@ type FeishuBotCommand = {
   description: string
 }
 
+type FeishuRecentThread = {
+  id: string
+  title: string
+  cwd: string
+}
+
 const FEISHU_MESSAGE_MAX_LENGTH = 3500
 const FEISHU_BOT_COMMANDS: FeishuBotCommand[] = [
   { command: 'start', description: 'Show quick start and thread picker' },
@@ -42,6 +50,54 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null
+}
+
+function normalizePathKey(value: string): string {
+  const normalized = value.trim().replace(/\\/g, '/').replace(/\/+$/u, '')
+  return /^[a-z]:\//iu.test(normalized) ? normalized.toLowerCase() : normalized
+}
+
+function getPathLeaf(value: string): string {
+  const normalized = value.trim().replace(/[\\/]+$/u, '')
+  if (!normalized) return ''
+  const separatorIndex = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  return separatorIndex >= 0 ? normalized.slice(separatorIndex + 1) : normalized
+}
+
+function getCodexGlobalStatePath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex')
+  return join(codexHome, '.codex-global-state.json')
+}
+
+async function readWorkspaceRootLabels(): Promise<Map<string, string>> {
+  try {
+    const raw = await readFile(getCodexGlobalStatePath(), 'utf8')
+    const payload = asRecord(JSON.parse(raw))
+    const labels = asRecord(payload?.['electron-workspace-root-labels'])
+    const result = new Map<string, string>()
+    for (const [rootPath, label] of Object.entries(labels ?? {})) {
+      if (typeof label !== 'string') continue
+      const key = normalizePathKey(rootPath)
+      const normalizedLabel = label.trim()
+      if (key && normalizedLabel) result.set(key, normalizedLabel)
+    }
+    return result
+  } catch {
+    return new Map()
+  }
+}
+
+function formatThreadProjectName(
+  cwd: string,
+  labelsByPath: Map<string, string>,
+): string {
+  const normalizedCwd = cwd.trim()
+  if (!normalizedCwd) return 'project'
+
+  const label = labelsByPath.get(normalizePathKey(normalizedCwd))
+  if (label) return label
+
+  return getPathLeaf(normalizedCwd) || normalizedCwd
 }
 
 function getErrorMessage(payload: unknown, fallback: string): string {
@@ -594,7 +650,7 @@ export class FeishuThreadBridge {
     await this.sendGroupedThreadCard(chatId, groups)
   }
 
-  private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: Array<{ id: string; title: string; cwd: string }> }>> {
+  private async listRecentThreadGroups(): Promise<Array<{ project: string; threads: FeishuRecentThread[] }>> {
     const allRows: unknown[] = []
     let cursor: string | null = null
 
@@ -614,9 +670,7 @@ export class FeishuThreadBridge {
         : null
     } while (cursor)
 
-    const groupMap = new Map<string, Array<{ id: string; title: string; cwd: string }>>()
-    const groupOrder: string[] = []
-
+    const threads: FeishuRecentThread[] = []
     for (const row of allRows) {
       const record = asRecord(row)
       const id = typeof record?.id === 'string' ? record.id.trim() : ''
@@ -624,18 +678,27 @@ export class FeishuThreadBridge {
       const name = typeof record?.name === 'string' ? record.name.trim() : ''
       const preview = typeof record?.preview === 'string' ? record.preview.trim() : ''
       const cwd = typeof record?.cwd === 'string' ? record.cwd.trim() : ''
-      const projectName = cwd ? basename(cwd) : 'project'
       const threadTitle = (name || preview || id).replace(/\s+/g, ' ').trim()
+      threads.push({ id, title: threadTitle.slice(0, 48), cwd })
+    }
 
-      if (!groupMap.has(projectName)) {
-        groupMap.set(projectName, [])
-        groupOrder.push(projectName)
+    const labelsByPath = await readWorkspaceRootLabels()
+    const groupMap = new Map<string, FeishuRecentThread[]>()
+    const groupNameByKey = new Map<string, string>()
+    const groupOrder: string[] = []
+
+    for (const thread of threads) {
+      const groupKey = thread.cwd ? normalizePathKey(thread.cwd) : 'project'
+      if (!groupMap.has(groupKey)) {
+        groupMap.set(groupKey, [])
+        groupNameByKey.set(groupKey, formatThreadProjectName(thread.cwd, labelsByPath))
+        groupOrder.push(groupKey)
       }
-      groupMap.get(projectName)!.push({ id, title: threadTitle.slice(0, 48), cwd })
+      groupMap.get(groupKey)!.push(thread)
     }
 
     return groupOrder
-      .map((project) => ({ project, threads: groupMap.get(project) ?? [] }))
+      .map((groupKey) => ({ project: groupNameByKey.get(groupKey) ?? groupKey, threads: groupMap.get(groupKey) ?? [] }))
       .filter((group) => group.threads.length > 0)
   }
 

--- a/src/server/feishuThreadBridge.ts
+++ b/src/server/feishuThreadBridge.ts
@@ -1,0 +1,658 @@
+import { basename } from 'node:path'
+import * as lark from '@larksuiteoapi/node-sdk'
+
+type AppServerLike = {
+  rpc: (method: string, params: unknown) => Promise<unknown>
+  onNotification: (listener: (value: { method: string; params: unknown }) => void) => () => void
+}
+
+type FeishuThreadBridgeOptions = {
+  onChatSeen?: (chatId: string) => void
+}
+
+export type FeishuBridgeStatus = {
+  configured: boolean
+  active: boolean
+  mappedChats: number
+  mappedThreads: number
+  allowedUsers: number
+  allowAllUsers: boolean
+  lastError: string
+}
+
+type FeishuBotCommand = {
+  command: string
+  description: string
+}
+
+const FEISHU_MESSAGE_MAX_LENGTH = 3500
+const FEISHU_BOT_COMMANDS: FeishuBotCommand[] = [
+  { command: 'start', description: 'Show quick start and thread picker' },
+  { command: 'threads', description: 'List recent threads to connect' },
+  { command: 'newthread', description: 'Create and connect a new thread' },
+  { command: 'thread', description: 'Connect existing thread: /thread <id>' },
+  { command: 'current', description: 'Show currently connected thread' },
+  { command: 'history', description: 'Show recent history for current thread' },
+  { command: 'status', description: 'Show bridge and mapping status' },
+  { command: 'whoami', description: 'Show your Feishu IDs' },
+  { command: 'help', description: 'Show available commands' },
+]
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function getErrorMessage(payload: unknown, fallback: string): string {
+  if (payload instanceof Error && payload.message.trim().length > 0) {
+    return payload.message
+  }
+  const record = asRecord(payload)
+  if (!record) return fallback
+  const error = record.error
+  if (typeof error === 'string' && error.length > 0) return error
+  const nestedError = asRecord(error)
+  if (nestedError && typeof nestedError.message === 'string' && nestedError.message.length > 0) {
+    return nestedError.message
+  }
+  return fallback
+}
+
+type NormalizedFeishuAllowlist = {
+  allowAllUsers: boolean
+  allowedUserIds: string[]
+}
+
+function normalizeFeishuAllowlist(values: unknown): NormalizedFeishuAllowlist {
+  const rawValues = Array.isArray(values) ? values : []
+  const allowAllUsers = rawValues.some((value) => typeof value === 'string' && value.trim() === '*')
+  const allowedUserIds = Array.from(new Set(rawValues
+    .map((value) => {
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim()
+      }
+      return ''
+    })
+    .filter((value) => value.length > 0))).slice(0, 100)
+  return { allowAllUsers, allowedUserIds }
+}
+
+function splitFeishuText(text: string, maxLength = FEISHU_MESSAGE_MAX_LENGTH): string[] {
+  const normalized = text.replace(/\r\n/g, '\n').trim()
+  if (!normalized) return []
+  if (normalized.length <= maxLength) return [normalized]
+
+  const chunks: string[] = []
+  let remaining = normalized
+
+  while (remaining.length > maxLength) {
+    let splitIndex = remaining.lastIndexOf('\n\n', maxLength)
+    if (splitIndex < Math.floor(maxLength * 0.5)) {
+      splitIndex = remaining.lastIndexOf('\n', maxLength)
+    }
+    if (splitIndex < Math.floor(maxLength * 0.5)) {
+      splitIndex = remaining.lastIndexOf(' ', maxLength)
+    }
+    if (splitIndex <= 0) {
+      splitIndex = maxLength
+    }
+    const chunk = remaining.slice(0, splitIndex).trim()
+    if (chunk) chunks.push(chunk)
+    remaining = remaining.slice(splitIndex).trim()
+  }
+
+  if (remaining) chunks.push(remaining)
+  return chunks
+}
+
+export class FeishuThreadBridge {
+  private appId: string
+  private appSecret: string
+  private readonly appServer: AppServerLike
+  private readonly defaultCwd: string
+  private allowAllUsers = false
+  private allowedUserIds = new Set<string>()
+  private readonly threadIdByChatId = new Map<string, string>()
+  private readonly chatIdsByThreadId = new Map<string, Set<string>>()
+  private readonly lastForwardedTurnByThreadId = new Map<string, string>()
+  private active = false
+  private lastError = ''
+  private readonly onChatSeen?: (chatId: string) => void
+  private client: lark.Client | null = null
+  private wsClient: lark.WSClient | null = null
+  private unsubscribeNotifications: (() => void) | null = null
+
+  constructor(appServer: AppServerLike, options: FeishuThreadBridgeOptions = {}) {
+    this.appServer = appServer
+    this.appId = process.env.FEISHU_APP_ID?.trim() ?? ''
+    this.appSecret = process.env.FEISHU_APP_SECRET?.trim() ?? ''
+    this.defaultCwd = process.env.FEISHU_DEFAULT_CWD?.trim() ?? process.cwd()
+    this.configureAllowedUserIds(
+      (process.env.FEISHU_ALLOWED_USER_IDS ?? '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean),
+    )
+    this.onChatSeen = options.onChatSeen
+  }
+
+  start(): void {
+    if (!this.appId || !this.appSecret || this.active) return
+    this.active = true
+
+    this.client = new lark.Client({
+      appId: this.appId,
+      appSecret: this.appSecret,
+      appType: lark.AppType.SelfBuild,
+      domain: lark.Domain.Feishu,
+    })
+
+    const eventDispatcher = new lark.EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: unknown) => {
+        await this.handleMessageEvent(data).catch((error) => {
+          this.lastError = getErrorMessage(error, 'Failed to handle message event')
+        })
+      },
+      'card.action.trigger': async (data: unknown) => {
+        await this.handleCardAction(data).catch((error) => {
+          this.lastError = getErrorMessage(error, 'Failed to handle card action')
+        })
+      },
+    })
+
+    this.wsClient = new lark.WSClient({
+      appId: this.appId,
+      appSecret: this.appSecret,
+      loggerLevel: lark.LoggerLevel.warn,
+    })
+
+    this.wsClient.start({ eventDispatcher })
+
+    this.unsubscribeNotifications = this.appServer.onNotification((notification) => {
+      void this.handleNotification(notification).catch(() => {})
+    })
+
+    void this.notifyOnlineForKnownChats().catch(() => {})
+  }
+
+  stop(): void {
+    this.active = false
+    this.unsubscribeNotifications?.()
+    this.unsubscribeNotifications = null
+    this.client = null
+    this.wsClient = null
+  }
+
+  configureApp(appId: string, appSecret: string): void {
+    const normalizedAppId = appId.trim()
+    const normalizedAppSecret = appSecret.trim()
+    if (!normalizedAppId) throw new Error('Feishu App ID is required')
+    if (!normalizedAppSecret) throw new Error('Feishu App Secret is required')
+    this.appId = normalizedAppId
+    this.appSecret = normalizedAppSecret
+  }
+
+  getStatus(): FeishuBridgeStatus {
+    return {
+      configured: this.appId.length > 0 && this.appSecret.length > 0,
+      active: this.active,
+      mappedChats: this.threadIdByChatId.size,
+      mappedThreads: this.chatIdsByThreadId.size,
+      allowedUsers: this.allowedUserIds.size,
+      allowAllUsers: this.allowAllUsers,
+      lastError: this.lastError,
+    }
+  }
+
+  configureAllowedUserIds(allowedUserIds: unknown): void {
+    const normalized = normalizeFeishuAllowlist(allowedUserIds)
+    this.allowAllUsers = normalized.allowAllUsers
+    this.allowedUserIds = new Set(normalized.allowedUserIds)
+  }
+
+  connectThread(threadId: string, chatId: string): void {
+    const normalizedThreadId = threadId.trim()
+    if (!normalizedThreadId) throw new Error('threadId is required')
+    const normalizedChatId = chatId.trim()
+    if (!normalizedChatId) throw new Error('chatId is required')
+    if (!this.appId || !this.appSecret) throw new Error('Feishu app credentials are not configured')
+    this.bindChatToThread(normalizedChatId, normalizedThreadId)
+    this.markChatSeen(normalizedChatId)
+    if (!this.active) this.start()
+    void this.sendOnlineMessage(normalizedChatId).catch(() => {})
+  }
+
+  private markChatSeen(chatId: string): void {
+    if (!chatId) return
+    this.onChatSeen?.(chatId)
+  }
+
+  private async sendFeishuMessage(
+    chatId: string,
+    text: string,
+    options: { buttons?: Array<{ text: string; value: string }> } = {},
+  ): Promise<void> {
+    if (!this.client) return
+    const chunks = splitFeishuText(text)
+    if (chunks.length === 0) return
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index]
+      const isLast = index === chunks.length - 1
+      if (isLast && options.buttons && options.buttons.length > 0) {
+        await this.sendCardMessage(chatId, chunk, options.buttons)
+      } else {
+        await this.sendTextMessage(chatId, chunk)
+      }
+    }
+  }
+
+  private async sendTextMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) return
+    await this.client.im.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        content: JSON.stringify({ text }),
+        msg_type: 'text',
+      },
+    })
+  }
+
+  private async sendCardMessage(
+    chatId: string,
+    text: string,
+    buttons: Array<{ text: string; value: string }>,
+  ): Promise<void> {
+    if (!this.client) return
+    const elements: unknown[] = [
+      { tag: 'markdown', content: text },
+    ]
+    if (buttons.length > 0) {
+      elements.push({
+        tag: 'action',
+        actions: buttons.map((btn) => ({
+          tag: 'button',
+          text: { content: btn.text, tag: 'plain_text' },
+          type: 'primary',
+          value: { threadId: btn.value },
+        })),
+      })
+    }
+    await this.client.im.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        content: JSON.stringify({
+          header: {
+            template: 'blue',
+            title: { content: 'Codex Thread Bridge', tag: 'plain_text' },
+          },
+          elements,
+        }),
+        msg_type: 'interactive',
+      },
+    })
+  }
+
+  private async sendOnlineMessage(chatId: string): Promise<void> {
+    await this.sendFeishuMessage(chatId, 'Codex thread bridge went online.')
+  }
+
+  private async notifyOnlineForKnownChats(): Promise<void> {
+    const knownChatIds = Array.from(this.threadIdByChatId.keys())
+    for (const chatId of knownChatIds) {
+      await this.sendOnlineMessage(chatId)
+    }
+  }
+
+  private async handleMessageEvent(data: unknown): Promise<void> {
+    const record = asRecord(data)
+    if (!record) return
+    const message = asRecord(record.message)
+    if (!message) return
+
+    const chatId = typeof message.chat_id === 'string' ? message.chat_id : ''
+    const sender = asRecord(record.sender)
+    const senderId = typeof sender?.sender_id === 'object'
+      ? (asRecord(sender.sender_id)?.open_id as string ?? '')
+      : ''
+    const msgType = typeof message.message_type === 'string' ? message.message_type : ''
+
+    if (!chatId) return
+
+    if (msgType === 'interactive') {
+      return
+    }
+
+    if (msgType !== 'text') {
+      await this.sendFeishuMessage(chatId, 'Only text messages are supported.')
+      return
+    }
+
+    let text = ''
+    try {
+      const content = typeof message.content === 'string' ? JSON.parse(message.content) : {}
+      text = typeof content.text === 'string' ? content.text.trim() : ''
+    } catch {
+      return
+    }
+    if (!text) return
+
+    if (!this.isAllowedSender(senderId)) {
+      await this.sendFeishuMessage(chatId, this.unauthorizedMessage(senderId))
+      return
+    }
+    this.markChatSeen(chatId)
+
+    const atMentionRegex = /@_user_\d+\s*/g
+    text = text.replace(atMentionRegex, '').trim()
+
+    if (text === '/start') {
+      await this.sendFeishuMessage(chatId, this.helpMessage())
+      await this.sendThreadPicker(chatId)
+      return
+    }
+
+    if (text === '/threads') {
+      await this.sendThreadPicker(chatId)
+      return
+    }
+
+    if (text === '/newthread') {
+      const threadId = await this.createThreadForChat(chatId)
+      await this.sendFeishuMessage(chatId, `Mapped to new thread: ${threadId}`)
+      return
+    }
+
+    const threadCommand = text.match(/^\/thread\s+(\S+)$/)
+    if (threadCommand) {
+      const threadId = threadCommand[1]
+      this.bindChatToThread(chatId, threadId)
+      await this.sendFeishuMessage(chatId, `Mapped to thread: ${threadId}`)
+      return
+    }
+
+    if (text === '/current') {
+      const threadId = this.threadIdByChatId.get(chatId)
+      await this.sendFeishuMessage(chatId, threadId
+        ? `Current thread: ${threadId}`
+        : 'No thread is connected for this chat yet. Use /threads, /newthread, or /thread <id>.')
+      return
+    }
+
+    if (text === '/history') {
+      const threadId = this.threadIdByChatId.get(chatId)
+      if (!threadId) {
+        await this.sendFeishuMessage(chatId, 'No thread is connected for this chat yet. Use /threads or /newthread first.')
+        return
+      }
+      const history = await this.readThreadHistorySummary(threadId)
+      await this.sendFeishuMessage(chatId, history)
+      return
+    }
+
+    if (text === '/status') {
+      const status = this.getStatus()
+      const mappedThreadId = this.threadIdByChatId.get(chatId) ?? 'none'
+      await this.sendFeishuMessage(
+        chatId,
+        [
+          '**Bridge status**',
+          `configured: ${String(status.configured)}`,
+          `active: ${String(status.active)}`,
+          `mapped chats: ${String(status.mappedChats)}`,
+          `mapped threads: ${String(status.mappedThreads)}`,
+          `allowed users: ${String(status.allowedUsers)}`,
+          `allow all users: ${String(status.allowAllUsers)}`,
+          `chat ${chatId} thread: ${mappedThreadId}`,
+          status.lastError ? `last error: ${status.lastError}` : '',
+        ].filter(Boolean).join('\n'),
+      )
+      return
+    }
+
+    if (text === '/whoami') {
+      const normalizedSenderId = senderId || 'unknown'
+      await this.sendFeishuMessage(
+        chatId,
+        [
+          '**Identity**',
+          `feishu open_id: ${normalizedSenderId}`,
+          `chat_id: ${chatId}`,
+          `authorized: ${String(this.isAllowedSender(senderId))}`,
+          this.allowAllUsers ? 'allowlist mode: *' : 'allowlist mode: explicit ids',
+        ].join('\n'),
+      )
+      return
+    }
+
+    if (text === '/help') {
+      await this.sendFeishuMessage(chatId, this.helpMessage())
+      return
+    }
+
+    const threadId = await this.ensureThreadForChat(chatId)
+    try {
+      await this.appServer.rpc('turn/start', {
+        threadId,
+        input: [{ type: 'text', text }],
+      })
+    } catch (error) {
+      const message = getErrorMessage(error, 'Failed to forward message to thread')
+      await this.sendFeishuMessage(chatId, `Forward failed: ${message}`)
+    }
+  }
+
+  private async handleCardAction(data: unknown): Promise<void> {
+    const record = asRecord(data)
+    if (!record) return
+
+    const operator = asRecord(record.operator)
+    const senderId = typeof operator?.open_id === 'string' ? operator.open_id : ''
+    if (!this.isAllowedSender(senderId)) return
+
+    const action = asRecord(record.action)
+    const value = asRecord(action?.value)
+    const threadId = typeof value?.threadId === 'string' ? value.threadId.trim() : ''
+    if (!threadId) return
+
+    const context = asRecord(record.context)
+    const chatId = typeof context?.open_chat_id === 'string' ? context.open_chat_id : ''
+    if (!chatId) return
+
+    this.bindChatToThread(chatId, threadId)
+    this.markChatSeen(chatId)
+    await this.sendFeishuMessage(chatId, `Connected to thread: ${threadId}`)
+    const history = await this.readThreadHistorySummary(threadId)
+    if (history) {
+      await this.sendFeishuMessage(chatId, history)
+    }
+  }
+
+  private isAllowedSender(senderId: string): boolean {
+    if (!senderId) return false
+    if (this.allowAllUsers) return true
+    return this.allowedUserIds.has(senderId)
+  }
+
+  private unauthorizedMessage(senderId: string): string {
+    const normalizedSenderId = senderId || 'unknown'
+    return `Unauthorized sender.\n\nYour Feishu open_id: ${normalizedSenderId}\nAdd this ID to the bot allowlist before using the bridge.`
+  }
+
+  private helpMessage(): string {
+    const rows = FEISHU_BOT_COMMANDS.map((command) => `/${command.command} - ${command.description}`)
+    return ['**Available commands**', ...rows].join('\n')
+  }
+
+  private async sendThreadPicker(chatId: string): Promise<void> {
+    const threads = await this.listRecentThreads()
+    if (threads.length === 0) {
+      await this.sendFeishuMessage(chatId, 'No threads found. Send /newthread to create one.')
+      return
+    }
+
+    const buttons = threads.map((thread) => ({
+      text: thread.title,
+      value: thread.id,
+    }))
+
+    await this.sendFeishuMessage(chatId, 'Select a thread to connect:', { buttons })
+  }
+
+  private async listRecentThreads(): Promise<Array<{ id: string; title: string }>> {
+    const payload = asRecord(await this.appServer.rpc('thread/list', {
+      archived: false,
+      limit: 20,
+      sortKey: 'updated_at',
+      modelProviders: [],
+    }))
+    const rows = Array.isArray(payload?.data) ? payload.data : []
+    const threads: Array<{ id: string; title: string }> = []
+    for (const row of rows) {
+      const record = asRecord(row)
+      const id = typeof record?.id === 'string' ? record.id.trim() : ''
+      if (!id) continue
+      const name = typeof record?.name === 'string' ? record.name.trim() : ''
+      const preview = typeof record?.preview === 'string' ? record.preview.trim() : ''
+      const cwd = typeof record?.cwd === 'string' ? record.cwd.trim() : ''
+      const projectName = cwd ? basename(cwd) : 'project'
+      const threadTitle = (name || preview || id).replace(/\s+/g, ' ').trim()
+      const title = `${projectName}/${threadTitle}`.slice(0, 64)
+      threads.push({ id, title })
+    }
+    return threads
+  }
+
+  private async createThreadForChat(chatId: string): Promise<string> {
+    const response = asRecord(await this.appServer.rpc('thread/start', { cwd: this.defaultCwd }))
+    const thread = asRecord(response?.thread)
+    const threadId = typeof thread?.id === 'string' ? thread.id : ''
+    if (!threadId) {
+      throw new Error('thread/start did not return thread id')
+    }
+    this.bindChatToThread(chatId, threadId)
+    return threadId
+  }
+
+  private async ensureThreadForChat(chatId: string): Promise<string> {
+    const existing = this.threadIdByChatId.get(chatId)
+    if (existing) return existing
+    return this.createThreadForChat(chatId)
+  }
+
+  private bindChatToThread(chatId: string, threadId: string): void {
+    const previousThreadId = this.threadIdByChatId.get(chatId)
+    if (previousThreadId && previousThreadId !== threadId) {
+      const previousSet = this.chatIdsByThreadId.get(previousThreadId)
+      previousSet?.delete(chatId)
+      if (previousSet && previousSet.size === 0) {
+        this.chatIdsByThreadId.delete(previousThreadId)
+      }
+    }
+    this.threadIdByChatId.set(chatId, threadId)
+    const chatIds = this.chatIdsByThreadId.get(threadId) ?? new Set<string>()
+    chatIds.add(chatId)
+    this.chatIdsByThreadId.set(threadId, chatIds)
+  }
+
+  private extractThreadId(notification: { method: string; params: unknown }): string {
+    const params = asRecord(notification.params)
+    if (!params) return ''
+    const directThreadId = typeof params.threadId === 'string' ? params.threadId : ''
+    if (directThreadId) return directThreadId
+    const turn = asRecord(params.turn)
+    const turnThreadId = typeof turn?.threadId === 'string' ? turn.threadId : ''
+    return turnThreadId
+  }
+
+  private extractTurnId(notification: { method: string; params: unknown }): string {
+    const params = asRecord(notification.params)
+    if (!params) return ''
+    const directTurnId = typeof params.turnId === 'string' ? params.turnId : ''
+    if (directTurnId) return directTurnId
+    const turn = asRecord(params.turn)
+    const turnId = typeof turn?.id === 'string' ? turn.id : ''
+    return turnId
+  }
+
+  private async handleNotification(notification: { method: string; params: unknown }): Promise<void> {
+    if (notification.method !== 'turn/completed') return
+    const threadId = this.extractThreadId(notification)
+    if (!threadId) return
+    const chatIds = this.chatIdsByThreadId.get(threadId)
+    if (!chatIds || chatIds.size === 0) return
+
+    const turnId = this.extractTurnId(notification)
+    const lastForwardedTurnId = this.lastForwardedTurnByThreadId.get(threadId)
+    if (turnId && lastForwardedTurnId === turnId) return
+
+    const assistantReply = await this.readLatestAssistantMessage(threadId)
+    if (!assistantReply) return
+    const chatIdList = Array.from(chatIds)
+    for (const chatId of chatIdList) {
+      await this.sendFeishuMessage(chatId, assistantReply)
+    }
+    if (turnId) {
+      this.lastForwardedTurnByThreadId.set(threadId, turnId)
+    }
+  }
+
+  private async readLatestAssistantMessage(threadId: string): Promise<string> {
+    const response = asRecord(await this.appServer.rpc('thread/read', { threadId, includeTurns: true }))
+    const thread = asRecord(response?.thread)
+    const turns = Array.isArray(thread?.turns) ? thread.turns : []
+
+    for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
+      const turn = asRecord(turns[turnIndex])
+      const items = Array.isArray(turn?.items) ? turn.items : []
+      for (let itemIndex = items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+        const item = asRecord(items[itemIndex])
+        if (item?.type === 'agentMessage') {
+          const text = typeof item.text === 'string' ? item.text.trim() : ''
+          if (text) return text
+        }
+      }
+    }
+    return ''
+  }
+
+  private async readThreadHistorySummary(threadId: string): Promise<string> {
+    const response = asRecord(await this.appServer.rpc('thread/read', { threadId, includeTurns: true }))
+    const thread = asRecord(response?.thread)
+    const turns = Array.isArray(thread?.turns) ? thread.turns : []
+    const historyRows: string[] = []
+
+    for (const turn of turns) {
+      const turnRecord = asRecord(turn)
+      const items = Array.isArray(turnRecord?.items) ? turnRecord.items : []
+      for (const item of items) {
+        const itemRecord = asRecord(item)
+        const type = typeof itemRecord?.type === 'string' ? itemRecord.type : ''
+        if (type === 'userMessage') {
+          const content = Array.isArray(itemRecord?.content) ? itemRecord.content : []
+          for (const block of content) {
+            const blockRecord = asRecord(block)
+            if (blockRecord?.type === 'text' && typeof blockRecord.text === 'string' && blockRecord.text.trim()) {
+              historyRows.push(`User: ${blockRecord.text.trim()}`)
+            }
+          }
+        }
+        if (type === 'agentMessage' && typeof itemRecord?.text === 'string' && itemRecord.text.trim()) {
+          historyRows.push(`Assistant: ${itemRecord.text.trim()}`)
+        }
+      }
+    }
+
+    if (historyRows.length === 0) {
+      return 'Thread has no message history yet.'
+    }
+
+    const tail = historyRows.slice(-12).join('\n\n')
+    const maxLen = 3800
+    const summary = tail.length > maxLen ? tail.slice(tail.length - maxLen) : tail
+    return `Recent history:\n\n${summary}`
+  }
+}


### PR DESCRIPTION
## Summary

Add Feishu Thread Bridge support for both domestic Feishu and international Lark.

This lets users choose which platform their bot belongs to, so the bridge can connect through either the Feishu API domain or the Lark international API domain.

## What Changed

- Added a Feishu / Lark platform selector in the app settings panel.
- Added `domain` to the Feishu bridge config API, persisted config, and status response.
- Defaulted existing/missing configs to `feishu` for backward compatibility.
- Added `FEISHU_DOMAIN` environment support for startup configuration.
- Configured both the Feishu REST client and WebSocket client with the selected SDK domain.
- Restarted the bridge client when App ID, App Secret, or platform changes, so switching between Feishu and Lark takes effect immediately after saving.

## Compatibility

Existing domestic Feishu setups continue to work without config changes because missing `domain` values default to `feishu`.

## Performance Notes

This change only adds a small config normalization path and passes the selected domain into SDK client construction. It does not add duplicate requests, polling, large payloads, or new fanout. The bridge only reconnects when credentials or platform change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Feishu/Lark bot bridging for bidirectional messaging.
  * Added Feishu bridge controls to the settings UI, including domain selection, app credentials, allowed-user configuration, and save flow.
  * Added bridge status reporting and command support for interacting with threads and history.
* **Documentation**
  * Updated the README with Feishu Bot Bridge (Optional) setup instructions, permissions/events, required environment variables, and supported commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->