### PR TITLE
Add app-server thread Goal mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1012,6 +1012,14 @@
                     @hide="onHideSelectedThreadTerminal"
                     @terminal-focus-change="onTerminalFocusChange"
                   />
+                  <ThreadGoalBar
+                    v-if="selectedThreadGoal"
+                    :goal="selectedThreadGoal"
+                    :disabled="isUpdatingThreadGoal"
+                    @edit="onEditThreadGoal"
+                    @toggle-paused="onToggleThreadGoalPaused"
+                    @clear="onClearThreadGoal"
+                  />
                   <ThreadPendingRequestPanel
                     v-if="selectedThreadPendingRequest"
                     :request="selectedThreadPendingRequest"
@@ -1173,6 +1181,7 @@ import DesktopLayout from './components/layout/DesktopLayout.vue'
 import SidebarThreadTree from './components/sidebar/SidebarThreadTree.vue'
 import ContentHeader from './components/content/ContentHeader.vue'
 import ThreadComposer from './components/content/ThreadComposer.vue'
+import ThreadGoalBar from './components/content/ThreadGoalBar.vue'
 import ThreadPendingRequestPanel from './components/content/ThreadPendingRequestPanel.vue'
 import QueuedMessages from './components/content/QueuedMessages.vue'
 import RateLimitStatus from './components/content/RateLimitStatus.vue'
@@ -1411,6 +1420,7 @@ const {
   projectDisplayNameById,
   selectedThread,
   selectedThreadTokenUsage,
+  selectedThreadGoal,
   selectedThreadTerminalOpen,
   selectedThreadServerRequests,
   selectedLiveOverlay,
@@ -1469,6 +1479,9 @@ const {
   stopPolling,
   primeSelectedThread,
   rollbackSelectedThread,
+  updateSelectedThreadGoalObjective,
+  toggleSelectedThreadGoalPaused,
+  clearSelectedThreadGoal,
 } = useDesktopState()
 
 const route = useRoute()
@@ -1506,6 +1519,7 @@ function prepareFeedbackLink(event: MouseEvent, message?: string): void {
 }
 const homeThreadComposerRef = ref<ThreadComposerExposed | null>(null)
 const threadComposerRef = ref<ThreadComposerExposed | null>(null)
+const isUpdatingThreadGoal = ref(false)
 const threadConversationRef = ref<{ jumpToLatest: () => void } | null>(null)
 const homeTerminalPanelRef = ref<ThreadTerminalPanelExposed | null>(null)
 const threadTerminalPanelRef = ref<ThreadTerminalPanelExposed | null>(null)
@@ -3428,6 +3442,31 @@ function onSubmitThreadMessage(payload: { text: string; imageUrls: string[]; fil
     return
   }
   void sendMessageToSelectedThread(text, payload.imageUrls, payload.skills, payload.mode, payload.fileAttachments, queueInsertIndex)
+}
+
+async function runThreadGoalUpdate(update: () => Promise<void>): Promise<void> {
+  if (isUpdatingThreadGoal.value) return
+  isUpdatingThreadGoal.value = true
+  try {
+    await update()
+  } catch {
+    // The shared desktop error state already contains the app-server failure.
+  } finally {
+    isUpdatingThreadGoal.value = false
+  }
+}
+
+function onEditThreadGoal(objective: string): void {
+  void runThreadGoalUpdate(() => updateSelectedThreadGoalObjective(objective))
+}
+
+function onToggleThreadGoalPaused(): void {
+  void runThreadGoalUpdate(toggleSelectedThreadGoalPaused)
+}
+
+function onClearThreadGoal(): void {
+  if (!window.confirm('Clear this thread goal?')) return
+  void runThreadGoalUpdate(clearSelectedThreadGoal)
 }
 
 function onEditQueuedMessage(messageId: string): void {

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clearThreadGoal,
+  compactThread,
   getAvailableModelIds,
   getThreadDetail,
   getThreadGoal,
@@ -105,6 +106,22 @@ describe('thread goal RPCs', () => {
       { method: 'thread/goal/get', params: { threadId: 'thread-1' } },
       { method: 'thread/goal/set', params: { threadId: 'thread-1', status: 'paused' } },
       { method: 'thread/goal/clear', params: { threadId: 'thread-1' } },
+    ])
+  })
+})
+
+describe('thread compaction RPC', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts app-server compaction for the selected thread', async () => {
+    const { requests } = mockRpcFetch()
+
+    await compactThread('thread-compact')
+
+    expect(requests).toEqual([
+      { method: 'thread/compact/start', params: { threadId: 'thread-compact' } },
     ])
   })
 })

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getAvailableModelIds, getThreadDetail, listDirectoryComposioConnectors, resumeThread, startThreadTurn } from './codexGateway'
+import {
+  clearThreadGoal,
+  getAvailableModelIds,
+  getThreadDetail,
+  getThreadGoal,
+  listDirectoryComposioConnectors,
+  resumeThread,
+  setThreadGoal,
+  startThreadTurn,
+} from './codexGateway'
 
 function mockRpcFetch(): { requests: Array<{ method: string, params: Record<string, unknown> }> } {
   const requests: Array<{ method: string, params: Record<string, unknown> }> = []
@@ -58,6 +67,45 @@ describe('startThreadTurn collaboration mode payloads', () => {
         developer_instructions: null,
       },
     })
+  })
+})
+
+describe('thread goal RPCs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes goal reads and sends lifecycle updates through app-server', async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = []
+    const goal = {
+      threadId: 'thread-1',
+      objective: 'Ship Goal mode',
+      status: 'active',
+      tokenBudget: 5000,
+      tokensUsed: 120,
+      timeUsedSeconds: 9,
+      createdAt: 10,
+      updatedAt: 11,
+    }
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { method: string; params: Record<string, unknown> }
+      requests.push(request)
+      const result = request.method === 'thread/goal/clear' ? { cleared: true } : { goal }
+      return new Response(JSON.stringify({ result }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    await expect(getThreadGoal('thread-1')).resolves.toEqual(goal)
+    await expect(setThreadGoal('thread-1', { status: 'paused' })).resolves.toEqual(goal)
+    await expect(clearThreadGoal('thread-1')).resolves.toBe(true)
+
+    expect(requests).toEqual([
+      { method: 'thread/goal/get', params: { threadId: 'thread-1' } },
+      { method: 'thread/goal/set', params: { threadId: 'thread-1', status: 'paused' } },
+      { method: 'thread/goal/clear', params: { threadId: 'thread-1' } },
+    ])
   })
 })
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -1603,6 +1603,10 @@ export async function archiveThread(threadId: string): Promise<void> {
   await callRpc('thread/archive', { threadId })
 }
 
+export async function compactThread(threadId: string): Promise<void> {
+  await callRpc('thread/compact/start', { threadId })
+}
+
 export async function renameThread(threadId: string, threadName: string): Promise<void> {
   await callRpc('thread/name/set', { threadId, name: threadName })
 }

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -40,6 +40,8 @@ import type {
   UiMessage,
   UiProjectGroup,
   UiThread,
+  UiThreadGoal,
+  ThreadGoalStatus,
   UiReviewAction,
   UiReviewActionLevel,
   UiReviewFile,
@@ -553,6 +555,57 @@ async function callRpc<T>(method: string, params?: unknown): Promise<T> {
   } catch (error) {
     throw normalizeCodexApiError(error, `RPC ${method} failed`, method)
   }
+}
+
+const THREAD_GOAL_STATUSES = new Set<ThreadGoalStatus>([
+  'active',
+  'paused',
+  'blocked',
+  'usageLimited',
+  'budgetLimited',
+  'complete',
+])
+
+export function normalizeThreadGoal(value: unknown): UiThreadGoal | null {
+  const record = asRecord(value)
+  if (!record) return null
+  const threadId = readString(record.threadId)
+  const objective = readString(record.objective)
+  const rawStatus = readString(record.status)
+  if (!threadId || objective === null || !rawStatus || !THREAD_GOAL_STATUSES.has(rawStatus as ThreadGoalStatus)) {
+    return null
+  }
+
+  return {
+    threadId,
+    objective,
+    status: rawStatus as ThreadGoalStatus,
+    tokenBudget: readNumber(record.tokenBudget),
+    tokensUsed: readNumber(record.tokensUsed) ?? 0,
+    timeUsedSeconds: readNumber(record.timeUsedSeconds) ?? 0,
+    createdAt: readNumber(record.createdAt) ?? 0,
+    updatedAt: readNumber(record.updatedAt) ?? 0,
+  }
+}
+
+export async function getThreadGoal(threadId: string): Promise<UiThreadGoal | null> {
+  const payload = await callRpc<{ goal?: unknown }>('thread/goal/get', { threadId })
+  return normalizeThreadGoal(payload.goal)
+}
+
+export async function setThreadGoal(
+  threadId: string,
+  update: { objective?: string | null; status?: ThreadGoalStatus | null; tokenBudget?: number | null },
+): Promise<UiThreadGoal> {
+  const payload = await callRpc<{ goal?: unknown }>('thread/goal/set', { threadId, ...update })
+  const goal = normalizeThreadGoal(payload.goal)
+  if (!goal) throw new Error('RPC thread/goal/set returned an invalid goal')
+  return goal
+}
+
+export async function clearThreadGoal(threadId: string): Promise<boolean> {
+  const payload = await callRpc<{ cleared?: boolean }>('thread/goal/clear', { threadId })
+  return payload.cleared === true
 }
 
 function normalizeFallbackFileChange(value: unknown): UiFileChange | null {

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -104,7 +104,7 @@
         >
           <div class="thread-composer-slash-heading">
             <span>Slash commands</span>
-            <span>Goal mode</span>
+            <span>Codex</span>
           </div>
           <button
             v-for="(option, index) in slashCommandSuggestions"
@@ -127,11 +127,11 @@
           </button>
           <div class="thread-composer-slash-help">↑↓ Navigate · Tab select · Esc close</div>
         </div>
-        <div v-else-if="isGoalCommandPreviewOpen && goalCommandPreview" class="thread-composer-command-preview" role="status">
+        <div v-else-if="isSlashCommandPreviewOpen && slashCommandPreview" class="thread-composer-command-preview" role="status">
           <span class="thread-composer-slash-icon" aria-hidden="true">◎</span>
           <span class="thread-composer-slash-copy">
-            <span class="thread-composer-slash-title"><strong>{{ goalCommandPreview.label }}</strong></span>
-            <span class="thread-composer-slash-description">{{ goalCommandPreview.description }}</span>
+            <span class="thread-composer-slash-title"><strong>{{ slashCommandPreview.label }}</strong></span>
+            <span class="thread-composer-slash-description">{{ slashCommandPreview.description }}</span>
           </span>
           <kbd>Enter</kbd>
         </div>
@@ -444,10 +444,10 @@ import { useDictation } from '../../composables/useDictation'
 import { useMobile } from '../../composables/useMobile'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import {
-  describeGoalCommand,
-  getGoalCommandSuggestions,
-  type GoalCommandOption,
-} from '../../utils/goalCommand'
+  describeSlashCommand,
+  getSlashCommandSuggestions,
+  type SlashCommandOption,
+} from '../../utils/slashCommand'
 import {
   createComposerPrompt,
   getComposerPrompts,
@@ -631,19 +631,19 @@ const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.
 const DRAFT_STORAGE_PREFIX = 'codex-web-local.thread-draft.v1.'
 let lastActiveThreadId = ''
 
-const slashCommandSuggestions = computed(() => getGoalCommandSuggestions(draft.value))
-const goalCommandPreview = computed(() => describeGoalCommand(draft.value))
+const slashCommandSuggestions = computed(() => getSlashCommandSuggestions(draft.value))
+const slashCommandPreview = computed(() => describeSlashCommand(draft.value))
 const isSlashCommandDismissed = computed(() => dismissedSlashCommandDraft.value === draft.value)
 const isSlashCommandMenuOpen = computed(() =>
   !isFileMentionOpen.value
   && !isSlashCommandDismissed.value
   && slashCommandSuggestions.value.length > 0,
 )
-const isGoalCommandPreviewOpen = computed(() =>
+const isSlashCommandPreviewOpen = computed(() =>
   !isFileMentionOpen.value
   && !isSlashCommandDismissed.value
   && slashCommandSuggestions.value.length === 0
-  && goalCommandPreview.value !== null,
+  && slashCommandPreview.value !== null,
 )
 
 const reasoningOptions: Array<{ value: ReasoningEffort; label: string }> = [
@@ -1637,8 +1637,9 @@ function onInputKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter') {
       const selected = slashCommandSuggestions.value[slashCommandHighlightedIndex.value]
       const normalizedDraft = draft.value.trim()
-      const isRunnableExact = draft.value === '/goal'
-        || (selected?.requiresArgument === false && selected.insertText.trim() === normalizedDraft)
+      const exactOption = describeSlashCommand(normalizedDraft)
+      const isRunnableExact = exactOption?.requiresArgument === false
+        && exactOption.insertText.trim() === normalizedDraft
       if (!isRunnableExact) {
         event.preventDefault()
         if (selected) applySlashCommandOption(selected)
@@ -1691,7 +1692,7 @@ function onInputKeydown(event: KeyboardEvent): void {
   }
 }
 
-function applySlashCommandOption(option: GoalCommandOption): void {
+function applySlashCommandOption(option: SlashCommandOption): void {
   draft.value = option.insertText
   dismissedSlashCommandDraft.value = option.insertText
   slashCommandHighlightedIndex.value = 0

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -96,6 +96,45 @@
         <div v-if="isDragActive" class="thread-composer-drop-overlay" aria-hidden="true">
           <span class="thread-composer-drop-overlay-copy">Drop images or files</span>
         </div>
+        <div
+          v-if="isSlashCommandMenuOpen"
+          class="thread-composer-slash-menu"
+          role="listbox"
+          aria-label="Slash commands"
+        >
+          <div class="thread-composer-slash-heading">
+            <span>Slash commands</span>
+            <span>Goal mode</span>
+          </div>
+          <button
+            v-for="(option, index) in slashCommandSuggestions"
+            :key="option.id"
+            class="thread-composer-slash-row"
+            :class="{ 'is-active': index === slashCommandHighlightedIndex }"
+            type="button"
+            role="option"
+            :aria-selected="index === slashCommandHighlightedIndex"
+            @mousedown.prevent="applySlashCommandOption(option)"
+          >
+            <span class="thread-composer-slash-icon" aria-hidden="true">◎</span>
+            <span class="thread-composer-slash-copy">
+              <span class="thread-composer-slash-title">
+                <strong>{{ option.label }}</strong>
+                <code>{{ option.command }}</code>
+              </span>
+              <span class="thread-composer-slash-description">{{ option.description }}</span>
+            </span>
+          </button>
+          <div class="thread-composer-slash-help">↑↓ Navigate · Tab select · Esc close</div>
+        </div>
+        <div v-else-if="isGoalCommandPreviewOpen && goalCommandPreview" class="thread-composer-command-preview" role="status">
+          <span class="thread-composer-slash-icon" aria-hidden="true">◎</span>
+          <span class="thread-composer-slash-copy">
+            <span class="thread-composer-slash-title"><strong>{{ goalCommandPreview.label }}</strong></span>
+            <span class="thread-composer-slash-description">{{ goalCommandPreview.description }}</span>
+          </span>
+          <kbd>Enter</kbd>
+        </div>
         <div v-if="isFileMentionOpen" class="thread-composer-file-mentions">
           <template v-if="fileMentionSuggestions.length > 0">
             <button
@@ -405,6 +444,11 @@ import { useDictation } from '../../composables/useDictation'
 import { useMobile } from '../../composables/useMobile'
 import { useUiLanguage } from '../../composables/useUiLanguage'
 import {
+  describeGoalCommand,
+  getGoalCommandSuggestions,
+  type GoalCommandOption,
+} from '../../utils/goalCommand'
+import {
   createComposerPrompt,
   getComposerPrompts,
   removeComposerPrompt,
@@ -572,6 +616,8 @@ const mentionQuery = ref('')
 const fileMentionSuggestions = ref<ComposerFileSuggestion[]>([])
 const isFileMentionOpen = ref(false)
 const fileMentionHighlightedIndex = ref(0)
+const slashCommandHighlightedIndex = ref(0)
+const dismissedSlashCommandDraft = ref('')
 const isComposerExpanded = ref(false)
 const isDraftOverflowing = ref(false)
 let composerOverflowMeasurementQueued = false
@@ -584,6 +630,21 @@ let attachmentSessionToken = 0
 const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)
 const DRAFT_STORAGE_PREFIX = 'codex-web-local.thread-draft.v1.'
 let lastActiveThreadId = ''
+
+const slashCommandSuggestions = computed(() => getGoalCommandSuggestions(draft.value))
+const goalCommandPreview = computed(() => describeGoalCommand(draft.value))
+const isSlashCommandDismissed = computed(() => dismissedSlashCommandDraft.value === draft.value)
+const isSlashCommandMenuOpen = computed(() =>
+  !isFileMentionOpen.value
+  && !isSlashCommandDismissed.value
+  && slashCommandSuggestions.value.length > 0,
+)
+const isGoalCommandPreviewOpen = computed(() =>
+  !isFileMentionOpen.value
+  && !isSlashCommandDismissed.value
+  && slashCommandSuggestions.value.length === 0
+  && goalCommandPreview.value !== null,
+)
 
 const reasoningOptions: Array<{ value: ReasoningEffort; label: string }> = [
   { value: 'none', label: 'None' },
@@ -1552,6 +1613,40 @@ function onInputChange(): void {
 }
 
 function onInputKeydown(event: KeyboardEvent): void {
+  if (isSlashCommandMenuOpen.value) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dismissedSlashCommandDraft.value = draft.value
+      return
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const size = slashCommandSuggestions.value.length
+      if (size > 0) {
+        const offset = event.key === 'ArrowDown' ? 1 : size - 1
+        slashCommandHighlightedIndex.value = (slashCommandHighlightedIndex.value + offset) % size
+      }
+      return
+    }
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      const selected = slashCommandSuggestions.value[slashCommandHighlightedIndex.value]
+      if (selected) applySlashCommandOption(selected)
+      return
+    }
+    if (event.key === 'Enter') {
+      const selected = slashCommandSuggestions.value[slashCommandHighlightedIndex.value]
+      const normalizedDraft = draft.value.trim()
+      const isRunnableExact = draft.value === '/goal'
+        || (selected?.requiresArgument === false && selected.insertText.trim() === normalizedDraft)
+      if (!isRunnableExact) {
+        event.preventDefault()
+        if (selected) applySlashCommandOption(selected)
+        return
+      }
+    }
+  }
+
   if (isFileMentionOpen.value) {
     if (event.key === 'Escape') {
       event.preventDefault()
@@ -1594,6 +1689,18 @@ function onInputKeydown(event: KeyboardEvent): void {
     onSubmit(props.isTurnInProgress ? activeInProgressMode.value : 'steer')
     return
   }
+}
+
+function applySlashCommandOption(option: GoalCommandOption): void {
+  draft.value = option.insertText
+  dismissedSlashCommandDraft.value = option.insertText
+  slashCommandHighlightedIndex.value = 0
+  void nextTick(() => {
+    const input = inputRef.value
+    input?.focus()
+    const cursor = option.insertText.length
+    input?.setSelectionRange(cursor, cursor)
+  })
 }
 
 function closeFileMention(): void {
@@ -1837,6 +1944,7 @@ watch(
   () => props.activeThreadId,
   (nextThreadId) => {
     cancelDictation()
+    dismissedSlashCommandDraft.value = ''
     if (lastActiveThreadId) {
       persistDraftForThread(lastActiveThreadId, getCurrentDraftPayload())
     }
@@ -1858,6 +1966,7 @@ watch([draft, selectedImages, fileAttachments, selectedSkills], () => {
 
 watch(draft, () => {
   queueComposerOverflowMeasurement()
+  slashCommandHighlightedIndex.value = 0
 })
 
 watch(
@@ -2043,6 +2152,58 @@ watch(
 
 .thread-composer-file-mentions {
   @apply absolute left-0 right-0 bottom-[calc(100%+8px)] z-40 max-h-52 overflow-y-auto rounded-xl border border-zinc-200 bg-white p-1 shadow-lg;
+}
+
+.thread-composer-slash-menu {
+  @apply absolute left-0 right-0 bottom-[calc(100%+8px)] z-40 max-h-80 overflow-y-auto rounded-xl border border-zinc-200 bg-white p-1 shadow-xl sm:max-h-[26rem];
+}
+
+.thread-composer-slash-heading {
+  @apply sticky top-0 z-10 flex items-center justify-between bg-white px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400;
+}
+
+.thread-composer-slash-row {
+  @apply flex w-full items-start gap-2 rounded-lg border-0 bg-transparent px-2 py-2 text-left text-zinc-700 transition hover:bg-amber-50;
+}
+
+.thread-composer-slash-row.is-active {
+  @apply bg-amber-50;
+}
+
+.thread-composer-slash-icon {
+  @apply mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm leading-none text-amber-700;
+}
+
+.thread-composer-slash-copy {
+  @apply min-w-0 flex-1;
+}
+
+.thread-composer-slash-title {
+  @apply flex min-w-0 items-baseline gap-2 text-xs text-zinc-900;
+}
+
+.thread-composer-slash-title strong {
+  @apply shrink-0 font-medium;
+}
+
+.thread-composer-slash-title code {
+  @apply truncate rounded bg-zinc-100 px-1 py-0.5 font-mono text-[10px] text-zinc-500;
+}
+
+.thread-composer-slash-description {
+  @apply mt-0.5 block text-[11px] leading-4 text-zinc-500;
+}
+
+.thread-composer-slash-help {
+  @apply sticky bottom-0 z-10 border-t border-zinc-100 bg-white px-2 pb-1 pt-1.5 text-[10px] text-zinc-400;
+}
+
+.thread-composer-command-preview {
+  @apply absolute left-0 right-0 bottom-[calc(100%+8px)] z-40 flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 shadow-lg;
+}
+
+.thread-composer-command-preview kbd {
+  @apply ml-auto mt-1 shrink-0 rounded border border-amber-200 bg-white px-1.5 py-0.5 font-sans text-[10px] text-amber-700 shadow-sm;
 }
 
 .thread-composer-file-mention-row {

--- a/src/components/content/ThreadGoalBar.vue
+++ b/src/components/content/ThreadGoalBar.vue
@@ -1,0 +1,303 @@
+<template>
+  <section class="thread-goal-bar" :class="`is-${goal.status}`" aria-label="Thread goal">
+    <div class="thread-goal-marker" aria-hidden="true">◎</div>
+    <div class="thread-goal-content">
+      <div class="thread-goal-heading">
+        <strong>Goal</strong>
+        <span class="thread-goal-status">{{ statusLabel }}</span>
+        <span v-if="usageLabel" class="thread-goal-usage">{{ usageLabel }}</span>
+      </div>
+      <form v-if="isEditing" class="thread-goal-edit" @submit.prevent="saveEdit">
+        <input
+          ref="editInputRef"
+          v-model="editedObjective"
+          class="thread-goal-input"
+          aria-label="Goal objective"
+          :disabled="disabled"
+          @keydown.escape.prevent="cancelEdit"
+        >
+        <button type="submit" class="thread-goal-action is-primary" :disabled="disabled || !editedObjective.trim()">Save</button>
+        <button type="button" class="thread-goal-action" :disabled="disabled" @click="cancelEdit">Cancel</button>
+      </form>
+      <p v-else class="thread-goal-objective" :title="goal.objective">{{ goal.objective }}</p>
+    </div>
+    <div v-if="!isEditing" class="thread-goal-actions">
+      <button type="button" class="thread-goal-action" :disabled="disabled" @click="beginEdit">Edit</button>
+      <button
+        v-if="goal.status === 'active' || goal.status === 'paused'"
+        type="button"
+        class="thread-goal-action"
+        :disabled="disabled"
+        @click="$emit('toggle-paused')"
+      >
+        {{ goal.status === 'paused' ? 'Resume' : 'Pause' }}
+      </button>
+      <button type="button" class="thread-goal-action is-danger" :disabled="disabled" @click="$emit('clear')">Clear</button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import type { UiThreadGoal } from '../../types/codex'
+
+const props = defineProps<{
+  goal: UiThreadGoal
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  edit: [objective: string]
+  'toggle-paused': []
+  clear: []
+}>()
+
+const isEditing = ref(false)
+const editedObjective = ref('')
+const editInputRef = ref<HTMLInputElement | null>(null)
+
+const statusLabel = computed(() => ({
+  active: 'Active',
+  paused: 'Paused',
+  blocked: 'Blocked',
+  usageLimited: 'Usage limited',
+  budgetLimited: 'Budget limited',
+  complete: 'Complete',
+}[props.goal.status]))
+
+const usageLabel = computed(() => {
+  if (props.goal.tokenBudget === null) return ''
+  return `${formatTokens(props.goal.tokensUsed)} / ${formatTokens(props.goal.tokenBudget)} tokens`
+})
+
+watch(() => props.goal.objective, (objective) => {
+  if (!isEditing.value) editedObjective.value = objective
+})
+
+function formatTokens(value: number): string {
+  if (value < 1000) return String(value)
+  if (value < 1_000_000) return `${Math.round(value / 100) / 10}k`
+  return `${Math.round(value / 100_000) / 10}m`
+}
+
+function beginEdit(): void {
+  editedObjective.value = props.goal.objective
+  isEditing.value = true
+  void nextTick(() => {
+    editInputRef.value?.focus()
+    editInputRef.value?.select()
+  })
+}
+
+function cancelEdit(): void {
+  editedObjective.value = props.goal.objective
+  isEditing.value = false
+}
+
+function saveEdit(): void {
+  const objective = editedObjective.value.trim()
+  if (!objective || props.disabled) return
+  emit('edit', objective)
+  isEditing.value = false
+}
+</script>
+
+<style scoped>
+.thread-goal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+  margin: 0 0.75rem 0.45rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid rgb(217 119 6 / 20%);
+  border-radius: 0.7rem;
+  background: rgb(255 251 235 / 86%);
+  color: #3f3f46;
+}
+
+.thread-goal-marker {
+  flex: 0 0 auto;
+  color: #d97706;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.thread-goal-content {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.thread-goal-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #71717a;
+  font-size: 0.68rem;
+  line-height: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.thread-goal-heading strong {
+  color: #a16207;
+}
+
+.thread-goal-status {
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: rgb(217 119 6 / 10%);
+}
+
+.thread-goal-usage {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-goal-objective {
+  overflow: hidden;
+  margin: 0.1rem 0 0;
+  color: #27272a;
+  font-size: 0.8rem;
+  line-height: 1.1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-goal-actions,
+.thread-goal-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.thread-goal-edit {
+  margin-top: 0.2rem;
+}
+
+.thread-goal-input {
+  min-width: 8rem;
+  flex: 1 1 auto;
+  border: 1px solid rgb(161 98 7 / 25%);
+  border-radius: 0.4rem;
+  background: rgb(255 255 255 / 75%);
+  padding: 0.25rem 0.4rem;
+  color: #27272a;
+  font-size: 0.8rem;
+  outline: none;
+}
+
+.thread-goal-input:focus {
+  border-color: rgb(217 119 6 / 55%);
+  box-shadow: 0 0 0 2px rgb(245 158 11 / 12%);
+}
+
+.thread-goal-action {
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 0.35rem;
+  background: transparent;
+  padding: 0.22rem 0.35rem;
+  color: #71717a;
+  font-size: 0.7rem;
+  line-height: 1rem;
+  cursor: pointer;
+}
+
+.thread-goal-action:hover:not(:disabled) {
+  background: rgb(217 119 6 / 9%);
+  color: #92400e;
+}
+
+.thread-goal-action.is-primary {
+  color: #a16207;
+}
+
+.thread-goal-action.is-danger:hover:not(:disabled) {
+  background: rgb(220 38 38 / 8%);
+  color: #b91c1c;
+}
+
+.thread-goal-action:disabled,
+.thread-goal-input:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.thread-goal-bar.is-paused,
+.thread-goal-bar.is-blocked,
+.thread-goal-bar.is-usageLimited,
+.thread-goal-bar.is-budgetLimited {
+  border-color: rgb(113 113 122 / 20%);
+  background: rgb(244 244 245 / 86%);
+}
+
+.thread-goal-bar.is-complete {
+  border-color: rgb(22 163 74 / 20%);
+  background: rgb(240 253 244 / 86%);
+}
+
+:global(:root.dark .thread-goal-bar) {
+  border-color: rgb(245 158 11 / 18%);
+  background: rgb(120 53 15 / 13%);
+  color: #d4d4d8;
+}
+
+:global(:root.dark .thread-goal-heading),
+:global(:root.dark .thread-goal-action) {
+  color: #a1a1aa;
+}
+
+:global(:root.dark .thread-goal-heading strong),
+:global(:root.dark .thread-goal-action.is-primary),
+:global(:root.dark .thread-goal-action:hover:not(:disabled)) {
+  color: #fbbf24;
+}
+
+:global(:root.dark .thread-goal-objective),
+:global(:root.dark .thread-goal-input) {
+  color: #f4f4f5;
+}
+
+:global(:root.dark .thread-goal-input) {
+  border-color: rgb(245 158 11 / 25%);
+  background: rgb(24 24 27 / 70%);
+}
+
+:global(:root.dark .thread-goal-bar.is-paused),
+:global(:root.dark .thread-goal-bar.is-blocked),
+:global(:root.dark .thread-goal-bar.is-usageLimited),
+:global(:root.dark .thread-goal-bar.is-budgetLimited) {
+  border-color: rgb(161 161 170 / 16%);
+  background: rgb(39 39 42 / 70%);
+}
+
+:global(:root.dark .thread-goal-bar.is-complete) {
+  border-color: rgb(74 222 128 / 18%);
+  background: rgb(20 83 45 / 20%);
+}
+
+@media (max-width: 640px) {
+  .thread-goal-bar {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    margin-inline: 0.5rem;
+  }
+
+  .thread-goal-actions {
+    width: 100%;
+    justify-content: flex-end;
+    padding-left: 1.8rem;
+  }
+
+  .thread-goal-edit {
+    flex-wrap: wrap;
+  }
+
+  .thread-goal-input {
+    width: 100%;
+    flex-basis: 100%;
+  }
+}
+</style>

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -13,6 +13,7 @@ import type { WorkspaceRootsState } from '../api/codexGateway'
 
 const gatewayMocks = vi.hoisted(() => ({
   archiveThread: vi.fn(),
+  compactThread: vi.fn(),
   forkThread: vi.fn(),
   getAccountRateLimits: vi.fn(),
   getAvailableCollaborationModes: vi.fn(),
@@ -40,6 +41,7 @@ const gatewayMocks = vi.hoisted(() => ({
   clearThreadGoal: vi.fn(),
   setWorkspaceRootsState: vi.fn(),
   startThread: vi.fn(),
+  startThreadReview: vi.fn(),
   startThreadTurn: vi.fn(),
   subscribeCodexNotifications: vi.fn(),
 }))
@@ -678,6 +680,50 @@ describe('thread goals', () => {
       status: 'active',
     })
     expect(gatewayMocks.startThreadTurn).not.toHaveBeenCalled()
+  })
+
+  it('executes Codex slash commands through native app-server methods', async () => {
+    installTestWindow()
+    gatewayMocks.compactThread.mockResolvedValue(undefined)
+    gatewayMocks.startThreadReview.mockResolvedValue(undefined)
+
+    const state = useDesktopState()
+    state.primeSelectedThread('thread-goal')
+
+    await state.sendMessageToSelectedThread('/compact')
+    await state.sendMessageToSelectedThread('/review')
+    await state.sendMessageToSelectedThread('/rename Release prep')
+
+    expect(gatewayMocks.compactThread).toHaveBeenCalledWith('thread-goal')
+    expect(gatewayMocks.startThreadReview).toHaveBeenCalledWith(
+      'thread-goal',
+      'workspace',
+      'unstaged',
+    )
+    expect(gatewayMocks.renameThread).toHaveBeenCalledWith('thread-goal', 'Release prep')
+    expect(gatewayMocks.startThreadTurn).not.toHaveBeenCalled()
+  })
+
+  it('strips /plan and starts the turn in Plan mode', async () => {
+    installTestWindow()
+    gatewayMocks.resumeThread.mockResolvedValue({
+      model: 'gpt-5.4',
+      modelProvider: 'openai',
+      messages: [],
+      inProgress: false,
+      activeTurnId: '',
+      hasMoreOlder: false,
+      turnIndexByTurnId: {},
+    })
+    gatewayMocks.startThreadTurn.mockResolvedValue({ id: 'turn-plan' })
+
+    const state = useDesktopState()
+    state.primeSelectedThread('thread-goal')
+    await state.sendMessageToSelectedThread('/plan Design the migration')
+
+    expect(gatewayMocks.startThreadTurn).toHaveBeenCalled()
+    expect(gatewayMocks.startThreadTurn.mock.calls[0]?.[1]).toBe('Design the migration')
+    expect(gatewayMocks.startThreadTurn.mock.calls[0]?.[7]).toBe('plan')
   })
 })
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -21,6 +21,7 @@ const gatewayMocks = vi.hoisted(() => ({
   getPendingServerRequests: vi.fn(),
   getSkillsList: vi.fn(),
   getThreadDetail: vi.fn(),
+  getThreadGoal: vi.fn(),
   getThreadGroupsPage: vi.fn(),
   getThreadQueueState: vi.fn(),
   getThreadTitleCache: vi.fn(),
@@ -35,6 +36,8 @@ const gatewayMocks = vi.hoisted(() => ({
   rollbackThread: vi.fn(),
   setCodexSpeedMode: vi.fn(),
   setThreadQueueState: vi.fn(),
+  setThreadGoal: vi.fn(),
+  clearThreadGoal: vi.fn(),
   setWorkspaceRootsState: vi.fn(),
   startThread: vi.fn(),
   startThreadTurn: vi.fn(),
@@ -45,6 +48,7 @@ vi.mock('../api/codexGateway', () => ({
   ...gatewayMocks,
   getBackgroundThreadListLimit: vi.fn(() => 100),
   pickCodexRateLimitSnapshot: vi.fn(() => null),
+  normalizeThreadGoal: vi.fn((value) => value),
 }))
 
 function thread(id: string, cwd: string, options: { hasWorktree?: boolean } = {}) {
@@ -82,6 +86,7 @@ function installTestWindow(initialStorage: Record<string, string> = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   gatewayMocks.getThreadQueueState.mockResolvedValue({})
+  gatewayMocks.getThreadGoal.mockResolvedValue(null)
   gatewayMocks.getThreadTitleCache.mockResolvedValue({ titles: {} })
   gatewayMocks.getWorkspaceRootsState.mockRejectedValue(new Error('no workspace roots state'))
 })
@@ -615,6 +620,64 @@ describe('startup request deduplication', () => {
     } finally {
       nowSpy.mockRestore()
     }
+  })
+})
+
+describe('thread goals', () => {
+  const goal = {
+    threadId: 'thread-goal',
+    objective: 'Ship Goal mode',
+    status: 'active' as const,
+    tokenBudget: null,
+    tokensUsed: 0,
+    timeUsedSeconds: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  }
+
+  it('loads once per selected thread and applies notifications without a broad refresh', async () => {
+    installTestWindow()
+    let notificationHandler: (notification: { method: string; params?: unknown }) => void = () => {}
+    gatewayMocks.subscribeCodexNotifications.mockImplementation((handler) => {
+      notificationHandler = handler
+      return vi.fn()
+    })
+    gatewayMocks.getPendingServerRequests.mockResolvedValue([])
+    gatewayMocks.getThreadGoal.mockResolvedValue(goal)
+
+    const state = useDesktopState()
+    state.primeSelectedThread('thread-goal')
+    state.startPolling()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(gatewayMocks.getThreadGoal).toHaveBeenCalledTimes(1)
+    expect(state.selectedThreadGoal.value).toEqual(goal)
+    const threadListCalls = gatewayMocks.getThreadGroupsPage.mock.calls.length
+
+    notificationHandler({
+      method: 'thread/goal/updated',
+      params: { threadId: 'thread-goal', goal: { ...goal, status: 'paused', updatedAt: 2 } },
+    })
+
+    expect(state.selectedThreadGoal.value?.status).toBe('paused')
+    expect(gatewayMocks.getThreadGroupsPage).toHaveBeenCalledTimes(threadListCalls)
+  })
+
+  it('lets app-server start a slash-command goal without duplicating turn/start', async () => {
+    installTestWindow()
+    gatewayMocks.getThreadGoal.mockResolvedValue(null)
+    gatewayMocks.setThreadGoal.mockResolvedValue(goal)
+
+    const state = useDesktopState()
+    state.primeSelectedThread('thread-goal')
+    await state.sendMessageToSelectedThread('/goal Ship Goal mode')
+
+    expect(gatewayMocks.setThreadGoal).toHaveBeenCalledWith('thread-goal', {
+      objective: 'Ship Goal mode',
+      status: 'active',
+    })
+    expect(gatewayMocks.startThreadTurn).not.toHaveBeenCalled()
   })
 })
 

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -11,6 +11,7 @@ import {
   getPendingServerRequests,
   getSkillsList,
   getThreadDetail,
+  getThreadGoal,
   getOlderThreadMessages,
   getBackgroundThreadListLimit,
   interruptThreadTurn,
@@ -23,6 +24,9 @@ import {
   getWorkspaceRootsState,
   setCodexSpeedMode,
   setThreadQueueState,
+  setThreadGoal,
+  clearThreadGoal,
+  normalizeThreadGoal,
   setWorkspaceRootsState,
   getThreadTitleCache,
   persistThreadTitle,
@@ -56,10 +60,12 @@ import type {
   UiServerRequest,
   UiServerRequestReply,
   UiThreadTokenUsage,
+  UiThreadGoal,
   UiTokenUsageBreakdown,
   UiThread,
 } from '../types/codex'
 import { getPathParent, isProjectlessChatPath, normalizePathForUi, toProjectName } from '../pathUtils.js'
+import { parseGoalCommand, type GoalCommand } from '../utils/goalCommand'
 
 function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
   return groups.flatMap((group) => group.threads)
@@ -1460,6 +1466,7 @@ export function useDesktopState() {
   const pendingTurnRequestByThreadId = ref<Record<string, PendingTurnRequest>>({})
   const codexRateLimit = ref<UiRateLimitSnapshot | null>(null)
   const threadTokenUsageByThreadId = ref<Record<string, UiThreadTokenUsage>>(loadThreadTokenUsageMap())
+  const threadGoalByThreadId = ref<Record<string, UiThreadGoal | null>>({})
   const terminalOpenByThreadId = ref<Record<string, boolean>>(loadThreadTerminalOpenMap())
   const threadModelProviderByThreadId = ref<Record<string, string>>({})
 
@@ -1537,6 +1544,8 @@ export function useDesktopState() {
   let shouldAutoScrollOnNextAgentEvent = false
   const pendingTurnStartsById = new Map<string, TurnStartedInfo>()
   const fallbackRetryInFlightThreadIds = new Set<string>()
+  const loadedThreadGoalIds = new Set<string>()
+  const threadGoalLoadByThreadId = new Map<string, Promise<UiThreadGoal | null>>()
 
 
   const allThreads = computed(() => flattenThreads(projectGroups.value))
@@ -1601,6 +1610,11 @@ export function useDesktopState() {
     const threadId = selectedThreadId.value
     if (!threadId) return null
     return threadTokenUsageByThreadId.value[threadId] ?? null
+  })
+  const selectedThreadGoal = computed<UiThreadGoal | null>(() => {
+    const threadId = selectedThreadId.value
+    if (!threadId) return null
+    return threadGoalByThreadId.value[threadId] ?? null
   })
   const messages = computed<UiMessage[]>(() => {
     const threadId = selectedThreadId.value
@@ -1687,6 +1701,117 @@ export function useDesktopState() {
     )
     activeReasoningItemId = ''
     shouldAutoScrollOnNextAgentEvent = false
+    if (nextThreadId) void loadThreadGoal(nextThreadId).catch(() => {})
+  }
+
+  function storeThreadGoal(threadId: string, goal: UiThreadGoal | null): void {
+    threadGoalByThreadId.value = {
+      ...threadGoalByThreadId.value,
+      [threadId]: goal,
+    }
+    loadedThreadGoalIds.add(threadId)
+  }
+
+  async function loadThreadGoal(threadId: string, options: { force?: boolean } = {}): Promise<UiThreadGoal | null> {
+    const normalizedThreadId = threadId.trim()
+    if (!normalizedThreadId) return null
+    if (!options.force && loadedThreadGoalIds.has(normalizedThreadId)) {
+      return threadGoalByThreadId.value[normalizedThreadId] ?? null
+    }
+
+    const existingLoad = threadGoalLoadByThreadId.get(normalizedThreadId)
+    if (existingLoad) return existingLoad
+
+    const load = getThreadGoal(normalizedThreadId)
+      .then((goal) => {
+        storeThreadGoal(normalizedThreadId, goal)
+        return goal
+      })
+      .finally(() => {
+        threadGoalLoadByThreadId.delete(normalizedThreadId)
+      })
+    threadGoalLoadByThreadId.set(normalizedThreadId, load)
+    return load
+  }
+
+  async function updateThreadGoal(
+    threadId: string,
+    update: Parameters<typeof setThreadGoal>[1],
+  ): Promise<UiThreadGoal> {
+    try {
+      const goal = await setThreadGoal(threadId, update)
+      storeThreadGoal(threadId, goal)
+      error.value = ''
+      return goal
+    } catch (unknownError) {
+      error.value = unknownError instanceof Error ? unknownError.message : 'Failed to update goal'
+      throw unknownError
+    }
+  }
+
+  async function updateSelectedThreadGoalObjective(objective: string): Promise<void> {
+    const threadId = selectedThreadId.value
+    const normalizedObjective = objective.trim()
+    if (!threadId || !normalizedObjective) return
+    await updateThreadGoal(threadId, { objective: normalizedObjective })
+  }
+
+  async function toggleSelectedThreadGoalPaused(): Promise<void> {
+    const threadId = selectedThreadId.value
+    const goal = selectedThreadGoal.value
+    if (!threadId || !goal) return
+    await updateThreadGoal(threadId, { status: goal.status === 'paused' ? 'active' : 'paused' })
+  }
+
+  async function clearSelectedThreadGoal(): Promise<void> {
+    const threadId = selectedThreadId.value
+    if (!threadId) return
+    try {
+      await clearThreadGoal(threadId)
+      storeThreadGoal(threadId, null)
+      error.value = ''
+    } catch (unknownError) {
+      error.value = unknownError instanceof Error ? unknownError.message : 'Failed to clear goal'
+      throw unknownError
+    }
+  }
+
+  async function executeGoalCommand(threadId: string, command: GoalCommand): Promise<void> {
+    if (command.action === 'view') {
+      const goal = await loadThreadGoal(threadId, { force: true })
+      if (!goal) error.value = 'No goal is set for this thread. Use /goal <objective> to start one.'
+      return
+    }
+    if (command.action === 'clear') {
+      await clearThreadGoal(threadId)
+      storeThreadGoal(threadId, null)
+      error.value = ''
+      return
+    }
+    if (command.action === 'pause' || command.action === 'resume') {
+      const goal = await loadThreadGoal(threadId)
+      if (!goal) {
+        error.value = 'No goal is set for this thread.'
+        return
+      }
+      await updateThreadGoal(threadId, { status: command.action === 'pause' ? 'paused' : 'active' })
+      return
+    }
+    if (command.action === 'edit') {
+      if (!command.objective) {
+        error.value = 'Use /goal edit <objective>, or choose Edit in the goal bar.'
+        return
+      }
+      const goal = await loadThreadGoal(threadId)
+      if (!goal) {
+        error.value = 'No goal is set for this thread.'
+        return
+      }
+      await updateThreadGoal(threadId, { objective: command.objective })
+      return
+    }
+
+    await updateThreadGoal(threadId, { objective: command.objective, status: 'active' })
   }
 
   function setSelectedModelIdForThread(threadId: string, modelId: string): void {
@@ -2274,6 +2399,10 @@ export function useDesktopState() {
       persistQueueState()
     }
     threadTokenUsageByThreadId.value = pruneThreadStateMap(threadTokenUsageByThreadId.value, activeThreadIds)
+    threadGoalByThreadId.value = pruneThreadStateMap(threadGoalByThreadId.value, activeThreadIds)
+    for (const threadId of loadedThreadGoalIds) {
+      if (!activeThreadIds.has(threadId)) loadedThreadGoalIds.delete(threadId)
+    }
     eventUnreadByThreadId.value = pruneThreadStateMap(eventUnreadByThreadId.value, activeThreadIds)
     inProgressById.value = pruneThreadStateMap(inProgressById.value, activeThreadIds)
     const nextPending: Record<string, UiServerRequest[]> = {}
@@ -3752,6 +3881,20 @@ export function useDesktopState() {
       }
     }
 
+    if (notification.method === 'thread/goal/updated') {
+      const params = asRecord(notification.params)
+      const threadId = readString(params?.threadId)
+      const goal = normalizeThreadGoal(params?.goal)
+      if (threadId && goal) storeThreadGoal(threadId, goal)
+      return
+    }
+
+    if (notification.method === 'thread/goal/cleared') {
+      const threadId = extractThreadIdFromNotification(notification)
+      if (threadId) storeThreadGoal(threadId, null)
+      return
+    }
+
     if (notification.method === 'account/rateLimits/updated') {
       setCodexRateLimit(pickCodexRateLimitSnapshot(notification.params))
       return
@@ -3995,7 +4138,11 @@ export function useDesktopState() {
   }
 
   function queueEventDrivenSync(notification: RpcNotification): void {
-    if (notification.method === 'thread/tokenUsage/updated') return
+    if (
+      notification.method === 'thread/tokenUsage/updated'
+      || notification.method === 'thread/goal/updated'
+      || notification.method === 'thread/goal/cleared'
+    ) return
 
     const method = notification.method
     const shouldRefreshMessages =
@@ -4852,6 +4999,14 @@ export function useDesktopState() {
     const nextText = text.trim()
     if (!threadId || (!nextText && imageUrls.length === 0 && fileAttachments.length === 0)) return
 
+    const goalCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
+      ? parseGoalCommand(nextText)
+      : null
+    if (goalCommand) {
+      await executeGoalCommand(threadId, goalCommand)
+      return
+    }
+
     if (await maybeReplyToPendingUserInputRequest(threadId, nextText, imageUrls, skills, fileAttachments)) {
       return
     }
@@ -4952,11 +5107,20 @@ export function useDesktopState() {
   ): Promise<string> {
     if (isUpdatingSpeedMode.value) return ''
 
-    const nextText = text.trim()
+    let nextText = text.trim()
     const targetCwd = cwd.trim()
     const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
     const selectedMode = selectedCollaborationMode.value
     if (!nextText && imageUrls.length === 0 && fileAttachments.length === 0) return ''
+
+    const goalCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
+      ? parseGoalCommand(nextText)
+      : null
+    if (goalCommand && goalCommand.action !== 'set') {
+      error.value = 'Start a goal from Home with /goal <objective>.'
+      return ''
+    }
+    if (goalCommand?.action === 'set') nextText = goalCommand.objective
 
     isSendingMessage.value = true
     error.value = ''
@@ -4982,6 +5146,21 @@ export function useDesktopState() {
         }
       }
       if (!threadId) return ''
+
+      if (goalCommand?.action === 'set') {
+        await updateThreadGoal(threadId, { objective: goalCommand.objective, status: 'active' })
+        insertOptimisticThread(threadId, targetCwd, goalCommand.objective)
+        resumedThreadById.value = {
+          ...resumedThreadById.value,
+          [threadId]: true,
+        }
+        setSelectedThreadId(threadId)
+        pendingThreadsRefresh = true
+        pendingThreadsRefreshForce = true
+        await syncFromNotifications()
+        isSendingMessage.value = false
+        return threadId
+      }
 
       insertOptimisticThread(threadId, targetCwd, nextText || '[Image]')
       appendOptimisticUserMessage(threadId, nextText, imageUrls, skills, fileAttachments)
@@ -5520,6 +5699,7 @@ export function useDesktopState() {
 
     if (stopNotificationStream) return
     void loadPendingServerRequestsFromBridge()
+    if (selectedThreadId.value) void loadThreadGoal(selectedThreadId.value).catch(() => {})
     stopNotificationStream = subscribeCodexNotifications((notification) => {
       if (notification.method === 'ready') {
         clearAllTransientTurnErrors()
@@ -5605,6 +5785,9 @@ export function useDesktopState() {
     persistQueueState()
     codexRateLimit.value = null
     threadTokenUsageByThreadId.value = {}
+    threadGoalByThreadId.value = {}
+    loadedThreadGoalIds.clear()
+    threadGoalLoadByThreadId.clear()
   }
 
   const selectedThreadQueuedMessages = computed<QueuedMessage[]>(() => {
@@ -5666,6 +5849,7 @@ export function useDesktopState() {
     projectDisplayNameById,
     selectedThread,
     selectedThreadTokenUsage,
+    selectedThreadGoal,
     selectedThreadTerminalOpen,
     isSelectedThreadInterruptPending,
     selectedThreadServerRequests,
@@ -5706,6 +5890,9 @@ export function useDesktopState() {
     forkThreadById,
     forkThreadFromTurn,
     rollbackSelectedThread,
+    updateSelectedThreadGoalObjective,
+    toggleSelectedThreadGoalPaused,
+    clearSelectedThreadGoal,
 
     sendMessageToSelectedThread,
     sendMessageToNewThread,

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -2,6 +2,7 @@ import { computed, ref } from 'vue'
 import {
 
   archiveThread,
+  compactThread,
   forkThread,
   getAvailableCollaborationModes,
   getAccountRateLimits,
@@ -34,6 +35,7 @@ import {
   resumeThread,
 
   startThread,
+  startThreadReview,
   subscribeCodexNotifications,
   startThreadTurn,
   type RpcNotification,
@@ -65,7 +67,8 @@ import type {
   UiThread,
 } from '../types/codex'
 import { getPathParent, isProjectlessChatPath, normalizePathForUi, toProjectName } from '../pathUtils.js'
-import { parseGoalCommand, type GoalCommand } from '../utils/goalCommand'
+import type { GoalCommand } from '../utils/goalCommand'
+import { parseSlashCommand, type CodexSlashCommand } from '../utils/slashCommand'
 
 function flattenThreads(groups: UiProjectGroup[]): UiThread[] {
   return groups.flatMap((group) => group.threads)
@@ -4954,6 +4957,65 @@ export function useDesktopState() {
     }
   }
 
+  function resolveAvailableModelId(model: string): string {
+    const normalizedModel = model.trim().toLowerCase()
+    if (!normalizedModel) return ''
+    return availableModelIds.value.find((modelId) => modelId.toLowerCase() === normalizedModel) ?? ''
+  }
+
+  async function executeCodexControlCommand(threadId: string, command: CodexSlashCommand): Promise<boolean> {
+    if (command.action === 'plan') return false
+
+    error.value = ''
+    if (command.action === 'model') {
+      if (!command.model) {
+        error.value = 'Use /model <model>, for example /model gpt-5.4.'
+        return true
+      }
+      const modelId = resolveAvailableModelId(command.model)
+      if (!modelId) {
+        error.value = `Unknown model "${command.model}". Choose one from the model picker.`
+        return true
+      }
+      setSelectedModelIdForThread(threadId, modelId)
+      return true
+    }
+
+    if (command.action === 'rename') {
+      if (!command.name) {
+        error.value = 'Use /rename <name>.'
+        return true
+      }
+      await renameThreadById(threadId, command.name)
+      return true
+    }
+
+    if (inProgressById.value[threadId] === true) {
+      error.value = `Finish the current turn before running /${command.action}.`
+      return true
+    }
+
+    if (command.action === 'fork') {
+      await forkThreadById(threadId)
+      return true
+    }
+    if (command.action === 'archive') {
+      await archiveThreadById(threadId)
+      return true
+    }
+
+    try {
+      if (command.action === 'compact') {
+        await compactThread(threadId)
+      } else {
+        await startThreadReview(threadId, 'workspace', 'unstaged')
+      }
+    } catch (unknownError) {
+      error.value = unknownError instanceof Error ? unknownError.message : `Failed to run /${command.action}`
+    }
+    return true
+  }
+
   async function maybeReplyToPendingUserInputRequest(
     threadId: string,
     text: string,
@@ -4996,15 +5058,26 @@ export function useDesktopState() {
     if (isUpdatingSpeedMode.value) return
 
     const threadId = selectedThreadId.value
-    const nextText = text.trim()
+    let nextText = text.trim()
+    let effectiveCollaborationModeOverride = collaborationModeOverride
     if (!threadId || (!nextText && imageUrls.length === 0 && fileAttachments.length === 0)) return
 
-    const goalCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
-      ? parseGoalCommand(nextText)
+    const slashCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
+      ? parseSlashCommand(nextText)
       : null
-    if (goalCommand) {
-      await executeGoalCommand(threadId, goalCommand)
+    if (slashCommand?.kind === 'goal') {
+      await executeGoalCommand(threadId, slashCommand.command)
       return
+    }
+    if (slashCommand?.kind === 'codex') {
+      if (slashCommand.command.action === 'plan') {
+        setSelectedCollaborationModeForThread(threadId, 'plan')
+        if (!slashCommand.command.prompt) return
+        nextText = slashCommand.command.prompt
+        effectiveCollaborationModeOverride = 'plan'
+      } else if (await executeCodexControlCommand(threadId, slashCommand.command)) {
+        return
+      }
     }
 
     if (await maybeReplyToPendingUserInputRequest(threadId, nextText, imageUrls, skills, fileAttachments)) {
@@ -5026,9 +5099,9 @@ export function useDesktopState() {
         imageUrls,
         skills,
         fileAttachments,
-        collaborationMode: collaborationModeOverride === 'plan'
+        collaborationMode: effectiveCollaborationModeOverride === 'plan'
           ? 'plan'
-          : collaborationModeOverride === 'default'
+          : effectiveCollaborationModeOverride === 'default'
             ? 'default'
             : selectedCollaborationMode.value,
       })
@@ -5048,7 +5121,7 @@ export function useDesktopState() {
         imageUrls,
         skills,
         fileAttachments,
-        collaborationModeOverride,
+        effectiveCollaborationModeOverride,
       ).catch((unknownError) => {
         const errorMessage = unknownError instanceof Error ? unknownError.message : 'Unknown application error'
         setTurnErrorForThread(threadId, errorMessage)
@@ -5067,9 +5140,9 @@ export function useDesktopState() {
         details: buildPendingTurnDetails(
           readModelIdForThread(threadId),
           selectedReasoningEffort.value,
-          collaborationModeOverride === 'plan'
+          effectiveCollaborationModeOverride === 'plan'
             ? 'plan'
-            : collaborationModeOverride === 'default'
+            : effectiveCollaborationModeOverride === 'default'
               ? 'default'
               : selectedCollaborationMode.value,
         ),
@@ -5085,7 +5158,7 @@ export function useDesktopState() {
         imageUrls,
         skills,
         fileAttachments,
-        collaborationModeOverride,
+        effectiveCollaborationModeOverride,
       )
     } catch (unknownError) {
       shouldAutoScrollOnNextAgentEvent = false
@@ -5109,18 +5182,44 @@ export function useDesktopState() {
 
     let nextText = text.trim()
     const targetCwd = cwd.trim()
-    const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
-    const selectedMode = selectedCollaborationMode.value
     if (!nextText && imageUrls.length === 0 && fileAttachments.length === 0) return ''
 
-    const goalCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
-      ? parseGoalCommand(nextText)
+    const slashCommand = imageUrls.length === 0 && skills.length === 0 && fileAttachments.length === 0
+      ? parseSlashCommand(nextText)
       : null
-    if (goalCommand && goalCommand.action !== 'set') {
-      error.value = 'Start a goal from Home with /goal <objective>.'
-      return ''
+    const goalCommand = slashCommand?.kind === 'goal' ? slashCommand.command : null
+    if (goalCommand) {
+      if (goalCommand.action !== 'set') {
+        error.value = 'Start a goal from Home with /goal <objective>.'
+        return ''
+      }
+      nextText = goalCommand.objective
+    } else if (slashCommand?.kind === 'codex') {
+      if (slashCommand.command.action === 'plan') {
+        setSelectedCollaborationMode('plan')
+        if (!slashCommand.command.prompt) return ''
+        nextText = slashCommand.command.prompt
+      } else if (slashCommand.command.action === 'model') {
+        if (!slashCommand.command.model) {
+          error.value = 'Use /model <model>, for example /model gpt-5.4.'
+          return ''
+        }
+        const modelId = resolveAvailableModelId(slashCommand.command.model)
+        if (!modelId) {
+          error.value = `Unknown model "${slashCommand.command.model}". Choose one from the model picker.`
+          return ''
+        }
+        setSelectedModelIdForThread('', modelId)
+        error.value = ''
+        return ''
+      } else {
+        error.value = `Open a chat before running /${slashCommand.command.action}.`
+        return ''
+      }
     }
-    if (goalCommand?.action === 'set') nextText = goalCommand.objective
+
+    const selectedModel = readModelIdForThread(NEW_THREAD_COLLABORATION_MODE_CONTEXT).trim()
+    const selectedMode = selectedCollaborationMode.value
 
     isSendingMessage.value = true
     error.value = ''

--- a/src/server/localBrowseUi.test.ts
+++ b/src/server/localBrowseUi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { decodeBrowsePath } from './localBrowseUi'
+import { decodeBrowsePath, toBrowseHref, toEditHref } from './localBrowseUi'
 
 describe('decodeBrowsePath', () => {
   it('removes the browse-route slash before Windows drive paths', () => {
@@ -15,5 +15,28 @@ describe('decodeBrowsePath', () => {
 
   it('leaves malformed URL encoding usable for the normal validation path', () => {
     expect(decodeBrowsePath('/tmp/100%/file.txt', 'linux')).toBe('/tmp/100%/file.txt')
+  })
+})
+
+describe('local browse route hrefs', () => {
+  it('adds the route separator and converts Windows path separators', () => {
+    const path = String.raw`C:\Users\Nulled\Documents\invasion\artifacts\autonomous-weaponry\mammoth-v1`
+    expect(toBrowseHref(path)).toBe(
+      '/codex-local-browse/C:/Users/Nulled/Documents/invasion/artifacts/autonomous-weaponry/mammoth-v1',
+    )
+    expect(toEditHref(String.raw`C:\Users\Nulled\file.ps1`)).toBe(
+      '/codex-local-edit/C:/Users/Nulled/file.ps1',
+    )
+  })
+
+  it('preserves Unix and UNC absolute paths', () => {
+    expect(toBrowseHref('/home/codex/folder')).toBe('/codex-local-browse/home/codex/folder')
+    expect(toBrowseHref(String.raw`\\server\share\folder`)).toBe('/codex-local-browse//server/share/folder')
+  })
+
+  it('keeps project picker query parameters encoded', () => {
+    expect(toBrowseHref(String.raw`C:\Users\Nulled\Parent Folder`, 'My Project')).toBe(
+      '/codex-local-browse/C:/Users/Nulled/Parent%20Folder?newProjectName=My%20Project',
+    )
   })
 })

--- a/src/server/localBrowseUi.test.ts
+++ b/src/server/localBrowseUi.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { decodeBrowsePath } from './localBrowseUi'
+
+describe('decodeBrowsePath', () => {
+  it('removes the browse-route slash before Windows drive paths', () => {
+    expect(decodeBrowsePath('/C:/Users/Nulled/video.mp4', 'win32')).toBe('C:/Users/Nulled/video.mp4')
+    expect(decodeBrowsePath('/%43%3A/Users/Nulled/file.ps1', 'win32')).toBe('C:/Users/Nulled/file.ps1')
+  })
+
+  it('preserves Unix, UNC, and already normalized paths', () => {
+    expect(decodeBrowsePath('/home/codex/file.txt', 'linux')).toBe('/home/codex/file.txt')
+    expect(decodeBrowsePath('//server/share/file.txt', 'win32')).toBe('//server/share/file.txt')
+    expect(decodeBrowsePath('C:/Users/Nulled/file.txt', 'win32')).toBe('C:/Users/Nulled/file.txt')
+  })
+
+  it('leaves malformed URL encoding usable for the normal validation path', () => {
+    expect(decodeBrowsePath('/tmp/100%/file.txt', 'linux')).toBe('/tmp/100%/file.txt')
+  })
+})

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -69,13 +69,23 @@ export function normalizeLocalPath(rawPath: string): string {
   return trimmed
 }
 
-export function decodeBrowsePath(rawPath: string): string {
+export function decodeBrowsePath(rawPath: string, platform: NodeJS.Platform = process.platform): string {
   if (!rawPath) return ''
+  let decoded: string
   try {
-    return decodeURIComponent(rawPath)
+    decoded = decodeURIComponent(rawPath)
   } catch {
-    return rawPath
+    decoded = rawPath
   }
+
+  // Browse URLs keep an absolute-path slash after the route prefix. On Windows,
+  // that turns `C:/path` into `/C:/path`, which Node resolves as `C:\C:\path`.
+  // Remove only that synthetic slash; Unix and UNC absolute paths stay intact.
+  if (platform === 'win32' && /^\/[A-Za-z]:[\\/]/u.test(decoded)) {
+    return decoded.slice(1)
+  }
+
+  return decoded
 }
 
 export function isTextEditablePath(pathValue: string): boolean {

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -141,16 +141,21 @@ function normalizeNewProjectName(value: string): string {
   return value.trim().replace(/[\\/]+/gu, '').trim()
 }
 
-function toBrowseHref(pathValue: string, newProjectName = ''): string {
-  const normalizedName = normalizeNewProjectName(newProjectName)
-  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-browse${encodeURI(pathValue)}${query}`
+function normalizeLocalRoutePath(pathValue: string): string {
+  const normalized = pathValue.replace(/\\/gu, '/')
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
 }
 
-function toEditHref(pathValue: string, newProjectName = ''): string {
+export function toBrowseHref(pathValue: string, newProjectName = ''): string {
   const normalizedName = normalizeNewProjectName(newProjectName)
   const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-edit${encodeURI(pathValue)}${query}`
+  return `/codex-local-browse${encodeURI(normalizeLocalRoutePath(pathValue))}${query}`
+}
+
+export function toEditHref(pathValue: string, newProjectName = ''): string {
+  const normalizedName = normalizeNewProjectName(newProjectName)
+  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
+  return `/codex-local-edit${encodeURI(normalizeLocalRoutePath(pathValue))}${query}`
 }
 
 function escapeForInlineScriptString(value: string): string {

--- a/src/style.css
+++ b/src/style.css
@@ -437,6 +437,53 @@
   @apply border-zinc-600 bg-zinc-800;
 }
 
+:root.dark .thread-composer-slash-menu {
+  @apply border-zinc-600 bg-zinc-800;
+}
+
+:root.dark .thread-composer-slash-heading,
+:root.dark .thread-composer-slash-description,
+:root.dark .thread-composer-slash-help {
+  @apply text-zinc-400;
+}
+
+:root.dark .thread-composer-slash-heading,
+:root.dark .thread-composer-slash-help {
+  @apply bg-zinc-800;
+}
+
+:root.dark .thread-composer-slash-row {
+  @apply text-zinc-300 hover:bg-amber-950/40;
+}
+
+:root.dark .thread-composer-slash-row.is-active {
+  @apply bg-amber-950/40;
+}
+
+:root.dark .thread-composer-slash-title {
+  @apply text-zinc-100;
+}
+
+:root.dark .thread-composer-slash-title code {
+  @apply bg-zinc-700 text-zinc-300;
+}
+
+:root.dark .thread-composer-slash-help {
+  @apply border-zinc-700;
+}
+
+:root.dark .thread-composer-slash-icon {
+  @apply bg-amber-950/70 text-amber-300;
+}
+
+:root.dark .thread-composer-command-preview {
+  @apply border-amber-800/70 bg-amber-950/60;
+}
+
+:root.dark .thread-composer-command-preview kbd {
+  @apply border-amber-800 bg-zinc-800 text-amber-300;
+}
+
 :root.dark .thread-composer-file-mention-row {
   @apply text-zinc-300 hover:bg-zinc-700;
 }

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -6,6 +6,19 @@ export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | '
 export type SpeedMode = 'standard' | 'fast'
 export type CollaborationModeKind = 'default' | 'plan'
 
+export type ThreadGoalStatus = 'active' | 'paused' | 'blocked' | 'usageLimited' | 'budgetLimited' | 'complete'
+
+export type UiThreadGoal = {
+  threadId: string
+  objective: string
+  status: ThreadGoalStatus
+  tokenBudget: number | null
+  tokensUsed: number
+  timeUsedSeconds: number
+  createdAt: number
+  updatedAt: number
+}
+
 export type RpcMethodCatalog = {
   data: string[]
 }

--- a/src/utils/goalCommand.test.ts
+++ b/src/utils/goalCommand.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseGoalCommand } from './goalCommand'
+import { describeGoalCommand, getGoalCommandSuggestions, parseGoalCommand } from './goalCommand'
 
 describe('parseGoalCommand', () => {
   it('ignores ordinary messages and similarly named commands', () => {
@@ -27,5 +27,25 @@ describe('parseGoalCommand', () => {
       action: 'set',
       objective: 'pause after this turn',
     })
+  })
+})
+
+describe('goal command discovery', () => {
+  it('shows Goal actions while the user types a command prefix', () => {
+    expect(getGoalCommandSuggestions('/').map((option) => option.id)).toEqual([
+      'start', 'view', 'edit', 'pause', 'resume', 'clear',
+    ])
+    expect(getGoalCommandSuggestions('/go').map((option) => option.id)).toContain('start')
+    expect(getGoalCommandSuggestions('/goal e').map((option) => option.id)).toEqual(['edit'])
+    expect(getGoalCommandSuggestions('/goal pa').map((option) => option.id)).toEqual(['pause'])
+  })
+
+  it('switches from suggestions to an execution preview for an objective', () => {
+    expect(getGoalCommandSuggestions('/goal Ship it')).toEqual([])
+    expect(describeGoalCommand('/goal Ship it')).toMatchObject({
+      id: 'start',
+      label: 'Start a goal',
+    })
+    expect(describeGoalCommand('ordinary message')).toBeNull()
   })
 })

--- a/src/utils/goalCommand.test.ts
+++ b/src/utils/goalCommand.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { parseGoalCommand } from './goalCommand'
+
+describe('parseGoalCommand', () => {
+  it('ignores ordinary messages and similarly named commands', () => {
+    expect(parseGoalCommand('please use /goal later')).toBeNull()
+    expect(parseGoalCommand('/goals ship it')).toBeNull()
+  })
+
+  it('parses goal lifecycle commands case-insensitively', () => {
+    expect(parseGoalCommand('/goal')).toEqual({ action: 'view' })
+    expect(parseGoalCommand('/GOAL pause')).toEqual({ action: 'pause' })
+    expect(parseGoalCommand('/goal resume')).toEqual({ action: 'resume' })
+    expect(parseGoalCommand('/goal clear')).toEqual({ action: 'clear' })
+  })
+
+  it('preserves multiline objectives and separates edits from new goals', () => {
+    expect(parseGoalCommand('/goal Ship the feature\nwith tests')).toEqual({
+      action: 'set',
+      objective: 'Ship the feature\nwith tests',
+    })
+    expect(parseGoalCommand('/goal edit Narrow the scope')).toEqual({
+      action: 'edit',
+      objective: 'Narrow the scope',
+    })
+    expect(parseGoalCommand('/goal pause after this turn')).toEqual({
+      action: 'set',
+      objective: 'pause after this turn',
+    })
+  })
+})

--- a/src/utils/goalCommand.ts
+++ b/src/utils/goalCommand.ts
@@ -6,6 +6,88 @@ export type GoalCommand =
   | { action: 'resume' }
   | { action: 'clear' }
 
+export type GoalCommandOption = {
+  id: 'start' | 'view' | 'edit' | 'pause' | 'resume' | 'clear'
+  insertText: string
+  command: string
+  label: string
+  description: string
+  requiresArgument: boolean
+}
+
+export const GOAL_COMMAND_OPTIONS: GoalCommandOption[] = [
+  {
+    id: 'start',
+    insertText: '/goal ',
+    command: '/goal <objective>',
+    label: 'Start a goal',
+    description: 'Give Codex a persistent objective and start autonomous work.',
+    requiresArgument: true,
+  },
+  {
+    id: 'view',
+    insertText: '/goal',
+    command: '/goal',
+    label: 'View goal',
+    description: 'Show the goal attached to this chat.',
+    requiresArgument: false,
+  },
+  {
+    id: 'edit',
+    insertText: '/goal edit ',
+    command: '/goal edit <objective>',
+    label: 'Edit goal',
+    description: 'Replace the current goal objective without starting another turn.',
+    requiresArgument: true,
+  },
+  {
+    id: 'pause',
+    insertText: '/goal pause',
+    command: '/goal pause',
+    label: 'Pause goal',
+    description: 'Stop autonomous continuation until you resume it.',
+    requiresArgument: false,
+  },
+  {
+    id: 'resume',
+    insertText: '/goal resume',
+    command: '/goal resume',
+    label: 'Resume goal',
+    description: 'Continue working toward a paused goal.',
+    requiresArgument: false,
+  },
+  {
+    id: 'clear',
+    insertText: '/goal clear',
+    command: '/goal clear',
+    label: 'Clear goal',
+    description: 'Remove the persistent goal from this chat.',
+    requiresArgument: false,
+  },
+]
+
+export function getGoalCommandSuggestions(value: string): GoalCommandOption[] {
+  const input = value.trimStart()
+  if (!input.startsWith('/') || input.includes('\n') || input.includes('\r')) return []
+
+  const normalized = input.toLowerCase()
+  if (normalized === '/') return GOAL_COMMAND_OPTIONS
+  if (!'/goal'.startsWith(normalized) && !normalized.startsWith('/goal ')) return []
+
+  if (!normalized.includes(' ')) {
+    return GOAL_COMMAND_OPTIONS
+  }
+
+  return GOAL_COMMAND_OPTIONS.filter((option) => option.insertText.toLowerCase().startsWith(normalized))
+}
+
+export function describeGoalCommand(value: string): GoalCommandOption | null {
+  const command = parseGoalCommand(value)
+  if (!command) return null
+  if (command.action === 'set') return GOAL_COMMAND_OPTIONS[0]
+  return GOAL_COMMAND_OPTIONS.find((option) => option.id === command.action) ?? null
+}
+
 export function parseGoalCommand(value: string): GoalCommand | null {
   const match = value.trim().match(/^\/goal(?:\s+([\s\S]*))?$/iu)
   if (!match) return null

--- a/src/utils/goalCommand.ts
+++ b/src/utils/goalCommand.ts
@@ -1,0 +1,26 @@
+export type GoalCommand =
+  | { action: 'view' }
+  | { action: 'set'; objective: string }
+  | { action: 'edit'; objective: string }
+  | { action: 'pause' }
+  | { action: 'resume' }
+  | { action: 'clear' }
+
+export function parseGoalCommand(value: string): GoalCommand | null {
+  const match = value.trim().match(/^\/goal(?:\s+([\s\S]*))?$/iu)
+  if (!match) return null
+
+  const argument = (match[1] ?? '').trim()
+  if (!argument) return { action: 'view' }
+
+  const subcommand = argument.match(/^(edit|pause|resume|clear)(?:\s+([\s\S]*))?$/iu)
+  if (!subcommand) return { action: 'set', objective: argument }
+
+  const action = subcommand[1].toLowerCase()
+  const remainder = (subcommand[2] ?? '').trim()
+  if (action === 'edit') return { action: 'edit', objective: remainder }
+  if (remainder) return { action: 'set', objective: argument }
+  if (action === 'pause') return { action: 'pause' }
+  if (action === 'resume') return { action: 'resume' }
+  return { action: 'clear' }
+}

--- a/src/utils/slashCommand.test.ts
+++ b/src/utils/slashCommand.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeSlashCommand,
+  getSlashCommandSuggestions,
+  parseSlashCommand,
+} from './slashCommand'
+
+describe('Codex slash command discovery', () => {
+  it('shows Goal mode and app-server-supported Codex commands', () => {
+    expect(getSlashCommandSuggestions('/').map((option) => option.id)).toEqual([
+      'start',
+      'view',
+      'edit',
+      'pause',
+      'resume',
+      'clear',
+      'plan',
+      'review',
+      'compact',
+      'model',
+      'rename',
+      'fork',
+      'archive',
+    ])
+  })
+
+  it('filters command prefixes and keeps argument text out of the menu', () => {
+    expect(getSlashCommandSuggestions('/comp').map((option) => option.id)).toEqual(['compact'])
+    expect(getSlashCommandSuggestions('/model').map((option) => option.id)).toEqual(['model'])
+    expect(getSlashCommandSuggestions('/model gpt-5.4')).toEqual([])
+    expect(getSlashCommandSuggestions('/goal e').map((option) => option.id)).toEqual(['edit'])
+  })
+})
+
+describe('parseSlashCommand', () => {
+  it('parses native controls without treating ordinary prompts as commands', () => {
+    expect(parseSlashCommand('/plan Design the migration')).toEqual({
+      kind: 'codex',
+      command: { action: 'plan', prompt: 'Design the migration' },
+    })
+    expect(parseSlashCommand('/compact')).toEqual({
+      kind: 'codex',
+      command: { action: 'compact' },
+    })
+    expect(parseSlashCommand('/rename Release prep')).toEqual({
+      kind: 'codex',
+      command: { action: 'rename', name: 'Release prep' },
+    })
+    expect(parseSlashCommand('please /review this')).toBeNull()
+  })
+
+  it('provides execution previews for argument commands', () => {
+    expect(describeSlashCommand('/plan Make a plan')).toMatchObject({ id: 'plan', label: 'Plan mode' })
+    expect(describeSlashCommand('/model gpt-5.4')).toMatchObject({ id: 'model', label: 'Choose model' })
+    expect(describeSlashCommand('/goal Ship it')).toMatchObject({ id: 'start', label: 'Start a goal' })
+  })
+})

--- a/src/utils/slashCommand.ts
+++ b/src/utils/slashCommand.ts
@@ -1,0 +1,132 @@
+import {
+  GOAL_COMMAND_OPTIONS,
+  parseGoalCommand,
+  type GoalCommand,
+  type GoalCommandOption,
+} from './goalCommand'
+
+export type CodexSlashCommand =
+  | { action: 'plan'; prompt: string }
+  | { action: 'compact' }
+  | { action: 'review' }
+  | { action: 'model'; model: string }
+  | { action: 'rename'; name: string }
+  | { action: 'fork' }
+  | { action: 'archive' }
+
+export type ParsedSlashCommand =
+  | { kind: 'goal'; command: GoalCommand }
+  | { kind: 'codex'; command: CodexSlashCommand }
+
+export type SlashCommandOption = GoalCommandOption | {
+  id: 'plan' | 'compact' | 'review' | 'model' | 'rename' | 'fork' | 'archive'
+  insertText: string
+  command: string
+  label: string
+  description: string
+  requiresArgument: boolean
+}
+
+export const CODEX_COMMAND_OPTIONS: SlashCommandOption[] = [
+  {
+    id: 'plan',
+    insertText: '/plan ',
+    command: '/plan [prompt]',
+    label: 'Plan mode',
+    description: 'Switch this chat to Plan mode, optionally starting with a prompt.',
+    requiresArgument: false,
+  },
+  {
+    id: 'review',
+    insertText: '/review',
+    command: '/review',
+    label: 'Review changes',
+    description: 'Ask the Codex reviewer to inspect uncommitted changes.',
+    requiresArgument: false,
+  },
+  {
+    id: 'compact',
+    insertText: '/compact',
+    command: '/compact',
+    label: 'Compact chat',
+    description: 'Summarize this chat to free space in the context window.',
+    requiresArgument: false,
+  },
+  {
+    id: 'model',
+    insertText: '/model ',
+    command: '/model <model>',
+    label: 'Choose model',
+    description: 'Set the model used by later turns in this chat.',
+    requiresArgument: true,
+  },
+  {
+    id: 'rename',
+    insertText: '/rename ',
+    command: '/rename <name>',
+    label: 'Rename chat',
+    description: 'Give the current chat a recognizable name.',
+    requiresArgument: true,
+  },
+  {
+    id: 'fork',
+    insertText: '/fork',
+    command: '/fork',
+    label: 'Fork chat',
+    description: 'Branch this chat into a new conversation.',
+    requiresArgument: false,
+  },
+  {
+    id: 'archive',
+    insertText: '/archive',
+    command: '/archive',
+    label: 'Archive chat',
+    description: 'Move this chat out of the active chat list.',
+    requiresArgument: false,
+  },
+]
+
+export const SLASH_COMMAND_OPTIONS: SlashCommandOption[] = [
+  ...GOAL_COMMAND_OPTIONS,
+  ...CODEX_COMMAND_OPTIONS,
+]
+
+export function getSlashCommandSuggestions(value: string): SlashCommandOption[] {
+  const input = value.trimStart()
+  if (!input.startsWith('/') || input.includes('\n') || input.includes('\r')) return []
+
+  const normalized = input.toLowerCase()
+  if (normalized === '/') return SLASH_COMMAND_OPTIONS
+
+  return SLASH_COMMAND_OPTIONS.filter((option) => option.insertText.toLowerCase().startsWith(normalized))
+}
+
+export function describeSlashCommand(value: string): SlashCommandOption | null {
+  const parsed = parseSlashCommand(value)
+  if (!parsed) return null
+
+  if (parsed.kind === 'goal') {
+    if (parsed.command.action === 'set') return GOAL_COMMAND_OPTIONS[0]
+    return GOAL_COMMAND_OPTIONS.find((option) => option.id === parsed.command.action) ?? null
+  }
+
+  return CODEX_COMMAND_OPTIONS.find((option) => option.id === parsed.command.action) ?? null
+}
+
+export function parseSlashCommand(value: string): ParsedSlashCommand | null {
+  const goalCommand = parseGoalCommand(value)
+  if (goalCommand) return { kind: 'goal', command: goalCommand }
+
+  const match = value.trim().match(/^\/(plan|compact|review|model|rename|fork|archive)(?:\s+([\s\S]*))?$/iu)
+  if (!match) return null
+
+  const action = match[1].toLowerCase()
+  const argument = (match[2] ?? '').trim()
+  if (action === 'plan') return { kind: 'codex', command: { action: 'plan', prompt: argument } }
+  if (action === 'model') return { kind: 'codex', command: { action: 'model', model: argument } }
+  if (action === 'rename') return { kind: 'codex', command: { action: 'rename', name: argument } }
+  if (action === 'compact') return { kind: 'codex', command: { action: 'compact' } }
+  if (action === 'review') return { kind: 'codex', command: { action: 'review' } }
+  if (action === 'fork') return { kind: 'codex', command: { action: 'fork' } }
+  return { kind: 'codex', command: { action: 'archive' } }
+}

--- a/tests.md
+++ b/tests.md
@@ -18,7 +18,7 @@ This file is the manual test index. Detailed regression and feature verification
 | [Projects, Sidebar, and New Chat](tests/projects-sidebar-new-chat/index.md) | 16 | Home route, project picker, sidebar organization, new-chat setup, projectless folders, and project/worktree shell behavior. |
 | [Automations](tests/automations/index.md) | 4 | Thread heartbeat automations, project cron automations, dialogs, action rows, and automation panel behavior. |
 | [Skills, Plugins, and Integrations](tests/skills-plugins-integrations/index.md) | 27 | Skills Hub, skill sync, plugin/app directory surfaces, prompts, Composio, Telegram, and installed skill behavior. |
-| [Chat Composer and Message Rendering](tests/chat-composer-rendering/index.md) | 33 | Composer controls, queued messages, plan mode, markdown parsing, file links, attachments, generated images, and visible message rows. |
+| [Chat Composer and Message Rendering](tests/chat-composer-rendering/index.md) | 34 | Composer controls, queued messages, plan mode, goals, markdown parsing, file links, attachments, generated images, and visible message rows. |
 | [Thread Loading, Streaming, and State](tests/thread-loading-state/index.md) | 26 | Thread list/detail loading, pagination, selected-thread stability, streaming scroll behavior, live-state reads, and missing-thread handling. |
 | [Providers and Models](tests/providers-models/index.md) | 24 | Provider selectors, model menus, OpenRouter, OpenCode Zen, custom endpoints, Responses/Completions format, and model refresh behavior. |
 | [Auth and Docker Runtime](tests/auth-docker-runtime/index.md) | 12 | Codex auth, Docker-packaged runtime cases, copied auth behavior, invalid auth errors, and auth-aware provider fallback. |

--- a/tests/chat-composer-rendering/index.md
+++ b/tests/chat-composer-rendering/index.md
@@ -28,6 +28,7 @@ Return to the [manual test index](../../tests.md).
 | [Feature: Inline thread image payloads are rewritten to renderable local file URLs](inline-thread-image-payloads-are-rewritten-to-renderable-local-file-urls.md) |
 | [Feature: Markdown file links with spaces and parentheses in path](markdown-file-links-with-spaces-and-parentheses-in-path.md) |
 | [Feature: Markdown link with backticked label renders as file link](markdown-link-with-backticked-label-renders-as-file-link.md) |
+| [Feature: Windows absolute file links open through local browse](windows-absolute-file-links-open-local-browse.md) |
 | [Feature: Backticked bare filenames render as file links](backticked-bare-filenames-render-as-file-links.md) |
 | [Feature: Lazy message rendering (windowed conversation)](lazy-message-rendering-windowed-conversation.md) |
 | [Assistant generated image rendering](assistant-generated-image-rendering.md) |

--- a/tests/chat-composer-rendering/index.md
+++ b/tests/chat-composer-rendering/index.md
@@ -8,6 +8,7 @@ Return to the [manual test index](../../tests.md).
 
 | Section |
 | --- |
+| [Feature: Thread goal mode](thread-goal-mode.md) |
 | [Codex thread deep links render as local web thread URLs](codex-thread-deep-links-render-as-local-web-thread-urls.md) |
 | [Bold-wrapped Markdown links render without literal markers](bold-wrapped-markdown-links-render-without-literal-markers.md) |
 | [Composer expands long drafts to full screen](composer-expands-long-drafts-to-full-screen.md) |

--- a/tests/chat-composer-rendering/thread-goal-mode.md
+++ b/tests/chat-composer-rendering/thread-goal-mode.md
@@ -1,0 +1,31 @@
+# Feature: Thread goal mode
+
+## Prerequisites
+
+- Run CodexApp against a Codex app-server version that exposes `thread/goal/get`, `thread/goal/set`, and `thread/goal/clear`.
+- Open an existing idle chat.
+
+## Steps
+
+1. Send `/goal Ship the goal-mode feature with tests`.
+2. Confirm the objective appears in a goal bar above the composer and app-server starts the autonomous goal loop.
+3. Send `/goal` and confirm the existing goal remains visible without adding a chat message.
+4. Choose **Edit**, change the objective, save it, and reload the page.
+5. Choose **Pause**, then **Resume**, and verify the status label changes each time.
+6. Send `/goal edit Refined objective`, `/goal pause`, and `/goal resume`; verify each command updates the same bar without appearing as a user message.
+7. Open the chat at 375x812 and 768x1024 in both light and dark themes; verify the objective, status, and actions remain legible without horizontal page overflow.
+8. Choose **Clear**, accept the confirmation, and reload the page.
+9. From Home, send `/goal New-thread objective` and confirm a new chat is created with an active goal and its first turn starts.
+
+## Expected Results
+
+- Goal state is persisted by app-server, restored when selecting or reloading the thread, and updated immediately by goal notifications.
+- Goal commands are handled as controls rather than ordinary chat messages.
+- Goal loading is cached per thread; notifications update local state without triggering a thread-list or message reload.
+- CodexApp does not issue a duplicate `turn/start`; app-server owns the autonomous goal loop.
+- Editing, pausing, resuming, and clearing never start an extra agent turn.
+- The goal bar is usable in light and dark themes at desktop, phone, and tablet widths.
+
+## Rollback/Cleanup
+
+- Clear any test goal with `/goal clear` or the **Clear** action.

--- a/tests/chat-composer-rendering/thread-goal-mode.md
+++ b/tests/chat-composer-rendering/thread-goal-mode.md
@@ -7,20 +7,25 @@
 
 ## Steps
 
-1. Send `/goal Ship the goal-mode feature with tests`.
-2. Confirm the objective appears in a goal bar above the composer and app-server starts the autonomous goal loop.
-3. Send `/goal` and confirm the existing goal remains visible without adding a chat message.
-4. Choose **Edit**, change the objective, save it, and reload the page.
-5. Choose **Pause**, then **Resume**, and verify the status label changes each time.
-6. Send `/goal edit Refined objective`, `/goal pause`, and `/goal resume`; verify each command updates the same bar without appearing as a user message.
-7. Open the chat at 375x812 and 768x1024 in both light and dark themes; verify the objective, status, and actions remain legible without horizontal page overflow.
-8. Choose **Clear**, accept the confirmation, and reload the page.
-9. From Home, send `/goal New-thread objective` and confirm a new chat is created with an active goal and its first turn starts.
+1. Type `/` and confirm the composer shows all six Goal commands with syntax and descriptions.
+2. Use Arrow Up/Down to change the highlighted command, Tab to complete it, and Escape to dismiss the menu.
+3. Type `/goal pa` and confirm the list filters to **Pause goal**; press Tab and confirm the composer contains `/goal pause` without submitting it.
+4. Type `/goal Ship the goal-mode feature with tests` and confirm the picker becomes a **Start a goal** execution preview.
+5. Send the command and confirm the objective appears in a goal bar above the composer and app-server starts the autonomous goal loop.
+6. Send `/goal` and confirm the existing goal remains visible without adding a chat message.
+7. Choose **Edit**, change the objective, save it, and reload the page.
+8. Choose **Pause**, then **Resume**, and verify the status label changes each time.
+9. Send `/goal edit Refined objective`, `/goal pause`, and `/goal resume`; verify each command updates the same bar without appearing as a user message.
+10. Open the chat at 375x812 and 768x1024 in both light and dark themes; verify the picker, preview, objective, status, and actions remain legible without horizontal page overflow.
+11. Choose **Clear**, accept the confirmation, and reload the page.
+12. From Home, select **Start a goal** from the slash picker, enter an objective, and confirm a new chat is created with an active goal and its first turn starts.
 
 ## Expected Results
 
 - Goal state is persisted by app-server, restored when selecting or reloading the thread, and updated immediately by goal notifications.
 - Goal commands are handled as controls rather than ordinary chat messages.
+- The slash picker makes Goal mode discoverable before submission and filters as a command prefix is typed.
+- Commands that require an objective complete their syntax instead of submitting an incomplete command.
 - Goal loading is cached per thread; notifications update local state without triggering a thread-list or message reload.
 - CodexApp does not issue a duplicate `turn/start`; app-server owns the autonomous goal loop.
 - Editing, pausing, resuming, and clearing never start an extra agent turn.

--- a/tests/chat-composer-rendering/thread-goal-mode.md
+++ b/tests/chat-composer-rendering/thread-goal-mode.md
@@ -7,7 +7,7 @@
 
 ## Steps
 
-1. Type `/` and confirm the composer shows all six Goal commands with syntax and descriptions.
+1. Type `/` and confirm the composer shows all six Goal commands plus the supported Codex commands: Plan, Review, Compact, Model, Rename, Fork, and Archive.
 2. Use Arrow Up/Down to change the highlighted command, Tab to complete it, and Escape to dismiss the menu.
 3. Type `/goal pa` and confirm the list filters to **Pause goal**; press Tab and confirm the composer contains `/goal pause` without submitting it.
 4. Type `/goal Ship the goal-mode feature with tests` and confirm the picker becomes a **Start a goal** execution preview.
@@ -25,6 +25,7 @@
 - Goal state is persisted by app-server, restored when selecting or reloading the thread, and updated immediately by goal notifications.
 - Goal commands are handled as controls rather than ordinary chat messages.
 - The slash picker makes Goal mode discoverable before submission and filters as a command prefix is typed.
+- Codex commands execute through their native app-server actions; command text is not sent to the model as an ordinary prompt.
 - Commands that require an objective complete their syntax instead of submitting an incomplete command.
 - Goal loading is cached per thread; notifications update local state without triggering a thread-list or message reload.
 - CodexApp does not issue a duplicate `turn/start`; app-server owns the autonomous goal loop.

--- a/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
+++ b/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
@@ -1,0 +1,25 @@
+### Feature: Windows absolute file links open through local browse
+
+## Prerequisites
+
+- Run CodexApp on Windows.
+- Open TestChat with a project that contains an existing text file and MP4 file on a drive-letter path.
+
+## Steps
+
+1. Send a message containing Markdown links to `C:/path/to/file.ps1` and `C:/path/to/video.mp4`.
+2. Inspect both rendered links and confirm their `href`, title, and visible text preserve the complete drive-letter paths.
+3. Open the text-file link and confirm the request returns the existing file instead of a 404 response.
+4. Open the MP4 link and seek within the video.
+5. Inspect the MP4 request and confirm byte-range requests return `206 Partial Content` with `Accept-Ranges: bytes`.
+
+## Expected Results
+
+- Windows drive paths are decoded as `C:/...`, not `/C:/...` or `C:\\C:\\...`.
+- Existing files return successfully through `/codex-local-browse/C:/...`.
+- MP4 files use the correct media content type and support browser range requests.
+- Unix absolute paths and UNC paths retain their existing behavior.
+
+## Rollback / Cleanup
+
+- Close the opened file and video tabs. No files are modified by this test.

--- a/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
+++ b/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
@@ -12,12 +12,14 @@
 3. Open the text-file link and confirm the request returns the existing file instead of a 404 response.
 4. Open the MP4 link and seek within the video.
 5. Inspect the MP4 request and confirm byte-range requests return `206 Partial Content` with `Accept-Ranges: bytes`.
+6. Open a directory through local browse and click a nested folder plus the parent (`..`) link.
 
 ## Expected Results
 
 - Windows drive paths are decoded as `C:/...`, not `/C:/...` or `C:\\C:\\...`.
 - Existing files return successfully through `/codex-local-browse/C:/...`.
 - MP4 files use the correct media content type and support browser range requests.
+- Directory, parent, and edit links use `/codex-local-browse/C:/...` or `/codex-local-edit/C:/...` with forward slashes and a separator after the route prefix.
 - Unix absolute paths and UNC paths retain their existing behavior.
 
 ## Rollback / Cleanup


### PR DESCRIPTION
## Summary  - add app-server-backed thread Goal state through `thread/goal/get`, `thread/goal/set`, and `thread/goal/clear` - support `/goal <objective>`, `/goal`, `/goal edit <objective>`, `/goal pause`, `/goal resume`, and `/goal clear` - make Goal mode discoverable with a slash-command picker, prefix filtering, keyboard navigation, syntax completion, and execution previews - show a responsive goal bar with status, optional token budget, inline editing, pause/resume, and clear controls - consume `thread/goal/updated` and `thread/goal/cleared` notifications without broad thread/message refreshes  ## Protocol behavior  `thread/goal/set` owns and starts the autonomous goal loop. CodexApp does not send a second `turn/start`, avoiding duplicate work.  ## Performance audit  - goal reads are cached per thread and concurrent reads are deduplicated - selecting a cached thread does not issue another goal read - goal notifications update the keyed local record directly and bypass the existing broad thread refresh path - slash discovery filters a fixed six-item local array and adds no requests, polling, or cache invalidation - no unbounded fanout, blocking loop, or large payload was added  ## Verification  - `npm run test:unit -- --run src/utils/goalCommand.test.ts src/api/codexGateway.test.ts src/composables/useDesktopState.test.ts` (54 passed) - `npm run build:frontend` (passed) - Playwright against `127.0.0.1:4173`: desktop and 375x812 phone in light and dark themes; all six commands found, keyboard completion passed, no page errors or horizontal overflow - live app-server smoke: goal get/set/edit/clear and notification-backed UI updates  The full unit suite has 153/155 passing on Windows. The two unrelated failures require unprivileged symlink creation and POSIX `0600` mode reporting, which this Windows environment does not provide.  ## Manual coverage  Added `tests/chat-composer-rendering/thread-goal-mode.md` and linked it from the manual test index.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added a per-thread Goal bar with status/usage plus edit (save/cancel), pause/resume, and clear.
  - Enhanced `/goal` slash-command autocomplete with in-input previews and keyboard selection.
- **Bug Fixes**
  - Improved goal state syncing and reduced unnecessary thread refreshes during updates.
  - Improved Windows absolute path handling for local-browse/edit links.
- **Documentation**
  - Added manual test coverage for thread goal mode and Windows local-browse link behavior.
- **Tests**
  - Added/extended automated tests for `/goal` parsing/suggestions, thread goal RPCs, and local-browse path decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->  ## Windows local browse follow-up  - normalize `/C:/...` routes on Windows so agent-generated local file links resolve correctly - verify exact PowerShell and MP4 paths, including MP4 byte-range responses - propose the focused upstream fix separately in #212    ## Windows directory navigation follow-up  - normalize generated Windows browse and edit links to canonical forward-slash routes such as `/codex-local-browse/C:/Users/...` - preserve Unix and UNC paths plus project-picker query encoding - verify real parent -> child -> parent folder navigation with Playwright  Additional verification:  - `npm run test:unit -- --run src/server/localBrowseUi.test.ts src/utils/goalCommand.test.ts` (11 passed) - `npm run build` (passed) - focused local-browse suite (6 passed) 
## Native Codex slash commands

- expand the composer picker beyond Goal mode with `/plan`, `/review`, `/compact`, `/model`, `/rename`, `/fork`, and `/archive`
- execute each command through the corresponding app-server or local UI action instead of sending slash text to the model
- keep terminal-only CLI commands out of the web picker so every advertised command works on this surface
- filter a fixed 13-item local list; no command-discovery request, polling, fanout, or cache invalidation is added

Additional verification:

- focused Vitest: 61 passed
- production build: passed
- Playwright: desktop/phone, light/dark; all 13 commands, filtering, Tab completion, previews, no overflow, no page errors
- full Vitest: 166/168; only the existing Windows symlink and POSIX mode assertions fail