### PR TITLE
Fix Windows local browse paths

### DIFF
--- a/src/server/localBrowseUi.test.ts
+++ b/src/server/localBrowseUi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { decodeBrowsePath } from './localBrowseUi'
+import { decodeBrowsePath, toBrowseHref, toEditHref } from './localBrowseUi'
 
 describe('decodeBrowsePath', () => {
   it('removes the browse-route slash before Windows drive paths', () => {
@@ -15,5 +15,28 @@ describe('decodeBrowsePath', () => {
 
   it('leaves malformed URL encoding usable for the normal validation path', () => {
     expect(decodeBrowsePath('/tmp/100%/file.txt', 'linux')).toBe('/tmp/100%/file.txt')
+  })
+})
+
+describe('local browse route hrefs', () => {
+  it('adds the route separator and converts Windows path separators', () => {
+    const path = String.raw`C:\Users\Nulled\Documents\invasion\artifacts\autonomous-weaponry\mammoth-v1`
+    expect(toBrowseHref(path)).toBe(
+      '/codex-local-browse/C:/Users/Nulled/Documents/invasion/artifacts/autonomous-weaponry/mammoth-v1',
+    )
+    expect(toEditHref(String.raw`C:\Users\Nulled\file.ps1`)).toBe(
+      '/codex-local-edit/C:/Users/Nulled/file.ps1',
+    )
+  })
+
+  it('preserves Unix and UNC absolute paths', () => {
+    expect(toBrowseHref('/home/codex/folder')).toBe('/codex-local-browse/home/codex/folder')
+    expect(toBrowseHref(String.raw`\\server\share\folder`)).toBe('/codex-local-browse//server/share/folder')
+  })
+
+  it('keeps project picker query parameters encoded', () => {
+    expect(toBrowseHref(String.raw`C:\Users\Nulled\Parent Folder`, 'My Project')).toBe(
+      '/codex-local-browse/C:/Users/Nulled/Parent%20Folder?newProjectName=My%20Project',
+    )
   })
 })

--- a/src/server/localBrowseUi.test.ts
+++ b/src/server/localBrowseUi.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { decodeBrowsePath } from './localBrowseUi'
+
+describe('decodeBrowsePath', () => {
+  it('removes the browse-route slash before Windows drive paths', () => {
+    expect(decodeBrowsePath('/C:/Users/Nulled/video.mp4', 'win32')).toBe('C:/Users/Nulled/video.mp4')
+    expect(decodeBrowsePath('/%43%3A/Users/Nulled/file.ps1', 'win32')).toBe('C:/Users/Nulled/file.ps1')
+  })
+
+  it('preserves Unix, UNC, and already normalized paths', () => {
+    expect(decodeBrowsePath('/home/codex/file.txt', 'linux')).toBe('/home/codex/file.txt')
+    expect(decodeBrowsePath('//server/share/file.txt', 'win32')).toBe('//server/share/file.txt')
+    expect(decodeBrowsePath('C:/Users/Nulled/file.txt', 'win32')).toBe('C:/Users/Nulled/file.txt')
+  })
+
+  it('leaves malformed URL encoding usable for the normal validation path', () => {
+    expect(decodeBrowsePath('/tmp/100%/file.txt', 'linux')).toBe('/tmp/100%/file.txt')
+  })
+})

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -69,13 +69,23 @@ export function normalizeLocalPath(rawPath: string): string {
   return trimmed
 }
 
-export function decodeBrowsePath(rawPath: string): string {
+export function decodeBrowsePath(rawPath: string, platform: NodeJS.Platform = process.platform): string {
   if (!rawPath) return ''
+  let decoded: string
   try {
-    return decodeURIComponent(rawPath)
+    decoded = decodeURIComponent(rawPath)
   } catch {
-    return rawPath
+    decoded = rawPath
   }
+
+  // Browse URLs keep an absolute-path slash after the route prefix. On Windows,
+  // that turns `C:/path` into `/C:/path`, which Node resolves as `C:\C:\path`.
+  // Remove only that synthetic slash; Unix and UNC absolute paths stay intact.
+  if (platform === 'win32' && /^\/[A-Za-z]:[\\/]/u.test(decoded)) {
+    return decoded.slice(1)
+  }
+
+  return decoded
 }
 
 export function isTextEditablePath(pathValue: string): boolean {

--- a/src/server/localBrowseUi.ts
+++ b/src/server/localBrowseUi.ts
@@ -141,16 +141,21 @@ function normalizeNewProjectName(value: string): string {
   return value.trim().replace(/[\\/]+/gu, '').trim()
 }
 
-function toBrowseHref(pathValue: string, newProjectName = ''): string {
-  const normalizedName = normalizeNewProjectName(newProjectName)
-  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-browse${encodeURI(pathValue)}${query}`
+function normalizeLocalRoutePath(pathValue: string): string {
+  const normalized = pathValue.replace(/\\/gu, '/')
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
 }
 
-function toEditHref(pathValue: string, newProjectName = ''): string {
+export function toBrowseHref(pathValue: string, newProjectName = ''): string {
   const normalizedName = normalizeNewProjectName(newProjectName)
   const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
-  return `/codex-local-edit${encodeURI(pathValue)}${query}`
+  return `/codex-local-browse${encodeURI(normalizeLocalRoutePath(pathValue))}${query}`
+}
+
+export function toEditHref(pathValue: string, newProjectName = ''): string {
+  const normalizedName = normalizeNewProjectName(newProjectName)
+  const query = normalizedName ? `?newProjectName=${encodeURIComponent(normalizedName)}` : ''
+  return `/codex-local-edit${encodeURI(normalizeLocalRoutePath(pathValue))}${query}`
 }
 
 function escapeForInlineScriptString(value: string): string {

--- a/tests/chat-composer-rendering/index.md
+++ b/tests/chat-composer-rendering/index.md
@@ -27,6 +27,7 @@ Return to the [manual test index](../../tests.md).
 | [Feature: Inline thread image payloads are rewritten to renderable local file URLs](inline-thread-image-payloads-are-rewritten-to-renderable-local-file-urls.md) |
 | [Feature: Markdown file links with spaces and parentheses in path](markdown-file-links-with-spaces-and-parentheses-in-path.md) |
 | [Feature: Markdown link with backticked label renders as file link](markdown-link-with-backticked-label-renders-as-file-link.md) |
+| [Feature: Windows absolute file links open through local browse](windows-absolute-file-links-open-local-browse.md) |
 | [Feature: Backticked bare filenames render as file links](backticked-bare-filenames-render-as-file-links.md) |
 | [Feature: Lazy message rendering (windowed conversation)](lazy-message-rendering-windowed-conversation.md) |
 | [Assistant generated image rendering](assistant-generated-image-rendering.md) |

--- a/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
+++ b/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
@@ -1,0 +1,25 @@
+### Feature: Windows absolute file links open through local browse
+
+## Prerequisites
+
+- Run CodexApp on Windows.
+- Open TestChat with a project that contains an existing text file and MP4 file on a drive-letter path.
+
+## Steps
+
+1. Send a message containing Markdown links to `C:/path/to/file.ps1` and `C:/path/to/video.mp4`.
+2. Inspect both rendered links and confirm their `href`, title, and visible text preserve the complete drive-letter paths.
+3. Open the text-file link and confirm the request returns the existing file instead of a 404 response.
+4. Open the MP4 link and seek within the video.
+5. Inspect the MP4 request and confirm byte-range requests return `206 Partial Content` with `Accept-Ranges: bytes`.
+
+## Expected Results
+
+- Windows drive paths are decoded as `C:/...`, not `/C:/...` or `C:\\C:\\...`.
+- Existing files return successfully through `/codex-local-browse/C:/...`.
+- MP4 files use the correct media content type and support browser range requests.
+- Unix absolute paths and UNC paths retain their existing behavior.
+
+## Rollback / Cleanup
+
+- Close the opened file and video tabs. No files are modified by this test.

--- a/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
+++ b/tests/chat-composer-rendering/windows-absolute-file-links-open-local-browse.md
@@ -12,12 +12,14 @@
 3. Open the text-file link and confirm the request returns the existing file instead of a 404 response.
 4. Open the MP4 link and seek within the video.
 5. Inspect the MP4 request and confirm byte-range requests return `206 Partial Content` with `Accept-Ranges: bytes`.
+6. Open a directory through local browse and click a nested folder plus the parent (`..`) link.
 
 ## Expected Results
 
 - Windows drive paths are decoded as `C:/...`, not `/C:/...` or `C:\\C:\\...`.
 - Existing files return successfully through `/codex-local-browse/C:/...`.
 - MP4 files use the correct media content type and support browser range requests.
+- Directory, parent, and edit links use `/codex-local-browse/C:/...` or `/codex-local-edit/C:/...` with forward slashes and a separator after the route prefix.
 - Unix absolute paths and UNC paths retain their existing behavior.
 
 ## Rollback / Cleanup


### PR DESCRIPTION
## Summary

- canonicalize `/C:/...` browse paths back to `C:/...` on Windows
- preserve Unix, UNC, already-normalized, and malformed-encoding behavior
- add focused unit and manual regression coverage

## Root cause

CodexApp deliberately generates `/codex-local-browse/C:/...` URLs for Windows file links. The server decoded the path as `/C:/...`, which Node resolves on Windows as `C:\\C:\\...`, so existing files returned 404.

## User impact

Agent-generated links to Windows files now open through local browse. Media files continue to use the existing `sendFile` path, including byte-range support for MP4 playback and seeking.

## Verification

- `pnpm exec vitest run src/server/localBrowseUi.test.ts` (3 passed)
- `pnpm run build` (passed)
- isolated production server: exact `.ps1` URL returned 200
- isolated production server: exact `.mp4` URL returned `video/mp4`, `Accept-Ranges: bytes`, and `206 Partial Content` for a 100-byte range
- TestChat Playwright validation: both representative links passed `hrefOk`, `titleOk`, and `textOk`
- screenshot: `output/playwright/testchat-windows-local-browse-cjs.png`

The full unit suite is 148/150 on Windows. The two unrelated failures require unprivileged symlink creation and POSIX `0600` mode reporting.

## Performance audit

The change adds one bounded regular-expression check to path decoding. It does not add requests, filesystem operations, polling, fanout, payload copies, or cache invalidation; successful links continue through the existing single `stat` plus `sendFile` request path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows absolute drive-letter links to open correctly via local browsing, including correct handling of `/C:/...` style paths.
  * Improved local browse/edit URL generation to normalize slashes consistently and keep Unix and UNC paths unchanged.
  * Enhanced path decoding behavior for encoded and malformed URL inputs.
* **Tests**
  * Added a Vitest suite covering browse path decoding and local browse/edit href creation.
  * Added a Windows-specific end-to-end test for drive-letter links (including directory navigation and MP4 byte-range requests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Directory navigation follow-up

- normalize backslashes in generated browse and edit links
- always insert the route separator before Windows drive-letter paths
- preserve Unix, UNC, and project-picker query behavior
- verified the generated `mammoth-v1` link, child HTTP 200 response, and parent navigation with Playwright
- focused decoder and URL-builder tests: 6 passed; production build passed

Performance remains one bounded string replacement and prefix check per generated href, with no additional requests, filesystem operations, polling, fanout, payload copying, or cache invalidation.

