### PR TITLE
Add model-aware reasoning and ChatGPT Pro handoff

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -489,7 +489,13 @@
                 </span>
               </div>
               <div class="sidebar-settings-rate-limits">
-                <RateLimitStatus :snapshots="accountRateLimitSnapshots" />
+                <RateLimitStatus
+                  :snapshots="accountRateLimitSnapshots"
+                  :reset-credits="rateLimitResetCredits"
+                  :is-consuming-reset="isConsumingRateLimitReset"
+                  :reset-notice="rateLimitResetNotice"
+                  @consume-reset="consumeBankedRateLimitReset"
+                />
               </div>
               <div class="sidebar-settings-build-label" :aria-label="t('Worktree name and version')">
                 WT {{ worktreeName }} · v{{ appVersion }}
@@ -1438,6 +1444,9 @@ const {
   codexCliMissingError,
   installedSkills,
   accountRateLimitSnapshots,
+  rateLimitResetCredits,
+  isConsumingRateLimitReset,
+  rateLimitResetNotice,
   messages,
   hasMoreOlderMessages,
   isLoadingThreads,
@@ -1450,6 +1459,7 @@ const {
   isUpdatingSpeedMode,
   error: desktopError,
   refreshAll,
+  consumeBankedRateLimitReset,
   refreshSkills,
   selectThread,
   ensureThreadMessagesLoaded,

--- a/src/App.vue
+++ b/src/App.vue
@@ -100,6 +100,7 @@
             @fork-thread="onForkThread"
             @remove-project="onRemoveProject" @reorder-project="onReorderProject"
             @copy-thread-chat="onCopyThreadChat"
+            @continue-in-chatgpt-pro="onContinueInChatGptPro"
             @automations-changed="onAutomationsChanged"
             @start-new-chat="onStartProjectlessNewChat" />
         </div>
@@ -944,7 +945,8 @@
                   :cwd="composerCwd"
                   :collaboration-modes="availableCollaborationModes"
                   :selected-collaboration-mode="selectedCollaborationMode"
-                  :models="availableModelIds" :selected-model="composerSelectedModelId"
+                  :models="availableModels" :selected-model="composerSelectedModelId"
+                  :reasoning-efforts="availableReasoningEfforts"
                   :selected-reasoning-effort="selectedReasoningEffort"
                   :selected-speed-mode="selectedSpeedMode"
                   :is-updating-speed-mode="isUpdatingSpeedMode"
@@ -1026,7 +1028,8 @@
                     :cwd="composerCwd"
                     :collaboration-modes="availableCollaborationModes"
                     :selected-collaboration-mode="selectedCollaborationMode"
-                    :models="availableModelIds"
+                    :models="availableModels"
+                    :reasoning-efforts="availableReasoningEfforts"
                     :selected-model="composerSelectedModelId"
                     :selected-reasoning-effort="selectedReasoningEffort"
                     :selected-speed-mode="selectedSpeedMode"
@@ -1054,6 +1057,14 @@
       </section>
     </template>
   </DesktopLayout>
+  <div
+    v-if="proHandoffNotice"
+    class="pro-handoff-notice"
+    :class="{ 'is-error': proHandoffNotice.type === 'error' }"
+    :role="proHandoffNotice.type === 'error' ? 'alert' : 'status'"
+  >
+    {{ proHandoffNotice.text }}
+  </div>
   <div v-if="projectZipExportStatus.phase !== 'idle'" class="project-zip-modal-backdrop" role="presentation">
     <div class="project-zip-modal" role="dialog" aria-modal="true" :aria-label="t('Export Project')" @click.stop>
       <div class="project-zip-modal-header">
@@ -1193,6 +1204,7 @@ import {
   checkoutGitBranch,
   cloneGithubRepository,
   configureTelegramBot,
+  createChatGptProHandoff,
   createPermanentWorktree,
   createWorktree,
   createProjectlessThreadDirectory,
@@ -1417,7 +1429,8 @@ const {
   codexQuota,
   selectedThreadId,
   availableCollaborationModes,
-  availableModelIds,
+  availableModels,
+  availableReasoningEfforts,
   selectedCollaborationMode,
   selectedModelId,
   selectedReasoningEffort,
@@ -1541,6 +1554,17 @@ const projectZipExportStatus = ref<{ phase: 'idle' | 'exporting' | 'ready'; load
   fileName: '',
   error: '',
 })
+const proHandoffNotice = ref<{ text: string; type: 'success' | 'error' } | null>(null)
+let proHandoffNoticeTimer: ReturnType<typeof setTimeout> | null = null
+
+function showProHandoffNotice(text: string, type: 'success' | 'error' = 'success'): void {
+  proHandoffNotice.value = { text, type }
+  if (proHandoffNoticeTimer) clearTimeout(proHandoffNoticeTimer)
+  proHandoffNoticeTimer = setTimeout(() => {
+    proHandoffNotice.value = null
+    proHandoffNoticeTimer = null
+  }, type === 'error' ? 6000 : 4000)
+}
 const worktreeInitStatus = ref<{ phase: 'idle' | 'running' | 'error'; title: string; message: string }>({
   phase: 'idle',
   title: '',
@@ -2173,6 +2197,10 @@ onUnmounted(() => {
   if (threadSearchTimer) {
     clearTimeout(threadSearchTimer)
     threadSearchTimer = null
+  }
+  if (proHandoffNoticeTimer) {
+    clearTimeout(proHandoffNoticeTimer)
+    proHandoffNoticeTimer = null
   }
   clearTerminalKeyboardFocusFallbackTimer()
   stopPolling()
@@ -4210,6 +4238,29 @@ async function copySelectedThreadChat(): Promise<void> {
   }
 }
 
+async function onContinueInChatGptPro(threadId: string): Promise<void> {
+  if (threadId !== selectedThreadId.value || !composerCwd.value) return
+  const chatWindow = window.open('about:blank', '_blank')
+  if (chatWindow) chatWindow.opener = null
+  showProHandoffNotice('Packaging this thread for ChatGPT Pro…')
+  try {
+    const handoff = await createChatGptProHandoff(threadId, composerCwd.value)
+    await copyTextToClipboard(handoff.markdown)
+    if (chatWindow) {
+      chatWindow.location.replace(handoff.chatgptUrl)
+      showProHandoffNotice('Handoff copied. Select GPT-5.6 Sol Pro, then paste and send.')
+    } else {
+      showProHandoffNotice('Handoff copied. Open ChatGPT, select GPT-5.6 Sol Pro, then paste and send.')
+    }
+  } catch (error) {
+    chatWindow?.close()
+    showProHandoffNotice(
+      error instanceof Error ? error.message : 'Failed to prepare the ChatGPT Pro handoff',
+      'error',
+    )
+  }
+}
+
 function buildThreadMarkdown(): string {
   const lines: string[] = []
   const threadTitle = selectedThread.value?.title?.trim() || 'Untitled thread'
@@ -6117,6 +6168,22 @@ async function loadWorktreeBranches(sourceCwd: string): Promise<void> {
 
 .sidebar-settings-build-label {
   @apply border-t border-zinc-100 px-3 py-2 text-[11px] text-zinc-500;
+}
+
+.pro-handoff-notice {
+  @apply fixed bottom-5 left-1/2 z-[120] max-w-[min(92vw,34rem)] -translate-x-1/2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-900 shadow-lg;
+}
+
+.pro-handoff-notice.is-error {
+  @apply border-rose-200 bg-rose-50 text-rose-900;
+}
+
+:root.dark .pro-handoff-notice {
+  @apply border-emerald-800 bg-emerald-950 text-emerald-100;
+}
+
+:root.dark .pro-handoff-notice.is-error {
+  @apply border-rose-800 bg-rose-950 text-rose-100;
 }
 
 </style>

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  consumeRateLimitResetCredit,
+  getAccountRateLimitsState,
   getAvailableModelIds,
   getAvailableModels,
   getThreadDetail,
@@ -65,6 +67,78 @@ describe('startThreadTurn collaboration mode payloads', () => {
         developer_instructions: null,
       },
     })
+  })
+})
+
+describe('banked rate-limit resets', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves the authoritative reset count and optional credit details', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { method: string }
+      expect(request.method).toBe('account/rateLimits/read')
+      return new Response(JSON.stringify({
+        result: {
+          rateLimits: {
+            limitId: 'codex',
+            primary: { usedPercent: 75, windowDurationMins: 300, resetsAt: 1780000000 },
+          },
+          rateLimitResetCredits: {
+            availableCount: 2,
+            credits: [{
+              id: 'RateLimitResetCredit_1',
+              resetType: 'codexRateLimits',
+              status: 'available',
+              grantedAt: 1779000000,
+              expiresAt: 1781000000,
+              title: 'Full reset',
+              description: 'Reset an eligible Codex rate-limit window.',
+            }],
+          },
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    await expect(getAccountRateLimitsState()).resolves.toMatchObject({
+      codexSnapshot: {
+        limitId: 'codex',
+        primary: { usedPercent: 75 },
+      },
+      snapshots: [{ limitId: 'codex' }],
+      resetCredits: {
+        availableCount: 2,
+        credits: [{
+          id: 'RateLimitResetCredit_1',
+          title: 'Full reset',
+          expiresAt: 1781000000,
+        }],
+      },
+    })
+  })
+
+  it('uses the selected opaque credit ID and caller-provided idempotency key', async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)) as { method: string; params: Record<string, unknown> })
+      return new Response(JSON.stringify({ result: { outcome: 'reset' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    await expect(consumeRateLimitResetCredit('RateLimitResetCredit_1', 'reset-attempt-1')).resolves.toBe('reset')
+    expect(requests).toEqual([{
+      method: 'account/rateLimitResetCredit/consume',
+      params: {
+        idempotencyKey: 'reset-attempt-1',
+        creditId: 'RateLimitResetCredit_1',
+      },
+    }])
   })
 })
 

--- a/src/api/codexGateway.test.ts
+++ b/src/api/codexGateway.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getAvailableModelIds, getThreadDetail, listDirectoryComposioConnectors, resumeThread, startThreadTurn } from './codexGateway'
+import {
+  getAvailableModelIds,
+  getAvailableModels,
+  getThreadDetail,
+  listDirectoryComposioConnectors,
+  resumeThread,
+  startThreadTurn,
+} from './codexGateway'
 
 function mockRpcFetch(): { requests: Array<{ method: string, params: Record<string, unknown> }> } {
   const requests: Array<{ method: string, params: Record<string, unknown> }> = []
@@ -172,6 +179,45 @@ describe('getAvailableModelIds', () => {
       includeProviderModels: true,
     })).resolves.toEqual(['gpt-5.5', 'gpt-5.4-mini'])
     expect(requests).toEqual(['/codex-api/provider-models', '/codex-api/rpc'])
+  })
+
+  it('preserves server-provided reasoning effort order including max and ultra', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = typeof init?.body === 'string'
+        ? JSON.parse(init.body) as { method: string }
+        : { method: '' }
+      expect(body.method).toBe('model/list')
+      return new Response(JSON.stringify({
+        result: {
+          data: [{
+            id: 'gpt-5.6-sol',
+            displayName: 'GPT-5.6 Sol',
+            description: 'Frontier coding model',
+            supportedReasoningEfforts: [
+              { reasoningEffort: 'low', description: 'Fast' },
+              { reasoningEffort: 'max', description: 'Deep' },
+              { reasoningEffort: 'ultra', description: 'Deepest' },
+            ],
+            defaultReasoningEffort: 'low',
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    await expect(getAvailableModels({ includeProviderModels: false })).resolves.toEqual([{
+      id: 'gpt-5.6-sol',
+      displayName: 'GPT-5.6 Sol',
+      description: 'Frontier coding model',
+      supportedReasoningEfforts: [
+        { value: 'low', description: 'Fast' },
+        { value: 'max', description: 'Deep' },
+        { value: 'ultra', description: 'Deepest' },
+      ],
+      defaultReasoningEffort: 'low',
+    }])
   })
 })
 

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -52,6 +52,9 @@ import type {
   UiReviewSummary,
   UiReviewWorkspaceView,
   UiRateLimitSnapshot,
+  UiRateLimitResetCredit,
+  UiRateLimitResetCredits,
+  UiRateLimitResetOutcome,
   UiRateLimitWindow,
   UiThreadAutomation,
   UiThreadAutomationStatus,
@@ -547,6 +550,73 @@ export function pickCodexRateLimitSnapshot(payload: unknown): UiRateLimitSnapsho
   if (codexBucket) return codexBucket
 
   return normalizeRateLimitSnapshot(record.rateLimits ?? record.rate_limits)
+}
+
+function normalizeRateLimitResetCredit(value: unknown): UiRateLimitResetCredit | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  const id = readString(record.id)
+  if (!id) return null
+  return {
+    id,
+    resetType: readString(record.resetType ?? record.reset_type) ?? '',
+    status: readString(record.status) ?? '',
+    grantedAt: readNumber(record.grantedAt ?? record.granted_at),
+    expiresAt: readNumber(record.expiresAt ?? record.expires_at),
+    title: readString(record.title),
+    description: readString(record.description),
+  }
+}
+
+export function pickRateLimitResetCredits(payload: unknown): UiRateLimitResetCredits | null {
+  const record = asRecord(payload)
+  const resetCredits = asRecord(record?.rateLimitResetCredits ?? record?.rate_limit_reset_credits)
+  if (!resetCredits) return null
+
+  const availableCount = readNumber(resetCredits.availableCount ?? resetCredits.available_count)
+  if (availableCount === null) return null
+  const rawCredits = resetCredits.credits
+  return {
+    availableCount: Math.max(0, Math.floor(availableCount)),
+    credits: rawCredits === null || rawCredits === undefined
+      ? null
+      : (Array.isArray(rawCredits)
+          ? rawCredits
+              .map(normalizeRateLimitResetCredit)
+              .filter((credit): credit is UiRateLimitResetCredit => credit !== null)
+          : null),
+  }
+}
+
+export function pickRateLimitSnapshots(payload: unknown): UiRateLimitSnapshot[] {
+  const record = asRecord(payload)
+  if (!record) return []
+
+  const snapshots: UiRateLimitSnapshot[] = []
+  const seen = new Set<string>()
+  const pushSnapshot = (snapshot: UiRateLimitSnapshot | null): void => {
+    if (!snapshot) return
+    const key = snapshot.limitId?.trim() || snapshot.limitName?.trim() || '__default__'
+    if (seen.has(key)) return
+    seen.add(key)
+    snapshots.push(snapshot)
+  }
+
+  pushSnapshot(normalizeRateLimitSnapshot(record.rateLimits ?? record.rate_limits))
+  const rateLimitsByLimitId = asRecord(record.rateLimitsByLimitId ?? record.rate_limits_by_limit_id)
+  if (rateLimitsByLimitId) {
+    for (const value of Object.values(rateLimitsByLimitId)) {
+      pushSnapshot(normalizeRateLimitSnapshot(value))
+    }
+  }
+  return snapshots
+}
+
+export type AccountRateLimitsState = {
+  codexSnapshot: UiRateLimitSnapshot | null
+  snapshots: UiRateLimitSnapshot[]
+  resetCredits: UiRateLimitResetCredits | null
 }
 
 async function callRpc<T>(method: string, params?: unknown): Promise<T> {
@@ -1418,6 +1488,51 @@ export async function getAccountRateLimits(): Promise<UiRateLimitSnapshot | null
   } catch (error) {
     throw normalizeCodexApiError(error, 'Failed to load account rate limits', 'account/rateLimits/read')
   }
+}
+
+export async function getAccountRateLimitsState(): Promise<AccountRateLimitsState> {
+  try {
+    const payload = await callRpc<unknown>('account/rateLimits/read')
+    return {
+      codexSnapshot: pickCodexRateLimitSnapshot(payload),
+      snapshots: pickRateLimitSnapshots(payload),
+      resetCredits: pickRateLimitResetCredits(payload),
+    }
+  } catch (error) {
+    throw normalizeCodexApiError(error, 'Failed to load account rate limits', 'account/rateLimits/read')
+  }
+}
+
+function createRateLimitResetIdempotencyKey(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  return `codexapp-reset-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+export async function consumeRateLimitResetCredit(
+  creditId?: string,
+  idempotencyKey: string = createRateLimitResetIdempotencyKey(),
+): Promise<UiRateLimitResetOutcome> {
+  const normalizedIdempotencyKey = idempotencyKey.trim()
+  if (!normalizedIdempotencyKey) throw new Error('A reset idempotency key is required')
+  const normalizedCreditId = creditId?.trim() ?? ''
+  const params: { idempotencyKey: string; creditId?: string } = {
+    idempotencyKey: normalizedIdempotencyKey,
+  }
+  if (normalizedCreditId) params.creditId = normalizedCreditId
+
+  const result = await callRpc<unknown>('account/rateLimitResetCredit/consume', params)
+  const outcome = readString(asRecord(result)?.outcome)
+  if (
+    outcome === 'reset'
+    || outcome === 'alreadyRedeemed'
+    || outcome === 'nothingToReset'
+    || outcome === 'noCredit'
+  ) {
+    return outcome
+  }
+  throw new Error('Codex returned an unknown rate-limit reset outcome')
 }
 
 function normalizeAccountsListResult(payload: unknown): AccountsListResult {

--- a/src/api/codexGateway.ts
+++ b/src/api/codexGateway.ts
@@ -12,7 +12,6 @@ import type {
   ConfigReadResponse,
   GetAccountRateLimitsResponse,
   ModelListResponse,
-  ReasoningEffort,
   ThreadForkResponse,
   ThreadListResponse,
   ThreadReadResponse,
@@ -30,6 +29,7 @@ import {
 } from './normalizers/v2'
 import type {
   SpeedMode,
+  ReasoningEffort,
   UiAccountEntry,
   UiAccountQuotaStatus,
   UiAccountUnavailableReason,
@@ -55,6 +55,8 @@ import type {
   UiRateLimitWindow,
   UiThreadAutomation,
   UiThreadAutomationStatus,
+  UiModelOption,
+  UiReasoningEffortOption,
 } from '../types/codex'
 import { normalizePathForUi } from '../pathUtils.js'
 
@@ -555,6 +557,29 @@ async function callRpc<T>(method: string, params?: unknown): Promise<T> {
   }
 }
 
+export type ChatGptProHandoff = {
+  markdown: string
+  chatgptUrl: string
+}
+
+export async function createChatGptProHandoff(threadId: string, cwd: string): Promise<ChatGptProHandoff> {
+  const response = await fetch('/codex-api/thread/pro-handoff', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ threadId, cwd }),
+  })
+  const payload = await response.json() as { data?: Partial<ChatGptProHandoff>; error?: unknown }
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, 'Failed to prepare the ChatGPT Pro handoff'))
+  }
+  const markdown = typeof payload.data?.markdown === 'string' ? payload.data.markdown : ''
+  const chatgptUrl = typeof payload.data?.chatgptUrl === 'string' ? payload.data.chatgptUrl : ''
+  if (!markdown || !chatgptUrl) {
+    throw new Error('The ChatGPT Pro handoff response was incomplete')
+  }
+  return { markdown, chatgptUrl }
+}
+
 function normalizeFallbackFileChange(value: unknown): UiFileChange | null {
   const record = asRecord(value)
   if (!record) return null
@@ -700,7 +725,7 @@ async function enrichThreadMessagesWithFallback(threadId: string, messages: UiMe
 }
 
 function normalizeReasoningEffort(value: unknown): ReasoningEffort | '' {
-  const allowed: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
+  const allowed: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
   return typeof value === 'string' && allowed.includes(value as ReasoningEffort)
     ? (value as ReasoningEffort)
     : ''
@@ -2036,27 +2061,84 @@ async function fetchProviderModelIds(providerId?: string): Promise<{ ids: string
   return null
 }
 
-export async function getAvailableModelIds(options: { includeProviderModels?: boolean; requireProviderModels?: boolean; providerId?: string } = {}): Promise<string[]> {
+function normalizeModelReasoningEfforts(value: unknown): UiReasoningEffortOption[] {
+  const rows = Array.isArray(value) ? value : []
+  const options: UiReasoningEffortOption[] = []
+  for (const row of rows) {
+    const record = row && typeof row === 'object' && !Array.isArray(row)
+      ? row as Record<string, unknown>
+      : null
+    const effort = normalizeReasoningEffort(record?.reasoningEffort ?? record?.reasoning_effort)
+    if (!effort || options.some((option) => option.value === effort)) continue
+    options.push({
+      value: effort,
+      description: typeof record?.description === 'string' ? record.description.trim() : '',
+    })
+  }
+  return options
+}
+
+export async function getAvailableModels(options: { includeProviderModels?: boolean; requireProviderModels?: boolean; providerId?: string } = {}): Promise<UiModelOption[]> {
   const shouldIncludeProviderModels = options.includeProviderModels !== false
   const providerModels = shouldIncludeProviderModels ? await fetchProviderModelIds(options.providerId) : null
 
   if (providerModels?.exclusive || options.requireProviderModels) {
-    return providerModels?.ids ?? []
+    return (providerModels?.ids ?? []).map((id) => ({
+      id,
+      displayName: '',
+      description: '',
+      supportedReasoningEfforts: [],
+      defaultReasoningEffort: '',
+    }))
   }
 
   const payload = await callRpc<ModelListResponse>('model/list', {})
-  const ids: string[] = []
+  const models: UiModelOption[] = []
   for (const row of payload.data) {
     const candidate = row.id || row.model
-    if (!candidate || ids.includes(candidate)) continue
-    ids.push(candidate)
+    if (!candidate || models.some((model) => model.id === candidate)) continue
+    const rawRow = row as unknown as Record<string, unknown>
+    models.push({
+      id: candidate,
+      displayName: typeof rawRow.displayName === 'string' ? rawRow.displayName.trim() : '',
+      description: typeof rawRow.description === 'string' ? rawRow.description.trim() : '',
+      supportedReasoningEfforts: normalizeModelReasoningEfforts(
+        rawRow.supportedReasoningEfforts ?? rawRow.supported_reasoning_efforts,
+      ),
+      defaultReasoningEffort: normalizeReasoningEffort(
+        rawRow.defaultReasoningEffort ?? rawRow.default_reasoning_effort,
+      ),
+    })
   }
 
-  if (!shouldIncludeProviderModels || !providerModels) return ids
+  if (!shouldIncludeProviderModels || !providerModels) return models
 
   for (const candidate of providerModels.ids) {
-    if (!ids.includes(candidate)) ids.push(candidate)
+    if (models.some((model) => model.id === candidate)) continue
+    models.push({
+      id: candidate,
+      displayName: '',
+      description: '',
+      supportedReasoningEfforts: [],
+      defaultReasoningEffort: '',
+    })
   }
+  return models
+}
+
+export type AvailableModelIdList = string[] & {
+  readonly modelOptions?: UiModelOption[]
+}
+
+export async function getAvailableModelIds(options: { includeProviderModels?: boolean; requireProviderModels?: boolean; providerId?: string } = {}): Promise<AvailableModelIdList> {
+  const models = await getAvailableModels(options)
+  const ids = models.map((model) => model.id) as AvailableModelIdList
+  Object.defineProperty(ids, 'modelOptions', {
+    value: models,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  })
   return ids
 }
 

--- a/src/components/content/RateLimitStatus.vue
+++ b/src/components/content/RateLimitStatus.vue
@@ -1,5 +1,9 @@
 <template>
-  <aside v-if="snapshots.length > 0" class="rate-limit-status" aria-live="polite">
+  <aside
+    v-if="snapshots.length > 0 || resetCredits !== null || resetNotice !== null"
+    class="rate-limit-status"
+    aria-live="polite"
+  >
     <div
       v-for="snapshot in snapshots"
       :key="getSnapshotKey(snapshot)"
@@ -25,15 +29,103 @@
         {{ getFooterParts(snapshot).join(' | ') }}
       </div>
     </div>
+
+    <section
+      v-if="resetCredits !== null"
+      class="banked-reset-card"
+      aria-label="Banked rate-limit resets"
+    >
+      <div class="banked-reset-header">
+        <div>
+          <span class="banked-reset-eyebrow">Banked resets</span>
+          <strong class="banked-reset-count">
+            {{ resetCredits.availableCount }} available
+          </strong>
+        </div>
+        <span class="banked-reset-icon" aria-hidden="true">↻</span>
+      </div>
+
+      <p class="banked-reset-explanation">
+        Use one reset on an eligible Codex rate-limit window. Using a reset cannot be undone.
+      </p>
+
+      <div v-if="visibleResetCredits.length > 0" class="banked-reset-list">
+        <article
+          v-for="credit in visibleResetCredits"
+          :key="credit.id"
+          class="banked-reset-entry"
+        >
+          <div class="banked-reset-entry-copy">
+            <strong>{{ credit.title || 'Rate-limit reset' }}</strong>
+            <span v-if="credit.description">{{ credit.description }}</span>
+            <span v-if="formatCreditExpiry(credit.expiresAt)" class="banked-reset-expiry">
+              {{ formatCreditExpiry(credit.expiresAt) }}
+            </span>
+          </div>
+          <button
+            class="banked-reset-use"
+            type="button"
+            :disabled="isConsumingReset || resetCredits.availableCount <= 0"
+            @click="onUseReset(credit.id)"
+          >
+            {{ getUseResetLabel(credit.id) }}
+          </button>
+        </article>
+      </div>
+
+      <button
+        v-else-if="resetCredits.availableCount > 0"
+        class="banked-reset-use banked-reset-use-generic"
+        type="button"
+        :disabled="isConsumingReset"
+        @click="onUseReset()"
+      >
+        {{ getUseResetLabel() }}
+      </button>
+
+      <p v-else class="banked-reset-empty">No banked resets available.</p>
+      <p v-if="hiddenResetCreditCount > 0" class="banked-reset-hidden">
+        +{{ hiddenResetCreditCount }} additional reset{{ hiddenResetCreditCount === 1 ? '' : 's' }}
+      </p>
+      <p
+        v-if="resetNotice"
+        class="banked-reset-notice"
+        :data-type="resetNotice.type"
+        :role="resetNotice.type === 'error' ? 'alert' : 'status'"
+      >
+        {{ resetNotice.text }}
+      </p>
+    </section>
   </aside>
 </template>
 
 <script setup lang="ts">
-import type { UiRateLimitSnapshot, UiRateLimitWindow } from '../../types/codex'
+import { computed, onUnmounted, ref, watch } from 'vue'
+import type {
+  UiRateLimitResetCredit,
+  UiRateLimitResetCredits,
+  UiRateLimitSnapshot,
+  UiRateLimitWindow,
+} from '../../types/codex'
 
-defineProps<{
+const props = defineProps<{
   snapshots: UiRateLimitSnapshot[]
+  resetCredits: UiRateLimitResetCredits | null
+  isConsumingReset: boolean
+  resetNotice: { type: 'success' | 'info' | 'error'; text: string } | null
 }>()
+
+const emit = defineEmits<{
+  'consume-reset': [creditId?: string]
+}>()
+
+const confirmingCreditId = ref('')
+let confirmationTimer: ReturnType<typeof setTimeout> | null = null
+const visibleResetCredits = computed<UiRateLimitResetCredit[]>(() => props.resetCredits?.credits ?? [])
+const hiddenResetCreditCount = computed(() => Math.max(
+  0,
+  (props.resetCredits?.availableCount ?? 0) - visibleResetCredits.value.length,
+))
 
 type RateLimitMetric = {
   key: string
@@ -181,6 +273,55 @@ function buildTooltip(snapshot: UiRateLimitSnapshot): string {
   }
   return lines.join('\n')
 }
+
+function confirmationKey(creditId?: string): string {
+  return creditId?.trim() || '__next_available__'
+}
+
+function clearResetConfirmation(): void {
+  confirmingCreditId.value = ''
+  if (confirmationTimer) {
+    clearTimeout(confirmationTimer)
+    confirmationTimer = null
+  }
+}
+
+function onUseReset(creditId?: string): void {
+  if (props.isConsumingReset) return
+  const key = confirmationKey(creditId)
+  if (confirmingCreditId.value !== key) {
+    clearResetConfirmation()
+    confirmingCreditId.value = key
+    confirmationTimer = setTimeout(clearResetConfirmation, 6000)
+    return
+  }
+  clearResetConfirmation()
+  emit('consume-reset', creditId)
+}
+
+function getUseResetLabel(creditId?: string): string {
+  if (props.isConsumingReset) return 'Using…'
+  return confirmingCreditId.value === confirmationKey(creditId)
+    ? 'Click again to confirm'
+    : 'Use reset'
+}
+
+function formatCreditExpiry(expiresAt: number | null): string {
+  if (!expiresAt) return ''
+  const date = new Date(expiresAt * 1000)
+  if (Number.isNaN(date.getTime())) return ''
+  const diffMs = date.getTime() - Date.now()
+  if (diffMs <= 0) return 'Expired'
+  const diffDays = Math.max(1, Math.ceil(diffMs / 86_400_000))
+  return `Expires ${date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+  })} · ${diffDays}d left`
+}
+
+watch(() => props.resetCredits?.availableCount, clearResetConfirmation)
+onUnmounted(clearResetConfirmation)
 </script>
 
 <style scoped>
@@ -217,5 +358,79 @@ function buildTooltip(snapshot: UiRateLimitSnapshot): string {
 
 .rate-limit-card-footer {
   @apply mt-1 text-[11px] text-zinc-500;
+}
+
+.banked-reset-card {
+  @apply w-full rounded-xl border border-violet-200 bg-violet-50/90 px-3 py-3 text-left shadow-sm;
+  max-width: 22rem;
+}
+
+.banked-reset-header {
+  @apply flex items-start justify-between gap-3;
+}
+
+.banked-reset-eyebrow {
+  @apply block text-[10px] font-semibold uppercase tracking-[0.1em] text-violet-600;
+}
+
+.banked-reset-count {
+  @apply mt-0.5 block text-sm font-semibold text-violet-950;
+}
+
+.banked-reset-icon {
+  @apply inline-flex h-7 w-7 items-center justify-center rounded-full bg-violet-200 text-base font-semibold text-violet-800;
+}
+
+.banked-reset-explanation {
+  @apply mt-2 text-[11px] leading-4 text-violet-800;
+}
+
+.banked-reset-list {
+  @apply mt-2 space-y-2;
+}
+
+.banked-reset-entry {
+  @apply rounded-lg border border-violet-200 bg-white/80 p-2;
+}
+
+.banked-reset-entry-copy {
+  @apply flex min-w-0 flex-col gap-0.5;
+}
+
+.banked-reset-entry-copy strong {
+  @apply text-xs font-semibold text-zinc-900;
+}
+
+.banked-reset-entry-copy span {
+  @apply text-[11px] leading-4 text-zinc-600;
+}
+
+.banked-reset-entry-copy .banked-reset-expiry {
+  @apply font-medium text-violet-700;
+}
+
+.banked-reset-use {
+  @apply mt-2 w-full rounded-lg bg-violet-700 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50;
+}
+
+.banked-reset-use-generic {
+  @apply mt-3;
+}
+
+.banked-reset-empty,
+.banked-reset-hidden {
+  @apply mt-2 text-[11px] text-violet-700;
+}
+
+.banked-reset-notice {
+  @apply mt-2 rounded-lg border border-emerald-200 bg-emerald-50 px-2 py-1.5 text-[11px] leading-4 text-emerald-800;
+}
+
+.banked-reset-notice[data-type='info'] {
+  @apply border-amber-200 bg-amber-50 text-amber-800;
+}
+
+.banked-reset-notice[data-type='error'] {
+  @apply border-rose-200 bg-rose-50 text-rose-800;
 }
 </style>

--- a/src/components/content/ThreadComposer.vue
+++ b/src/components/content/ThreadComposer.vue
@@ -396,8 +396,10 @@ import type {
   CollaborationModeOption,
   ReasoningEffort,
   SpeedMode,
+  UiModelOption,
   UiRateLimitSnapshot,
   UiRateLimitWindow,
+  UiReasoningEffortOption,
   UiThreadTokenUsage,
   UiTokenUsageBreakdown,
 } from '../../types/codex'
@@ -437,7 +439,8 @@ const props = defineProps<{
   cwd?: string
   collaborationModes?: CollaborationModeOption[]
   selectedCollaborationMode: CollaborationModeKind
-  models: string[]
+  models: UiModelOption[]
+  reasoningEfforts: UiReasoningEffortOption[]
   selectedModel: string
   selectedReasoningEffort: ReasoningEffort | ''
   selectedSpeedMode: SpeedMode
@@ -585,20 +588,27 @@ const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.
 const DRAFT_STORAGE_PREFIX = 'codex-web-local.thread-draft.v1.'
 let lastActiveThreadId = ''
 
-const reasoningOptions: Array<{ value: ReasoningEffort; label: string }> = [
-  { value: 'none', label: 'None' },
-  { value: 'minimal', label: 'Minimal' },
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra high' },
-]
+function formatReasoningEffortLabel(effort: ReasoningEffort): string {
+  if (effort === 'xhigh') return 'Extra high'
+  return `${effort.slice(0, 1).toUpperCase()}${effort.slice(1)}`
+}
+
+const reasoningOptions = computed(() =>
+  props.reasoningEfforts.map((option) => ({
+    value: option.value,
+    label: formatReasoningEffortLabel(option.value),
+  })),
+)
+
 function formatModelLabel(modelId: string): string {
   return modelId.trim().replace(/^gpt/i, 'GPT')
 }
 
 const modelOptions = computed(() =>
-  props.models.map((modelId) => ({ value: modelId, label: formatModelLabel(modelId) })),
+  props.models.map((model) => ({
+    value: model.id,
+    label: model.displayName.trim() || formatModelLabel(model.id),
+  })),
 )
 const isPlanModeSelected = computed(() => props.selectedCollaborationMode === 'plan')
 

--- a/src/components/sidebar/SidebarThreadTree.vue
+++ b/src/components/sidebar/SidebarThreadTree.vue
@@ -633,6 +633,15 @@
         >
           Copy chat
         </button>
+        <button
+          class="thread-menu-item"
+          type="button"
+          :disabled="openThreadMenuThread.id !== selectedThreadId"
+          :title="openThreadMenuThread.id === selectedThreadId ? 'Package this thread and open ChatGPT' : 'Open this chat before continuing in ChatGPT Pro'"
+          @click="onContinueInChatGptPro(openThreadMenuThread.id)"
+        >
+          Continue in ChatGPT Pro…
+        </button>
         <button class="thread-menu-item" type="button" @click="onForkThread(openThreadMenuThread.id)">
           Create chat fork
         </button>
@@ -935,6 +944,7 @@ const emit = defineEmits<{
   'remove-project': [projectName: string]
   'reorder-project': [payload: { projectName: string; toIndex: number }]
   'copy-thread-chat': [threadId: string]
+  'continue-in-chatgpt-pro': [threadId: string]
   'fork-thread': [threadId: string]
   'start-new-chat': []
   'automations-changed': []
@@ -1714,6 +1724,12 @@ function setAutomationScheduleMode(mode: AutomationScheduleMode): void {
 function onCopyThreadChat(threadId: string): void {
   if (threadId !== props.selectedThreadId) return
   emit('copy-thread-chat', threadId)
+  closeThreadMenu()
+}
+
+function onContinueInChatGptPro(threadId: string): void {
+  if (threadId !== props.selectedThreadId) return
+  emit('continue-in-chatgpt-pro', threadId)
   closeThreadMenu()
 }
 

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -13,8 +13,10 @@ import type { WorkspaceRootsState } from '../api/codexGateway'
 
 const gatewayMocks = vi.hoisted(() => ({
   archiveThread: vi.fn(),
+  consumeRateLimitResetCredit: vi.fn(),
   forkThread: vi.fn(),
   getAccountRateLimits: vi.fn(),
+  getAccountRateLimitsState: vi.fn(),
   getAvailableCollaborationModes: vi.fn(),
   getAvailableModelIds: vi.fn(),
   getCurrentModelConfig: vi.fn(),
@@ -84,10 +86,56 @@ beforeEach(() => {
   gatewayMocks.getThreadQueueState.mockResolvedValue({})
   gatewayMocks.getThreadTitleCache.mockResolvedValue({ titles: {} })
   gatewayMocks.getWorkspaceRootsState.mockRejectedValue(new Error('no workspace roots state'))
+  gatewayMocks.getAccountRateLimitsState.mockResolvedValue({
+    codexSnapshot: null,
+    snapshots: [],
+    resetCredits: null,
+  })
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
+})
+
+describe('banked rate-limit resets', () => {
+  it('uses a selected reset and refreshes the authoritative balance and quota', async () => {
+    gatewayMocks.consumeRateLimitResetCredit.mockResolvedValue('reset')
+    gatewayMocks.getAccountRateLimitsState.mockResolvedValue({
+      codexSnapshot: {
+        limitId: 'codex',
+        limitName: null,
+        primary: { usedPercent: 0, windowDurationMins: 300, windowMinutes: 300, resetsAt: 1780000000 },
+        secondary: null,
+        credits: null,
+        planType: 'pro',
+      },
+      snapshots: [{
+        limitId: 'codex',
+        limitName: null,
+        primary: { usedPercent: 0, windowDurationMins: 300, windowMinutes: 300, resetsAt: 1780000000 },
+        secondary: null,
+        credits: null,
+        planType: 'pro',
+      }],
+      resetCredits: {
+        availableCount: 1,
+        credits: null,
+      },
+    })
+
+    const state = useDesktopState()
+    await state.consumeBankedRateLimitReset('RateLimitResetCredit_1')
+
+    expect(gatewayMocks.consumeRateLimitResetCredit).toHaveBeenCalledWith('RateLimitResetCredit_1')
+    expect(gatewayMocks.getAccountRateLimitsState).toHaveBeenCalledTimes(1)
+    expect(state.rateLimitResetCredits.value?.availableCount).toBe(1)
+    expect(state.codexQuota.value?.primary?.usedPercent).toBe(0)
+    expect(state.rateLimitResetNotice.value).toEqual({
+      type: 'success',
+      text: 'Rate limits reset. Your quota and banked-reset balance were refreshed.',
+    })
+    expect(state.isConsumingRateLimitReset.value).toBe(false)
+  })
 })
 
 describe('filterGroupsByWorkspaceRoots', () => {

--- a/src/composables/useDesktopState.test.ts
+++ b/src/composables/useDesktopState.test.ts
@@ -741,6 +741,60 @@ describe('live error overlay', () => {
 })
 
 describe('provider model selection', () => {
+  it('uses the selected model metadata to expose max and ultra and resets unsupported effort', async () => {
+    installTestWindow()
+    gatewayMocks.getThreadGroupsPage.mockResolvedValue({ groups: [], nextCursor: null })
+    gatewayMocks.getAvailableCollaborationModes.mockResolvedValue([{ value: 'default', label: 'Default' }])
+    gatewayMocks.getSkillsList.mockResolvedValue([])
+    gatewayMocks.getAccountRateLimits.mockResolvedValue(null)
+    gatewayMocks.getCurrentModelConfig.mockResolvedValue({
+      model: 'gpt-5.6-sol',
+      providerId: 'codex',
+      reasoningEffort: 'low',
+      speedMode: 'standard',
+    })
+    const modelIds = ['gpt-5.6-sol', 'gpt-5.4-mini']
+    Object.defineProperty(modelIds, 'modelOptions', {
+      value: [
+        {
+          id: 'gpt-5.6-sol',
+          displayName: 'GPT-5.6 Sol',
+          description: '',
+          supportedReasoningEfforts: [
+            { value: 'low', description: '' },
+            { value: 'max', description: '' },
+            { value: 'ultra', description: '' },
+          ],
+          defaultReasoningEffort: 'low',
+        },
+        {
+          id: 'gpt-5.4-mini',
+          displayName: 'GPT-5.4 mini',
+          description: '',
+          supportedReasoningEfforts: [
+            { value: 'low', description: '' },
+            { value: 'medium', description: '' },
+            { value: 'high', description: '' },
+          ],
+          defaultReasoningEffort: 'medium',
+        },
+      ],
+      enumerable: false,
+    })
+    gatewayMocks.getAvailableModelIds.mockResolvedValue(modelIds)
+
+    const state = useDesktopState()
+    await state.refreshAll({ includeSelectedThreadMessages: false, awaitAncillaryRefreshes: true })
+
+    expect(state.availableReasoningEfforts.value.map((option) => option.value)).toEqual(['low', 'max', 'ultra'])
+    state.setSelectedReasoningEffort('ultra')
+    expect(state.selectedReasoningEffort.value).toBe('ultra')
+
+    state.setSelectedModelIdForThread('', 'gpt-5.4-mini')
+    expect(state.availableReasoningEfforts.value.map((option) => option.value)).toEqual(['low', 'medium', 'high'])
+    expect(state.selectedReasoningEffort.value).toBe('medium')
+  })
+
   it('ignores global selected-model localStorage when OpenCode Zen is the active provider', async () => {
     installTestWindow({
       'codex-web-local.selected-model-by-context.v1': JSON.stringify({

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -33,6 +33,7 @@ import {
   subscribeCodexNotifications,
   startThreadTurn,
   type RpcNotification,
+  type AvailableModelIdList,
   type SkillInfo,
   type ThreadQueueState,
   type WorkspaceRootsState,
@@ -49,6 +50,7 @@ import type {
   UiFileChange,
   UiLiveOverlay,
   UiMessage,
+  UiModelOption,
   UiPlanData,
   UiPlanStep,
   UiProjectGroup,
@@ -58,6 +60,7 @@ import type {
   UiThreadTokenUsage,
   UiTokenUsageBreakdown,
   UiThread,
+  UiReasoningEffortOption,
 } from '../types/codex'
 import { getPathParent, isProjectlessChatPath, normalizePathForUi, toProjectName } from '../pathUtils.js'
 
@@ -91,7 +94,14 @@ const TURN_START_FOLLOW_UP_SYNC_DELAY_MS = 3000
 const RECENT_THREAD_MESSAGE_LOAD_REUSE_MS = 2000
 const RECENT_THREAD_LIST_LOAD_REUSE_MS = 2000
 const RECENT_SKILLS_LOAD_REUSE_MS = 2000
-const REASONING_EFFORT_OPTIONS: ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
+const LEGACY_REASONING_EFFORT_OPTIONS: UiReasoningEffortOption[] = [
+  { value: 'none', description: '' },
+  { value: 'minimal', description: '' },
+  { value: 'low', description: '' },
+  { value: 'medium', description: '' },
+  { value: 'high', description: '' },
+  { value: 'xhigh', description: '' },
+]
 const GLOBAL_SERVER_REQUEST_SCOPE = '__global__'
 const MODEL_FALLBACK_ID = 'gpt-5.4-mini'
 const OPENCODE_ZEN_DEFAULT_MODEL = 'big-pickle'
@@ -1423,6 +1433,7 @@ export function useDesktopState() {
   let hasLoadedPersistedQueueState = false
   const eventUnreadByThreadId = ref<Record<string, boolean>>({})
   const availableModelIds = ref<string[]>([])
+  const availableModels = ref<UiModelOption[]>([])
   const availableCollaborationModes = ref<CollaborationModeOption[]>([
     { value: 'default', label: 'Default' },
     { value: 'plan', label: 'Plan' },
@@ -1625,6 +1636,26 @@ export function useDesktopState() {
     const threadId = selectedThreadId.value
     return threadId ? loadingOlderMessagesByThreadId.value[threadId] === true : false
   })
+  const availableReasoningEfforts = computed<UiReasoningEffortOption[]>(() => {
+    const selectedModel = availableModels.value.find((model) => model.id === selectedModelId.value.trim())
+    return selectedModel?.supportedReasoningEfforts.length
+      ? selectedModel.supportedReasoningEfforts
+      : LEGACY_REASONING_EFFORT_OPTIONS
+  })
+
+  function ensureSelectedReasoningEffortForModel(): void {
+    const supported = availableReasoningEfforts.value
+    if (selectedReasoningEffort.value && supported.some((option) => option.value === selectedReasoningEffort.value)) {
+      return
+    }
+    const selectedModel = availableModels.value.find((model) => model.id === selectedModelId.value.trim())
+    const preferred = selectedModel?.defaultReasoningEffort
+    selectedReasoningEffort.value = (
+      preferred && supported.some((option) => option.value === preferred)
+        ? preferred
+        : supported[0]?.value
+    ) ?? ''
+  }
 
   function getFirstPersistedTurnId(threadId: string): string {
     const persisted = persistedMessagesByThreadId.value[threadId] ?? []
@@ -1656,15 +1687,26 @@ export function useDesktopState() {
 
   function ensureAvailableModelIds(...modelIds: string[]): void {
     const nextModelIds = [...availableModelIds.value]
+    const nextModels = [...availableModels.value]
     for (const modelId of modelIds) {
       const normalizedModelId = modelId.trim()
       if (normalizedModelId && !nextModelIds.includes(normalizedModelId)) {
         nextModelIds.push(normalizedModelId)
       }
+      if (normalizedModelId && !nextModels.some((model) => model.id === normalizedModelId)) {
+        nextModels.push({
+          id: normalizedModelId,
+          displayName: '',
+          description: '',
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: '',
+        })
+      }
     }
     if (!areStringArraysEqual(availableModelIds.value, nextModelIds)) {
       availableModelIds.value = nextModelIds
     }
+    availableModels.value = nextModels
   }
 
   function readProviderCompatibleSelectedModel(modelId: string): string {
@@ -1681,6 +1723,7 @@ export function useDesktopState() {
       saveSelectedThreadId(nextThreadId)
     }
     selectedModelId.value = readProviderCompatibleSelectedModel(readModelIdForThread(nextThreadId))
+    ensureSelectedReasoningEffortForModel()
     selectedCollaborationMode.value = readSelectedCollaborationMode(
       selectedCollaborationModeByContext.value,
       nextThreadId,
@@ -1715,6 +1758,7 @@ export function useDesktopState() {
     if (threadId.trim() === selectedThreadId.value) {
       selectedModelId.value = readModelIdForThread(selectedThreadId.value)
       ensureAvailableModelIds(selectedModelId.value)
+      ensureSelectedReasoningEffortForModel()
     } else {
       ensureAvailableModelIds(normalizedModelId)
     }
@@ -1740,6 +1784,7 @@ export function useDesktopState() {
     ensureAvailableModelIds(normalizedModelId)
     if (selectedThreadId.value === normalizedThreadId) {
       selectedModelId.value = readModelIdForThread(selectedThreadId.value)
+      ensureSelectedReasoningEffortForModel()
     }
     saveSelectedModelMap(selectedModelIdByContext.value)
   }
@@ -1926,7 +1971,7 @@ export function useDesktopState() {
   }
 
   function setSelectedReasoningEffort(effort: ReasoningEffort | ''): void {
-    if (effort && !REASONING_EFFORT_OPTIONS.includes(effort)) {
+    if (effort && !availableReasoningEfforts.value.some((option) => option.value === effort)) {
       return
     }
     selectedReasoningEffort.value = effort
@@ -1992,6 +2037,14 @@ export function useDesktopState() {
         requireProviderModels: isProviderBacked,
         providerId: isProviderBacked ? targetProviderId : undefined,
       })
+      const modelOptions = (modelIds as AvailableModelIdList).modelOptions
+        ?? modelIds.map((id) => ({
+          id,
+          displayName: '',
+          description: '',
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: '' as const,
+        }))
       const providerModelContextId = toProviderModelContextId(targetProviderId)
       const providerScopedModelId = providerModelContextId
         ? normalizeStoredModelId(selectedModelIdByContext.value[providerModelContextId])
@@ -2007,6 +2060,18 @@ export function useDesktopState() {
         nextModelIds.push(normalizedConfiguredModelId)
       }
       availableModelIds.value = nextModelIds
+      availableModels.value = [
+        ...modelOptions,
+        ...nextModelIds
+          .filter((modelId) => !modelOptions.some((model) => model.id === modelId))
+          .map((modelId) => ({
+            id: modelId,
+            displayName: '',
+            description: '',
+            supportedReasoningEfforts: [],
+            defaultReasoningEffort: '' as const,
+          })),
+      ]
 
       const currentModelInNewList = normalizedSelectedModelId && modelIds.includes(normalizedSelectedModelId)
       if (!normalizedSelectedModelId || !currentModelInNewList || options?.providerChanged) {
@@ -2045,9 +2110,11 @@ export function useDesktopState() {
 
       if (
         currentConfig.reasoningEffort &&
-        REASONING_EFFORT_OPTIONS.includes(currentConfig.reasoningEffort)
+        availableReasoningEfforts.value.some((option) => option.value === currentConfig.reasoningEffort)
       ) {
         selectedReasoningEffort.value = currentConfig.reasoningEffort
+      } else {
+        ensureSelectedReasoningEffortForModel()
       }
       selectedSpeedMode.value = currentConfig.speedMode
     } catch (unknownError) {
@@ -5674,6 +5741,8 @@ export function useDesktopState() {
     selectedThreadId,
     availableCollaborationModes,
     availableModelIds,
+    availableModels,
+    availableReasoningEfforts,
     selectedCollaborationMode,
     selectedModelId,
     selectedReasoningEffort,

--- a/src/composables/useDesktopState.ts
+++ b/src/composables/useDesktopState.ts
@@ -2,9 +2,10 @@ import { computed, ref } from 'vue'
 import {
 
   archiveThread,
+  consumeRateLimitResetCredit,
   forkThread,
   getAvailableCollaborationModes,
-  getAccountRateLimits,
+  getAccountRateLimitsState,
   renameThread,
   getAvailableModelIds,
   getCurrentModelConfig,
@@ -54,6 +55,7 @@ import type {
   UiPlanData,
   UiPlanStep,
   UiProjectGroup,
+  UiRateLimitResetCredits,
   UiRateLimitSnapshot,
   UiServerRequest,
   UiServerRequestReply,
@@ -1478,6 +1480,9 @@ export function useDesktopState() {
 
   const installedSkills = ref<SkillInfo[]>([])
   const accountRateLimitSnapshots = ref<UiRateLimitSnapshot[]>([])
+  const rateLimitResetCredits = ref<UiRateLimitResetCredits | null>(null)
+  const isConsumingRateLimitReset = ref(false)
+  const rateLimitResetNotice = ref<{ type: 'success' | 'info' | 'error'; text: string } | null>(null)
 
   const isLoadingThreads = ref(false)
   const isLoadingMessages = ref(false)
@@ -2135,9 +2140,10 @@ export function useDesktopState() {
 
     rateLimitRefreshPromise = (async () => {
       try {
-        const snapshot = await getAccountRateLimits()
-        setCodexRateLimit(snapshot)
-        accountRateLimitSnapshots.value = snapshot ? [snapshot] : []
+        const state = await getAccountRateLimitsState()
+        setCodexRateLimit(state.codexSnapshot)
+        accountRateLimitSnapshots.value = state.snapshots
+        rateLimitResetCredits.value = state.resetCredits
       } catch {
         // Keep the last known rate-limit state if the endpoint is temporarily unavailable.
       } finally {
@@ -2146,6 +2152,39 @@ export function useDesktopState() {
     })()
 
     await rateLimitRefreshPromise
+  }
+
+  async function consumeBankedRateLimitReset(creditId?: string): Promise<void> {
+    if (isConsumingRateLimitReset.value) return
+    isConsumingRateLimitReset.value = true
+    rateLimitResetNotice.value = null
+    try {
+      const outcome = await consumeRateLimitResetCredit(creditId)
+      if (outcome === 'reset' || outcome === 'alreadyRedeemed') {
+        rateLimitResetNotice.value = {
+          type: 'success',
+          text: 'Rate limits reset. Your quota and banked-reset balance were refreshed.',
+        }
+      } else if (outcome === 'nothingToReset') {
+        rateLimitResetNotice.value = {
+          type: 'info',
+          text: 'No eligible Codex rate-limit window can be reset right now.',
+        }
+      } else {
+        rateLimitResetNotice.value = {
+          type: 'error',
+          text: 'No banked rate-limit resets are available.',
+        }
+      }
+      await refreshRateLimits()
+    } catch (unknownError) {
+      rateLimitResetNotice.value = {
+        type: 'error',
+        text: unknownError instanceof Error ? unknownError.message : 'Failed to use the banked rate-limit reset.',
+      }
+    } finally {
+      isConsumingRateLimitReset.value = false
+    }
   }
 
   function scheduleRateLimitRefresh(): void {
@@ -5750,6 +5789,9 @@ export function useDesktopState() {
     codexCliMissingError,
     installedSkills,
     accountRateLimitSnapshots,
+    rateLimitResetCredits,
+    isConsumingRateLimitReset,
+    rateLimitResetNotice,
     messages,
     hasMoreOlderMessages,
     isLoadingThreads,
@@ -5763,6 +5805,7 @@ export function useDesktopState() {
 
     error,
     refreshAll,
+    consumeBankedRateLimitReset,
     refreshSkills,
     selectThread,
     loadMessages,

--- a/src/server/codexAppServerBridge.ts
+++ b/src/server/codexAppServerBridge.ts
@@ -38,6 +38,11 @@ import {
   type FreeModeState,
 } from './freeMode.js'
 import { handleOpenRouterProxyRequest } from './openRouterProxy.js'
+import {
+  buildChatGptProHandoff,
+  type ProHandoffContextFile,
+  type ProHandoffRepositorySnapshot,
+} from './proHandoff.js'
 import { handleZenProxyRequest } from './zenProxy.js'
 import { handleCustomEndpointProxyRequest } from './customEndpointProxy.js'
 import { ThreadTerminalManager } from './terminalManager.js'
@@ -4256,6 +4261,141 @@ async function runCommandCaptureRaw(command: string, args: string[], options: { 
   })
 }
 
+async function runBoundedCommandCapture(
+  command: string,
+  args: string[],
+  options: { cwd?: string; maxCharacters?: number; timeoutMs?: number } = {},
+): Promise<{ output: string; truncated: boolean }> {
+  const maxCharacters = Math.max(1, options.maxCharacters ?? 200_000)
+  const timeoutMs = Math.max(1000, options.timeoutMs ?? 10_000)
+  return await new Promise((resolveCommand, rejectCommand) => {
+    const proc = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let truncated = false
+    let settled = false
+    const append = (target: 'stdout' | 'stderr', chunk: Buffer) => {
+      const value = chunk.toString()
+      if (target === 'stdout') {
+        const remaining = maxCharacters - stdout.length
+        if (remaining > 0) stdout += value.slice(0, remaining)
+        if (value.length > remaining) truncated = true
+      } else {
+        const remaining = Math.min(32_000, maxCharacters) - stderr.length
+        if (remaining > 0) stderr += value.slice(0, remaining)
+      }
+    }
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      proc.kill()
+      rejectCommand(new Error(`Command timed out (${command} ${args.join(' ')})`))
+    }, timeoutMs)
+    timer.unref?.()
+    proc.stdout.on('data', (chunk: Buffer) => append('stdout', chunk))
+    proc.stderr.on('data', (chunk: Buffer) => append('stderr', chunk))
+    proc.on('error', (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      rejectCommand(error)
+    })
+    proc.on('close', (code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (code === 0) {
+        resolveCommand({ output: stdout.trim(), truncated })
+        return
+      }
+      const details = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n')
+      rejectCommand(new Error(details || `Command failed (${command} ${args.join(' ')})`))
+    })
+  })
+}
+
+async function buildProHandoffRepositorySnapshot(cwd: string): Promise<ProHandoffRepositorySnapshot | null> {
+  const gitArgs = (args: string[]) => ['-c', 'safe.directory=*', ...args]
+  let root = ''
+  try {
+    root = (await runBoundedCommandCapture('git', gitArgs(['rev-parse', '--show-toplevel']), {
+      cwd,
+      maxCharacters: 32_000,
+    })).output
+  } catch {
+    return null
+  }
+  if (!root) return null
+
+  const readGit = async (args: string[], maxCharacters = 64_000) => {
+    try {
+      return await runBoundedCommandCapture('git', gitArgs(args), { cwd: root, maxCharacters })
+    } catch {
+      return { output: '', truncated: false }
+    }
+  }
+  const [branch, status, recentCommits, diffStat, diff] = await Promise.all([
+    readGit(['branch', '--show-current'], 8_000),
+    readGit(['status', '--short', '--branch'], 80_000),
+    readGit(['log', '-5', '--date=short', '--pretty=format:%h %ad %s'], 24_000),
+    readGit(['diff', '--no-ext-diff', '--no-textconv', '--stat', 'HEAD', '--', '.'], 40_000),
+    readGit(['diff', '--no-ext-diff', '--no-textconv', '--unified=3', 'HEAD', '--', '.'], 180_000),
+  ])
+  return {
+    root,
+    branch: branch.output,
+    status: status.output,
+    recentCommits: recentCommits.output,
+    diffStat: diffStat.output,
+    changedFiles: status.output
+      .split(/\r?\n/u)
+      .filter((line) => !line.startsWith('## '))
+      .join('\n'),
+    diff: diff.output,
+    diffTruncated: diff.truncated,
+  }
+}
+
+async function readProHandoffContextFiles(cwd: string, repoRoot: string | null): Promise<ProHandoffContextFile[]> {
+  const paths: string[] = []
+  let current = resolve(cwd)
+  const boundary = repoRoot ? resolve(repoRoot) : current
+  for (let depth = 0; depth < 12; depth += 1) {
+    paths.push(join(current, 'AGENTS.md'))
+    if (current.toLowerCase() === boundary.toLowerCase()) break
+    const parent = dirname(current)
+    if (parent === current) break
+    if (repoRoot) {
+      const parentRelativeToBoundary = relative(boundary, parent)
+      if (parentRelativeToBoundary.startsWith('..') || isAbsolute(parentRelativeToBoundary)) break
+    }
+    current = parent
+  }
+
+  const files: ProHandoffContextFile[] = []
+  let remainingCharacters = 50_000
+  for (const filePath of paths.reverse()) {
+    if (remainingCharacters <= 0) break
+    try {
+      const raw = await readFile(filePath, 'utf8')
+      const content = raw.slice(0, Math.min(20_000, remainingCharacters))
+      files.push({
+        path: filePath,
+        content,
+        truncated: content.length < raw.length,
+      })
+      remainingCharacters -= content.length
+    } catch {
+      // Missing or unreadable instruction files are simply not part of the handoff.
+    }
+  }
+  return files
+}
+
 function normalizeBranchRefName(value: string): string {
   const trimmed = value.trim()
   if (!trimmed) return ''
@@ -7916,6 +8056,55 @@ export function createCodexBridgeMiddleware(): CodexBridgeMiddleware {
 
       if (req.method === 'POST' && url.pathname === '/codex-api/upload-file') {
         handleFileUpload(req, res)
+        return
+      }
+
+      if (req.method === 'POST' && url.pathname === '/codex-api/thread/pro-handoff') {
+        try {
+          const body = asRecord(await readJsonBody(req))
+          const threadId = readNonEmptyString(body?.threadId)
+          if (!threadId) {
+            setJson(res, 400, { error: 'Missing threadId' })
+            return
+          }
+
+          const threadResult = await callRpcWithArchiveRecovery(appServer, 'thread/read', {
+            threadId,
+            includeTurns: true,
+          })
+          const thread = asRecord(asRecord(threadResult)?.thread)
+          const requestedCwd = readNonEmptyString(body?.cwd)
+          const cwd = readNonEmptyString(thread?.cwd) || requestedCwd
+          if (!cwd || !isAbsolute(cwd)) {
+            setJson(res, 400, { error: 'The thread does not have a valid working directory' })
+            return
+          }
+          const cwdStat = await stat(cwd)
+          if (!cwdStat.isDirectory()) {
+            setJson(res, 400, { error: 'The thread working directory is not a directory' })
+            return
+          }
+
+          const [goalResult, repository] = await Promise.all([
+            appServer.rpc('thread/goal/get', { threadId }).catch(() => null),
+            buildProHandoffRepositorySnapshot(cwd),
+          ])
+          const contextFiles = await readProHandoffContextFiles(cwd, repository?.root ?? null)
+          const markdown = buildChatGptProHandoff({
+            threadResult,
+            goalResult,
+            repository,
+            contextFiles,
+          })
+          setJson(res, 200, {
+            data: {
+              markdown,
+              chatgptUrl: 'https://chatgpt.com/',
+            },
+          })
+        } catch (error) {
+          setJson(res, 500, { error: getErrorMessage(error, 'Failed to prepare the ChatGPT Pro handoff') })
+        }
         return
       }
 

--- a/src/server/proHandoff.test.ts
+++ b/src/server/proHandoff.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { buildChatGptProHandoff } from './proHandoff'
+
+describe('buildChatGptProHandoff', () => {
+  it('packages the goal, transcript, repository state, and repository instructions', () => {
+    const markdown = buildChatGptProHandoff({
+      exportedAt: '2026-07-30T10:00:00.000Z',
+      threadResult: {
+        thread: {
+          id: 'thread-1',
+          cwd: 'C:\\repo',
+          preview: 'Ship the picker',
+          modelProvider: 'openai',
+          cliVersion: '0.145.0',
+          turns: [{
+            id: 'turn-1',
+            status: 'completed',
+            items: [
+              { type: 'userMessage', content: [{ type: 'text', text: 'Please implement this.' }] },
+              { type: 'agentMessage', text: 'Implemented the first part.' },
+              {
+                type: 'commandExecution',
+                command: 'pnpm test',
+                cwd: 'C:\\repo',
+                status: 'completed',
+                exitCode: 0,
+                aggregatedOutput: '42 tests passed',
+              },
+              {
+                type: 'fileChange',
+                status: 'completed',
+                changes: [{ path: 'src/App.vue' }],
+              },
+            ],
+          }],
+        },
+      },
+      goalResult: {
+        goal: {
+          objective: 'Finish the CodexApp handoff',
+          status: 'active',
+          tokenBudget: 20_000,
+          tokensUsed: 4_000,
+          timeUsedSeconds: 120,
+        },
+      },
+      repository: {
+        root: 'C:\\repo',
+        branch: 'agent/pro-handoff',
+        status: '## agent/pro-handoff\n M src/App.vue',
+        recentCommits: 'abc123 Add goal mode',
+        diffStat: 'src/App.vue | 10 +++++',
+        changedFiles: 'M\tsrc/App.vue',
+        diff: 'diff --git a/src/App.vue b/src/App.vue',
+        diffTruncated: false,
+      },
+      contextFiles: [{
+        path: 'C:\\repo\\AGENTS.md',
+        content: 'Run focused tests.',
+        truncated: false,
+      }],
+    })
+
+    expect(markdown).toContain('GPT-5.6 Sol Pro')
+    expect(markdown).toContain('Finish the CodexApp handoff')
+    expect(markdown).toContain('Please implement this.')
+    expect(markdown).toContain('42 tests passed')
+    expect(markdown).toContain('src/App.vue')
+    expect(markdown).toContain('Run focused tests.')
+    expect(markdown).not.toContain('[object Object]')
+  })
+
+  it('does not include raw reasoning items', () => {
+    const markdown = buildChatGptProHandoff({
+      threadResult: {
+        thread: {
+          turns: [{
+            items: [{
+              type: 'reasoning',
+              summary: ['Safe summary'],
+              content: ['private chain of thought'],
+            }],
+          }],
+        },
+      },
+    })
+
+    expect(markdown).not.toContain('private chain of thought')
+    expect(markdown).not.toContain('Safe summary')
+  })
+})

--- a/src/server/proHandoff.ts
+++ b/src/server/proHandoff.ts
@@ -1,0 +1,264 @@
+type UnknownRecord = Record<string, unknown>
+
+export type ProHandoffRepositorySnapshot = {
+  root: string
+  branch: string
+  status: string
+  recentCommits: string
+  diffStat: string
+  changedFiles: string
+  diff: string
+  diffTruncated: boolean
+}
+
+export type ProHandoffContextFile = {
+  path: string
+  content: string
+  truncated: boolean
+}
+
+export type BuildProHandoffInput = {
+  threadResult: unknown
+  goalResult?: unknown
+  repository?: ProHandoffRepositorySnapshot | null
+  contextFiles?: ProHandoffContextFile[]
+  exportedAt?: string
+}
+
+const TRANSCRIPT_CHARACTER_LIMIT = 360_000
+const ITEM_OUTPUT_CHARACTER_LIMIT = 12_000
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function appendBounded(target: string[], value: string, state: { characters: number; truncated: boolean }): void {
+  if (!value || state.truncated) return
+  const remaining = TRANSCRIPT_CHARACTER_LIMIT - state.characters
+  if (remaining <= 0) {
+    state.truncated = true
+    return
+  }
+  if (value.length > remaining) {
+    target.push(`${value.slice(0, remaining)}\n\n_[Transcript truncated at ${TRANSCRIPT_CHARACTER_LIMIT.toLocaleString()} characters.]_`)
+    state.characters += remaining
+    state.truncated = true
+    return
+  }
+  target.push(value)
+  state.characters += value.length
+}
+
+function fencedText(value: string, limit = ITEM_OUTPUT_CHARACTER_LIMIT): string {
+  const normalized = value.trim()
+  if (!normalized) return ''
+  const clipped = normalized.length > limit
+    ? `${normalized.slice(0, limit)}\n… [output truncated]`
+    : normalized
+  return `\`\`\`text\n${clipped.split('```').join('``\\`')}\n\`\`\``
+}
+
+function formatUserMessage(item: UnknownRecord): string {
+  const content = Array.isArray(item.content) ? item.content : []
+  const blocks: string[] = []
+  for (const entry of content) {
+    const input = asRecord(entry)
+    if (!input) continue
+    const type = readString(input.type)
+    if (type === 'text') {
+      const text = readString(input.text)
+      if (text) blocks.push(text)
+    } else if (type === 'image') {
+      blocks.push(`[Attached image: ${readString(input.url) || 'inline image'}]`)
+    } else if (type === 'localImage') {
+      blocks.push(`[Attached local image: ${readString(input.path)}]`)
+    } else if (type === 'skill') {
+      blocks.push(`[Selected skill: ${readString(input.name)} (${readString(input.path)})]`)
+    } else if (type === 'mention') {
+      blocks.push(`[Mentioned file: ${readString(input.name)} (${readString(input.path)})]`)
+    }
+  }
+  return blocks.join('\n\n')
+}
+
+function formatThreadItem(value: unknown): string {
+  const item = asRecord(value)
+  if (!item) return ''
+  const type = readString(item.type)
+  if (type === 'userMessage') {
+    const body = formatUserMessage(item)
+    return body ? `### User\n\n${body}` : ''
+  }
+  if (type === 'agentMessage') {
+    const text = readString(item.text)
+    return text ? `### Assistant\n\n${text}` : ''
+  }
+  if (type === 'plan') {
+    const text = readString(item.text)
+    return text ? `### Assistant plan\n\n${text}` : ''
+  }
+  if (type === 'commandExecution') {
+    const command = readString(item.command)
+    const cwd = readString(item.cwd)
+    const status = readString(item.status)
+    const exitCode = typeof item.exitCode === 'number' ? String(item.exitCode) : ''
+    const metadata = [
+      command ? `Command: \`${command.split('`').join('\\`')}\`` : '',
+      cwd ? `CWD: \`${cwd.split('`').join('\\`')}\`` : '',
+      status ? `Status: ${status}` : '',
+      exitCode ? `Exit code: ${exitCode}` : '',
+    ].filter(Boolean).join('\n')
+    const output = fencedText(typeof item.aggregatedOutput === 'string' ? item.aggregatedOutput : '')
+    return `### Tool · command\n\n${metadata}${output ? `\n\n${output}` : ''}`
+  }
+  if (type === 'fileChange') {
+    const changes = Array.isArray(item.changes) ? item.changes : []
+    const paths = changes
+      .map((change) => readString(asRecord(change)?.path))
+      .filter(Boolean)
+      .map((path) => `- ${path}`)
+    return paths.length > 0
+      ? `### Tool · file changes (${readString(item.status) || 'unknown'})\n\n${paths.join('\n')}`
+      : ''
+  }
+  if (type === 'mcpToolCall') {
+    const server = readString(item.server)
+    const tool = readString(item.tool)
+    const status = readString(item.status)
+    return `### Tool · ${[server, tool].filter(Boolean).join('/') || 'MCP'}\n\nStatus: ${status || 'unknown'}`
+  }
+  if (type === 'webSearch') {
+    const query = readString(item.query)
+    return query ? `### Tool · web search\n\nQuery: ${query}` : ''
+  }
+  if (type === 'imageView') {
+    const path = readString(item.path)
+    return path ? `### Tool · image viewed\n\n${path}` : ''
+  }
+  if (type === 'contextCompaction') {
+    return '### Context event\n\nCodex compacted the conversation context at this point.'
+  }
+  return ''
+}
+
+function buildTranscript(thread: UnknownRecord): string {
+  const turns = Array.isArray(thread.turns) ? thread.turns : []
+  const lines: string[] = []
+  const state = { characters: 0, truncated: false }
+  for (let index = 0; index < turns.length && !state.truncated; index += 1) {
+    const turn = asRecord(turns[index])
+    if (!turn) continue
+    const turnId = readString(turn.id)
+    const turnStatus = readString(turn.status)
+    appendBounded(
+      lines,
+      `## Turn ${index + 1}${turnId ? ` · ${turnId}` : ''}${turnStatus ? ` · ${turnStatus}` : ''}`,
+      state,
+    )
+    const items = Array.isArray(turn.items) ? turn.items : []
+    for (const item of items) {
+      const formatted = formatThreadItem(item)
+      if (formatted) appendBounded(lines, formatted, state)
+    }
+  }
+  return lines.join('\n\n')
+}
+
+function buildGoalSection(goalResult: unknown): string {
+  const result = asRecord(goalResult)
+  const goal = asRecord(result?.goal ?? goalResult)
+  if (!goal) return '_No active Codex goal was found._'
+  const objective = readString(goal.objective)
+  const status = readString(goal.status)
+  const tokenBudget = typeof goal.tokenBudget === 'number' ? goal.tokenBudget : null
+  const tokensUsed = typeof goal.tokensUsed === 'number' ? goal.tokensUsed : null
+  const timeUsedSeconds = typeof goal.timeUsedSeconds === 'number' ? goal.timeUsedSeconds : null
+  return [
+    objective ? `- Objective: ${objective}` : '',
+    status ? `- Status: ${status}` : '',
+    tokenBudget !== null ? `- Token budget: ${tokenBudget.toLocaleString()}` : '',
+    tokensUsed !== null ? `- Tokens used: ${tokensUsed.toLocaleString()}` : '',
+    timeUsedSeconds !== null ? `- Time used: ${timeUsedSeconds.toLocaleString()} seconds` : '',
+  ].filter(Boolean).join('\n') || '_No active Codex goal was found._'
+}
+
+function buildRepositorySection(repository: ProHandoffRepositorySnapshot | null | undefined): string {
+  if (!repository) return '_The working directory is not inside a Git repository._'
+  const sections = [
+    `- Root: \`${repository.root}\``,
+    `- Branch: \`${repository.branch || '(detached HEAD)'}\``,
+    repository.status ? `\n### Status\n\n${fencedText(repository.status)}` : '',
+    repository.recentCommits ? `\n### Recent commits\n\n${fencedText(repository.recentCommits)}` : '',
+    repository.diffStat ? `\n### Diff stat\n\n${fencedText(repository.diffStat)}` : '',
+    repository.changedFiles ? `\n### Changed files\n\n${fencedText(repository.changedFiles)}` : '',
+    repository.diff
+      ? `\n### Working-tree diff${repository.diffTruncated ? ' (truncated)' : ''}\n\n\`\`\`diff\n${repository.diff.split('```').join('``\\`')}\n\`\`\``
+      : '',
+  ]
+  return sections.filter(Boolean).join('\n')
+}
+
+function buildContextSection(contextFiles: ProHandoffContextFile[]): string {
+  if (contextFiles.length === 0) return '_No AGENTS.md instruction files were found between the working directory and repository root._'
+  return contextFiles.map((file) => [
+    `### ${file.path}${file.truncated ? ' (truncated)' : ''}`,
+    '',
+    '```markdown',
+    file.content.split('```').join('``\\`'),
+    '```',
+  ].join('\n')).join('\n\n')
+}
+
+export function buildChatGptProHandoff(input: BuildProHandoffInput): string {
+  const response = asRecord(input.threadResult)
+  const thread = asRecord(response?.thread ?? input.threadResult) ?? {}
+  const threadId = readString(thread.id)
+  const cwd = readString(thread.cwd)
+  const preview = readString(thread.preview)
+  const modelProvider = readString(thread.modelProvider)
+  const cliVersion = readString(thread.cliVersion)
+  const exportedAt = input.exportedAt ?? new Date().toISOString()
+  const transcript = buildTranscript(thread)
+
+  return [
+    '# Codex → ChatGPT Pro handoff',
+    '',
+    '> Switch this ChatGPT conversation to **GPT-5.6 Sol Pro**, then continue from the exact state below. Preserve existing decisions and do not redo completed work. Ask only if a genuinely blocking choice is missing.',
+    '',
+    '## Session',
+    '',
+    `- Exported: ${exportedAt}`,
+    threadId ? `- Codex thread: \`${threadId}\`` : '',
+    cwd ? `- Working directory: \`${cwd}\`` : '',
+    modelProvider ? `- Model provider: ${modelProvider}` : '',
+    cliVersion ? `- Codex CLI: ${cliVersion}` : '',
+    preview ? `- Thread preview: ${preview}` : '',
+    '',
+    '## Goal',
+    '',
+    buildGoalSection(input.goalResult),
+    '',
+    '## Repository state',
+    '',
+    buildRepositorySection(input.repository),
+    '',
+    '## Applicable repository instructions',
+    '',
+    buildContextSection(input.contextFiles ?? []),
+    '',
+    '## Persisted transcript',
+    '',
+    transcript || '_No persisted turns were returned for this thread._',
+    '',
+    '## Continue',
+    '',
+    'Continue the user’s current request using this transcript, goal, repository state, changed-file list, diff, and repository instructions as context. Treat the local repository state as authoritative.',
+    '',
+  ].join('\n')
+}

--- a/src/server/rateLimitDecodeRecovery.test.ts
+++ b/src/server/rateLimitDecodeRecovery.test.ts
@@ -51,6 +51,18 @@ const proliteDecodeError = new Error(`failed to fetch codex rate limits: Decode 
     "has_credits": false,
     "unlimited": false,
     "balance": "0"
+  },
+  "rate_limit_reset_credits": {
+    "available_count": 1,
+    "credits": [{
+      "id": "RateLimitResetCredit_1",
+      "reset_type": "codexRateLimits",
+      "status": "available",
+      "granted_at": 1779000000,
+      "expires_at": 1781000000,
+      "title": "Full reset",
+      "description": "Reset an eligible Codex rate-limit window."
+    }]
   }
 }`)
 
@@ -142,6 +154,18 @@ describe('recoverRateLimitsFromPlanTypeDecodeError', () => {
           credits: null,
           planType: 'prolite',
         },
+      },
+      rateLimitResetCredits: {
+        available_count: 1,
+        credits: [{
+          id: 'RateLimitResetCredit_1',
+          reset_type: 'codexRateLimits',
+          status: 'available',
+          granted_at: 1779000000,
+          expires_at: 1781000000,
+          title: 'Full reset',
+          description: 'Reset an eligible Codex rate-limit window.',
+        }],
       },
     })
   })

--- a/src/server/rateLimitDecodeRecovery.ts
+++ b/src/server/rateLimitDecodeRecovery.ts
@@ -183,9 +183,11 @@ export function recoverRateLimitsFromPlanTypeDecodeError(error: unknown): unknow
     }
   }
 
+  const resetCredits = asRecord(body.rate_limit_reset_credits ?? body.rateLimitResetCredits)
   return {
     rateLimits: primarySnapshot,
     rateLimitsByLimitId,
+    ...(resetCredits ? { rateLimitResetCredits: resetCredits } : {}),
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -381,6 +381,57 @@
   @apply text-zinc-400;
 }
 
+:root.dark .banked-reset-card {
+  @apply border-violet-800 bg-violet-950/70;
+}
+
+:root.dark .banked-reset-eyebrow,
+:root.dark .banked-reset-expiry,
+:root.dark .banked-reset-empty,
+:root.dark .banked-reset-hidden {
+  @apply text-violet-300;
+}
+
+:root.dark .banked-reset-count {
+  @apply text-violet-100;
+}
+
+:root.dark .banked-reset-icon {
+  @apply bg-violet-900 text-violet-200;
+}
+
+:root.dark .banked-reset-explanation {
+  @apply text-violet-200;
+}
+
+:root.dark .banked-reset-entry {
+  @apply border-violet-800 bg-zinc-900/80;
+}
+
+:root.dark .banked-reset-entry-copy strong {
+  @apply text-zinc-100;
+}
+
+:root.dark .banked-reset-entry-copy span {
+  @apply text-zinc-300;
+}
+
+:root.dark .banked-reset-use {
+  @apply bg-violet-600 hover:bg-violet-500;
+}
+
+:root.dark .banked-reset-notice {
+  @apply border-emerald-800 bg-emerald-950 text-emerald-200;
+}
+
+:root.dark .banked-reset-notice[data-type='info'] {
+  @apply border-amber-800 bg-amber-950 text-amber-200;
+}
+
+:root.dark .banked-reset-notice[data-type='error'] {
+  @apply border-rose-800 bg-rose-950 text-rose-200;
+}
+
 :root.dark .thread-composer-attach-menu {
   @apply border-zinc-600 bg-zinc-800;
 }

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -2,9 +2,22 @@ export type RpcEnvelope<T> = {
   result: T
 }
 
-export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
 export type SpeedMode = 'standard' | 'fast'
 export type CollaborationModeKind = 'default' | 'plan'
+
+export type UiReasoningEffortOption = {
+  value: ReasoningEffort
+  description: string
+}
+
+export type UiModelOption = {
+  id: string
+  displayName: string
+  description: string
+  supportedReasoningEfforts: UiReasoningEffortOption[]
+  defaultReasoningEffort: ReasoningEffort | ''
+}
 
 export type RpcMethodCatalog = {
   data: string[]

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -286,6 +286,27 @@ export type UiRateLimitSnapshot = {
   planType: string | null
 }
 
+export type UiRateLimitResetCredit = {
+  id: string
+  resetType: string
+  status: string
+  grantedAt: number | null
+  expiresAt: number | null
+  title: string | null
+  description: string | null
+}
+
+export type UiRateLimitResetCredits = {
+  availableCount: number
+  credits: UiRateLimitResetCredit[] | null
+}
+
+export type UiRateLimitResetOutcome =
+  | 'reset'
+  | 'alreadyRedeemed'
+  | 'nothingToReset'
+  | 'noCredit'
+
 export type UiTokenUsageBreakdown = {
   totalTokens: number
   inputTokens: number

--- a/tests/accounts-feedback-observability/banked-rate-limit-resets.md
+++ b/tests/accounts-feedback-observability/banked-rate-limit-resets.md
@@ -1,0 +1,33 @@
+### Banked rate-limit resets
+
+#### Feature/Change Name
+The Settings quota section shows earned banked resets and lets the user apply one to an eligible Codex rate-limit window.
+
+#### Prerequisites/Setup
+1. Sign in with ChatGPT-managed Codex authentication.
+2. Use an account whose `account/rateLimits/read` response includes `rateLimitResetCredits`.
+3. For the redemption path, use a disposable test credit or stub `account/rateLimitResetCredit/consume`; do not spend a real reset merely for visual testing.
+4. Run the app at the active local URL and allow the initial quota refresh to finish.
+
+#### Steps
+1. Open Settings in light theme and scroll to the rate-limit cards.
+2. Confirm the `Banked resets` card shows the authoritative available count.
+3. When detail rows are present, verify each visible row shows its title, description, expiration date, and remaining days.
+4. Click `Use reset` once and verify the button changes to `Click again to confirm` without calling the consume RPC.
+5. Wait six seconds and verify the confirmation expires.
+6. Click twice within six seconds and verify exactly one `account/rateLimitResetCredit/consume` request is sent with a non-empty idempotency key and the selected opaque credit ID.
+7. Verify CodexApp fetches `account/rateLimits/read` after the consume response and updates both quota windows and the available reset count.
+8. Exercise `reset`, `alreadyRedeemed`, `nothingToReset`, `noCredit`, and request-error responses and verify their status messages.
+9. Repeat the card, confirmation, disabled/loading, and status-message checks in dark theme.
+10. Repeat at 375×812 and 768×1024 and confirm the Settings panel remains usable without horizontal overflow.
+
+#### Expected Results
+- The card is absent when the service omits `rateLimitResetCredits`, shows `0 available` when the service explicitly returns zero, and treats `availableCount` as authoritative when detail rows are capped.
+- A reset cannot be consumed with a single accidental click.
+- While a consume request is active, all reset buttons are disabled and display `Using…`.
+- The app never guesses the post-redemption count or quota; it refreshes from the app-server.
+- Light and dark themes retain readable contrast, and narrow layouts remain scrollable.
+
+#### Rollback/Cleanup
+- Restore any RPC stubs used for outcome testing.
+- If a disposable credit was intentionally consumed, record the account and outcome; banked resets cannot be restored by CodexApp.

--- a/tests/accounts-feedback-observability/index.md
+++ b/tests/accounts-feedback-observability/index.md
@@ -22,3 +22,4 @@ Return to the [manual test index](../../tests.md).
 | [Accounts panel Codex login callback modal](accounts-panel-codex-login-callback-modal.md) |
 | [Startup profiler request dedupe](startup-profiler-request-dedupe.md) |
 | [Qodo free-mode state write fixes](qodo-free-mode-state-write-fixes.md) |
+| [Banked rate-limit resets](banked-rate-limit-resets.md) |

--- a/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
+++ b/tests/git-worktrees-rollback/thread-menu-copy-chat-action.md
@@ -29,3 +29,39 @@ The thread overflow menu includes a `Copy chat` item that copies the selected ch
 - Restore any previous clipboard contents manually if needed
 
 ---
+
+### Continue in ChatGPT Pro handoff
+
+#### Feature/Change Name
+The selected thread menu includes `Continue in ChatGPT Pro…`, which packages the persisted thread and local repository state into a clipboard handoff and opens ChatGPT.
+
+#### Prerequisites/Setup
+1. App is running at the active local URL.
+2. Open a persisted thread whose working directory is a Git repository.
+3. The thread has an active Goal and at least one user/assistant turn.
+4. Make a harmless uncommitted change in the repository.
+5. Browser clipboard access and popups are allowed.
+
+#### Steps
+1. In light theme, open the selected thread's overflow menu.
+2. Click `Continue in ChatGPT Pro…`.
+3. Confirm a new tab opens at `https://chatgpt.com/`.
+4. Paste the clipboard into a temporary editor without sending it.
+5. Verify the handoff contains the thread ID, working directory, Goal, persisted user/assistant transcript, branch, status, recent commits, changed-file list, diff, and applicable `AGENTS.md`.
+6. Verify raw reasoning items and excessively long command output are absent or explicitly truncated.
+7. Open a non-selected thread's menu and verify the action is disabled.
+8. Repeat the selected-thread menu check in dark theme.
+9. Temporarily block popups and retry; confirm the handoff is still copied and the notice tells you to open ChatGPT manually.
+
+#### Expected Results
+- The menu closes immediately and a visible packaging notice appears.
+- The clipboard contains a self-contained Markdown prompt beginning with `Codex → ChatGPT Pro handoff`.
+- The prompt asks ChatGPT to switch to GPT-5.6 Sol Pro and continue without redoing completed work.
+- Repository inspection occurs only after the explicit menu click.
+- The new ChatGPT tab opens when popups are allowed; clipboard copy still succeeds when they are blocked.
+- Failures close the blank tab and surface a visible error notice.
+- The action and notice remain readable in light and dark themes.
+
+#### Rollback/Cleanup
+- Revert the harmless test change if it was created only for this check.
+- Restore popup permissions and previous clipboard contents if needed.

--- a/tests/providers-models/per-thread-model-selection.md
+++ b/tests/providers-models/per-thread-model-selection.md
@@ -30,3 +30,31 @@
 
 #### Rollback/Cleanup
 - Reset each tested thread back to its original model selection if you changed an existing conversation for the test.
+
+---
+
+### Feature: Model-aware reasoning effort picker
+
+#### Prerequisites
+- App is running against a Codex app-server whose `model/list` response includes `supportedReasoningEfforts`.
+- `gpt-5.6-sol` is available with `max` and `ultra`.
+- A second model without `ultra` is available.
+
+#### Steps
+1. In light theme, select `gpt-5.6-sol` in the composer model picker.
+2. Open the Thinking picker and inspect the listed options.
+3. Select `Ultra`, close the picker, and verify the trigger shows `Ultra`.
+4. Switch to the second model that does not support `Ultra`.
+5. Open the Thinking picker again.
+6. Repeat steps 1–5 in dark theme.
+
+#### Expected Results
+- The Thinking picker preserves the effort order returned by the app-server.
+- `Max` and `Ultra` appear for `gpt-5.6-sol`.
+- Efforts not returned for the selected model are absent.
+- Switching away from a model while an unsupported effort is selected changes the selection to that model's advertised default (or first supported effort).
+- Provider-only models without effort metadata retain the conservative legacy choices and do not invent `Max` or `Ultra`.
+- The custom picker is readable and correctly positioned in both themes.
+
+#### Rollback/Cleanup
+- Restore the original model and reasoning effort for any existing thread changed during the test.


### PR DESCRIPTION
## Summary

- make the model and reasoning pickers consume `model/list` metadata, preserving server order/defaults and exposing Max/Ultra for models such as GPT-5.6 Sol while retaining a conservative fallback for provider-only models
- add **Continue in ChatGPT Pro…** to the selected-thread menu; it copies a bounded handoff containing the persisted transcript, active Goal, repository status/commits/diff, changed files, and applicable `AGENTS.md` instructions, then opens ChatGPT
- keep repository inspection read-only, explicitly user-triggered, time-bounded, and exclude raw reasoning from the handoff

## Validation

- `pnpm exec vitest run src/api/codexGateway.test.ts src/composables/useDesktopState.test.ts src/server/proHandoff.test.ts` — 50/50 passed on the clean upstream branch
- `pnpm run build` — passed
- CJS/public entry smoke: `node dist-cli/index.js --help` — passed
- Playwright at 1440×1000 verified Max/Ultra visibility, unsupported-effort filtering, the selected-thread action, clipboard copy, popup navigation, and light/dark themes
- full suite: 149/151 passed; the two remaining assertions are existing Windows-only path-casing and POSIX-mode expectations
- Docker provider matrix was not run because Docker Desktop's Linux engine was unavailable on this machine

## Performance

- browser runtime profile completed with no warnings and one request each for thread list, skills, rate limits, and provider models (218.7 KB total API traffic)
- the handoff endpoint runs only after the explicit menu action; a live 220,654-character handoff completed in 1.76 seconds
- Git commands have 10-second timeouts, output caps, and external diff/textconv disabled; transcript, command output, diff, and instruction context are bounded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Continue in ChatGPT Pro…” thread action with packaged Markdown handoff, repository context, and clipboard support.
  - Introduced banked rate-limit reset credits with a confirm-then-consume flow and automatic state refresh.
  - Model-aware reasoning efforts now include **Max** and **Ultra**, and update per model selection.
- **Bug Fixes**
  - Preserve server-defined ordering for reasoning options.
  - Improve consistency of reasoning-effort selection when models/providers change.
- **Documentation**
  - Added end-to-end verification guides for ChatGPT Pro handoffs and model-aware reasoning controls.
  - Added manual test plans for banked rate-limit resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->